### PR TITLE
Task 4: packaging and Python integration validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,64 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --workspace
 
+  python-source-install:
+    name: Python source install (${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        # Add macos-latest / windows-latest here once someone has verified
+        # the steps below on those platforms (see CONTRIBUTING.md).
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install maturin numpy pytest
+      - name: maturin develop (editable source install)
+        run: maturin develop --release --manifest-path python_bindings/Cargo.toml
+      - name: Import smoke test + end-to-end sampling test
+        run: python -m pytest tests/test_smoke.py -q
+
+  python-wheel-install:
+    name: Python wheel install (${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        # Add macos-latest / windows-latest here once someone has verified
+        # the steps below on those platforms (see CONTRIBUTING.md).
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install maturin
+      - name: Build wheel
+        run: maturin build --release --manifest-path python_bindings/Cargo.toml --out dist
+      - name: Create clean environment outside the checkout
+        run: python -m venv "${{ runner.temp }}/wheel-env"
+      - name: Install wheel + numpy into the clean environment
+        shell: bash
+        run: |
+          WHEEL=$(ls dist/rustmc-*.whl | head -1)
+          "${{ runner.temp }}/wheel-env/bin/pip" install "$WHEEL" numpy
+      - name: Copy verification script outside the checkout
+        run: cp scripts/verify_wheel_install.py "${{ runner.temp }}/verify_wheel_install.py"
+      - name: Import smoke test + end-to-end sampling test (installed wheel only)
+        working-directory: ${{ runner.temp }}
+        env:
+          RUSTMC_REQUIRE_SITE_PACKAGES: "1"
+        run: "${{ runner.temp }}/wheel-env/bin/python ${{ runner.temp }}/verify_wheel_install.py"
+
   version-check:
     name: Version matches tag
     needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ target*
 .env*
 .codex*
 /*site*
+/dist/
+.pytest_cache/
+__pycache__/
+*.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to rustmc
+
+## Prerequisites
+
+Building rustmc from source requires:
+
+- **Rust** 1.75+ (workspace uses the 2021 edition; developed against 1.89).
+  Install via [rustup](https://rustup.rs/).
+- **Python** 3.9–3.13 (CPython; the classifiers in `pyproject.toml` list
+  the versions we build and test wheels for). Any of these works to build
+  and develop against.
+- **maturin** `>=1.0,<2.0` — builds the PyO3 extension module and wheels.
+  Install into your virtualenv with `pip install maturin` or `uv pip
+  install maturin`.
+- **numpy** — runtime dependency, also needed to run the examples/tests.
+- A C linker (`cc`/`clang`/`gcc`) available on `PATH`, as with any Rust
+  build. No other system libraries are required — `faer` (linear algebra)
+  is pure Rust with no BLAS/LAPACK dependency.
+
+No macOS- or Windows-specific system packages are known to be required,
+but only Linux builds have been locally verified as part of packaging
+validation (see `.github/workflows/ci.yml` and the notes below). Treat
+macOS/Windows as unverified until someone builds and tests there.
+
+## Building from source
+
+```bash
+git clone https://github.com/tbosier/rustmc.git
+cd rustmc
+
+# Rust core (no Python involved)
+cargo test --workspace
+
+# Python extension, editable install into a venv
+python -m venv .venv && source .venv/bin/activate
+pip install maturin numpy
+maturin develop --release --manifest-path python_bindings/Cargo.toml
+```
+
+## Building a wheel
+
+```bash
+pip install maturin
+maturin build --release --manifest-path python_bindings/Cargo.toml --out dist
+pip install dist/rustmc-*.whl
+```
+
+## Running the test suite
+
+Rust:
+
+```bash
+cargo test --all
+```
+
+Python (pytest suite under `tests/`):
+
+```bash
+pip install -e ".[test]"     # or: pip install pytest
+.venv/bin/python -m pytest tests/ -q
+```
+
+By default the Python suite skips tests that need a pre-built wheel
+(`tests/test_packaging.py`'s file-content/metadata checks — build a wheel
+first with `maturin build` if you want those to run instead of skip) and
+deselects the `network` marker, which builds a wheel from scratch and
+installs it into a fresh virtualenv end-to-end
+(`pytest -m network tests/test_packaging.py` to run it explicitly).
+
+## Verifying a wheel install manually
+
+`scripts/verify_wheel_install.py` is a small, dependency-free script that
+imports rustmc, checks the public API surface, and runs a tiny end-to-end
+sampling run. Run it with the interpreter of a clean environment (not this
+repo's dev `.venv`) after installing a built wheel there, from a working
+directory outside the repo checkout, to prove you're exercising the
+installed wheel rather than any local source:
+
+```bash
+python -m venv /tmp/rustmc-clean && /tmp/rustmc-clean/bin/pip install dist/rustmc-*.whl numpy
+cp scripts/verify_wheel_install.py /tmp/rustmc-clean/
+(cd /tmp && /tmp/rustmc-clean/bin/python /tmp/rustmc-clean/verify_wheel_install.py)
+```
+
+It exits non-zero and prints a `FAIL:` line on any problem, including if
+`rustmc.__file__` doesn't resolve to a `site-packages` directory.
+
+## Known gaps / follow-ups
+
+- No `py.typed` marker or `.pyi` type stubs are currently shipped, so type
+  checkers (mypy/pyright) treat the package as untyped
+  (`tests/test_packaging.py::test_wheel_ships_type_information` documents
+  this as an `xfail`).
+- CI (`.github/workflows/ci.yml`) currently only builds/tests on Linux
+  (`x86_64-unknown-linux-gnu`). macOS and Windows wheel-build jobs already
+  exist for tagged releases but have no install/import/sampling
+  verification job — add matrix entries there once someone can verify the
+  steps on those platforms (this repo's dev sandbox is Linux-only).
+- `cargo fmt --check` and `cargo clippy -- -D warnings` are not enforced
+  in CI yet; the current tree has pre-existing formatting/clippy issues
+  being addressed in a separate pass. Do not add a blocking gate for
+  these until that cleanup lands.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustmc"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ndarray",
  "numpy",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "rustmc_core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "faer",
  "ndarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ classifiers = [
 
 [project.optional-dependencies]
 viz = ["arviz", "matplotlib"]
+# NOTE: deliberately not using a [dependency-groups] (PEP 735) table here --
+# `maturin develop` auto-installs dependency groups via `pip install
+# --group`, which requires pip >=25.1. Older pip (as ships with several
+# actions/setup-python versions and plain `python -m venv`) errors out with
+# "no such option: --group". Keep dev/test deps as a normal extra instead.
+test = ["pytest>=7", "maturin>=1.0,<2.0", "numpy"]
 
 [project.urls]
 Repository = "https://github.com/tbosier/rustmc"
@@ -38,3 +44,15 @@ Repository = "https://github.com/tbosier/rustmc"
 manifest-path = "python_bindings/Cargo.toml"
 features = ["pyo3/extension-module"]
 include = ["LICENSE"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+testpaths = ["tests"]
+# `network` tests build a wheel with maturin and create a fresh venv; they
+# need network access and are deselected by default. Run them explicitly
+# with `pytest -m network` (see tests/test_packaging.py).
+addopts = "-m 'not network'"
+markers = [
+    "network: test builds a wheel and/or hits the network (deselected by default)",
+    "slow: test is slower than the rest of the suite",
+]

--- a/scripts/verify_wheel_install.py
+++ b/scripts/verify_wheel_install.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+Verify an installed rustmc wheel actually works, run with the *target*
+interpreter of a clean environment (not this repo's dev venv, and not with
+the repo on sys.path).
+
+Usage:
+    /path/to/clean/venv/bin/python scripts/verify_wheel_install.py
+
+Intended usage pattern (both locally and in CI): copy this file to a
+directory outside the repo checkout, then run it with a python whose only
+`rustmc` on sys.path is the one just `pip install`-ed from a built wheel.
+Running it from outside the repo means sys.path[0] (the script's own
+directory) cannot possibly resolve to a package named `rustmc`, which is
+the concrete guard against silently importing repo source instead of the
+installed wheel.
+
+Exits 0 on success, 1 with a diagnostic message on any failure.
+"""
+import sys
+
+
+def main() -> int:
+    import numpy as np
+
+    import rustmc as rmc
+
+    mod_file = getattr(rmc, "__file__", "") or ""
+    print(f"Python:          {sys.version.split()[0]}")
+    print(f"rustmc.__file__: {mod_file}")
+
+    if "site-packages" not in mod_file.replace("\\", "/").split("/"):
+        print(
+            f"FAIL: rustmc was not loaded from a site-packages directory: {mod_file}",
+            file=sys.stderr,
+        )
+        return 1
+
+    expected_api = {
+        "ModelBuilder", "ModelSpec", "ParamRef", "VectorParamRef", "Expr",
+        "FitResult", "BatchResult", "sample", "batch_sample",
+        "sample_prior_predictive",
+    }
+    missing = {name for name in expected_api if not hasattr(rmc, name)}
+    if missing:
+        print(f"FAIL: missing API members: {sorted(missing)}", file=sys.stderr)
+        return 1
+    print(f"API surface OK: {sorted(expected_api)}")
+
+    rng = np.random.default_rng(42)
+    n = 200
+    x = rng.standard_normal(n)
+    alpha_true, beta_true, sigma_true = 1.5, 2.5, 1.0
+    y = alpha_true + beta_true * x + rng.standard_normal(n) * sigma_true
+
+    builder = rmc.ModelBuilder(data={"x": x, "y": y})
+    alpha = builder.normal_prior("alpha", mu=0.0, sigma=10.0)
+    beta = builder.normal_prior("beta", mu=0.0, sigma=10.0)
+    sigma = builder.half_normal_prior("sigma", sigma=2.0)
+    builder.normal_likelihood("obs", mu_expr=alpha + beta * "x", sigma=sigma, observed_key="y")
+    model = builder.build()
+
+    fit = rmc.sample(model_spec=model, chains=2, draws=300, warmup=300, seed=42)
+    means = fit.mean()
+    print(f"Posterior means: {means}")
+
+    if abs(means["alpha"] - alpha_true) > 1.5:
+        print(f"FAIL: alpha mean {means['alpha']} too far from {alpha_true}", file=sys.stderr)
+        return 1
+    if abs(means["beta"] - beta_true) > 1.5:
+        print(f"FAIL: beta mean {means['beta']} too far from {beta_true}", file=sys.stderr)
+        return 1
+    if means["sigma"] <= 0:
+        print(f"FAIL: sigma mean {means['sigma']} not positive", file=sys.stderr)
+        return 1
+
+    samples = fit.get_samples()
+    alpha_arr = samples["alpha"]
+    if not isinstance(alpha_arr, np.ndarray) or alpha_arr.dtype != np.float64:
+        print(f"FAIL: expected float64 ndarray, got {type(alpha_arr)} {getattr(alpha_arr, 'dtype', None)}", file=sys.stderr)
+        return 1
+
+    print("OK: wheel install verified (import, API surface, numpy interop, end-to-end sampling)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,86 @@
+"""
+Shared pytest fixtures for the rustmc test suite.
+
+This file is intentionally general-purpose: in addition to Task 4's own
+tests (test_smoke.py, test_packaging.py), other test files may live in this
+directory (e.g. test_param_resolution.py, test_statistical_*.py, added by
+parallel workstreams). Nothing here should assume it is the only test
+module present, and nothing here should impose collection-time
+requirements (env vars, network, etc.) on files it does not own.
+"""
+import os
+import sys
+
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "network: test builds a wheel and/or hits the network (deselected by default)"
+    )
+    config.addinivalue_line(
+        "markers", "slow: test is slower than the rest of the suite"
+    )
+
+
+@pytest.fixture(scope="session")
+def rustmc_module():
+    """
+    Import rustmc once per session and hand back the module object.
+
+    Does NOT assert anything about where it was loaded from -- that check
+    is specific to packaging validation (see test_packaging.py /
+    RUSTMC_REQUIRE_SITE_PACKAGES) and would be the wrong thing to force on
+    every consumer of this fixture, since local dev workflows legitimately
+    run against an editable `maturin develop` install.
+    """
+    import rustmc as rmc
+    return rmc
+
+
+@pytest.fixture(scope="session")
+def linreg_data():
+    """A small, deterministic synthetic linear-regression dataset."""
+    import numpy as np
+
+    rng = np.random.default_rng(42)
+    n = 200
+    x = rng.standard_normal(n)
+    alpha_true, beta_true, sigma_true = 1.5, 2.5, 1.0
+    y = alpha_true + beta_true * x + rng.standard_normal(n) * sigma_true
+    return {
+        "x": x,
+        "y": y,
+        "alpha_true": alpha_true,
+        "beta_true": beta_true,
+        "sigma_true": sigma_true,
+    }
+
+
+def _module_file_is_under_site_packages(mod) -> bool:
+    mod_file = getattr(mod, "__file__", "") or ""
+    parts = mod_file.replace(os.sep, "/").split("/")
+    return "site-packages" in parts or "dist-packages" in parts
+
+
+@pytest.fixture(scope="session")
+def assert_installed_from_site_packages():
+    """
+    Helper fixture used by packaging tests that specifically need to prove
+    they're exercising an installed wheel and not the repo's source tree
+    (there is no pure-Python source tree to leak from today, but this
+    guards the invariant going forward).
+    """
+    def _check(mod):
+        assert _module_file_is_under_site_packages(mod), (
+            f"expected {mod.__name__} to be importable from a site-packages "
+            f"directory, got __file__={getattr(mod, '__file__', None)!r}"
+        )
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        mod_file = os.path.abspath(getattr(mod, "__file__", ""))
+        assert not mod_file.startswith(repo_root + os.sep), (
+            f"{mod.__name__} was loaded from inside the repo checkout ({mod_file}), "
+            "not an installed package -- sys.path leakage suspected"
+        )
+        return mod_file
+    return _check

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,150 @@
+"""
+Packaging validation: wheel contents, metadata, and (optionally) a full
+build-and-install-into-a-clean-environment round trip.
+
+Fast checks (no network, no build) run whenever a wheel is already present
+in dist/ -- they skip with a clear reason otherwise, so `pytest tests/ -q`
+stays hermetic by default.
+
+The full round trip (`test_wheel_installs_in_clean_environment`) is marked
+`network` and deselected by default (see `addopts` in pyproject.toml)
+because it builds a wheel with maturin and creates a fresh venv, which
+needs network access this sandbox only grants when explicitly
+unsandboxed. CI exercises the equivalent path directly as dedicated
+workflow jobs (see .github/workflows/ci.yml) using
+scripts/verify_wheel_install.py, which is the same script this test
+shells out to.
+"""
+import glob
+import os
+import subprocess
+import sys
+import venv
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _find_wheel():
+    matches = sorted(glob.glob(str(REPO_ROOT / "dist" / "rustmc-*.whl")))
+    matches += sorted(glob.glob(str(REPO_ROOT / "target" / "wheels" / "rustmc-*.whl")))
+    return matches[0] if matches else None
+
+
+@pytest.fixture(scope="module")
+def wheel_path():
+    whl = _find_wheel()
+    if whl is None:
+        pytest.skip(
+            "no built wheel found in dist/ or target/wheels/; "
+            "run `maturin build --release` first to exercise packaging tests"
+        )
+    return whl
+
+
+def test_wheel_contains_expected_files(wheel_path):
+    with zipfile.ZipFile(wheel_path) as z:
+        names = z.namelist()
+
+    assert any(n.endswith(".so") or n.endswith(".pyd") for n in names), (
+        f"wheel has no compiled extension module: {names}"
+    )
+    assert "rustmc/__init__.py" in names, f"wheel missing rustmc/__init__.py: {names}"
+    assert any("dist-info/METADATA" in n for n in names), "wheel missing METADATA"
+    assert any("dist-info/RECORD" in n for n in names), "wheel missing RECORD"
+    assert any("LICENSE" in n for n in names), "wheel missing LICENSE"
+
+
+def test_wheel_metadata_matches_pyproject(wheel_path):
+    import re
+
+    # Parsed with a regex rather than tomllib so this test works on Python
+    # 3.9/3.10 too (tomllib is stdlib only from 3.11+), matching the
+    # project's actual supported-version floor.
+    pyproject_text = (REPO_ROOT / "pyproject.toml").read_text()
+    expected_version = re.search(r'(?m)^version\s*=\s*"([^"]+)"', pyproject_text).group(1)
+    expected_requires_python = re.search(
+        r'(?m)^requires-python\s*=\s*"([^"]+)"', pyproject_text
+    ).group(1)
+
+    with zipfile.ZipFile(wheel_path) as z:
+        metadata_name = next(n for n in z.namelist() if n.endswith("dist-info/METADATA"))
+        metadata = z.read(metadata_name).decode()
+
+    assert f"Version: {expected_version}" in metadata, metadata
+    assert f"Requires-Python: {expected_requires_python}" in metadata, metadata
+
+
+@pytest.mark.xfail(strict=True, reason=(
+    "known packaging gap (Task 4 finding): no py.typed marker or .pyi stubs "
+    "are shipped, so type checkers see an untyped package. Remove this "
+    "xfail once stubs/py.typed are added."
+))
+def test_wheel_ships_type_information(wheel_path):
+    with zipfile.ZipFile(wheel_path) as z:
+        names = z.namelist()
+    assert any(n.endswith("py.typed") for n in names) or any(n.endswith(".pyi") for n in names)
+
+
+def test_no_stray_rustmc_shadow_at_repo_root():
+    """
+    Guard against a future accidental top-level rustmc/ directory or
+    rustmc.py file at the repo root, which would shadow the installed
+    package and reintroduce the exact sys.path leakage this task exists to
+    prevent.
+    """
+    assert not (REPO_ROOT / "rustmc").exists()
+    assert not (REPO_ROOT / "rustmc.py").exists()
+
+
+@pytest.mark.network
+def test_wheel_installs_in_clean_environment(tmp_path):
+    """
+    Full round trip: `maturin build`, install the resulting wheel into a
+    brand-new venv created outside the repo (tmp_path, a pytest tmp
+    directory under the system temp dir), and run
+    scripts/verify_wheel_install.py from that same directory -- so the
+    only `rustmc` importable is the one just installed from the wheel.
+    """
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+
+    subprocess.run(
+        [
+            sys.executable, "-m", "maturin", "build", "--release",
+            "--out", str(dist_dir),
+            "--manifest-path", str(REPO_ROOT / "python_bindings" / "Cargo.toml"),
+        ],
+        check=True,
+    )
+    wheels = list(dist_dir.glob("*.whl"))
+    assert wheels, "maturin build produced no wheel"
+
+    env_dir = tmp_path / "clean-env"
+    venv.EnvBuilder(with_pip=True).create(env_dir)
+    env_python = env_dir / "bin" / "python"
+
+    subprocess.run(
+        [str(env_python), "-m", "pip", "install", "--quiet", str(wheels[0]), "numpy"],
+        check=True,
+    )
+
+    script_src = REPO_ROOT / "scripts" / "verify_wheel_install.py"
+    script_dst = tmp_path / "verify_wheel_install.py"
+    script_dst.write_text(script_src.read_text())
+
+    result = subprocess.run(
+        [str(env_python), str(script_dst)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        env={**os.environ, "RUSTMC_REQUIRE_SITE_PACKAGES": "1"},
+    )
+    print(result.stdout)
+    print(result.stderr, file=sys.stderr)
+    assert result.returncode == 0, "verify_wheel_install.py failed against the clean install"
+    assert "site-packages" in result.stdout
+    assert str(REPO_ROOT) not in result.stdout

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,75 @@
+"""
+Import / API-surface / end-to-end smoke tests for whatever `rustmc` is
+importable in the current interpreter.
+
+These run against a `maturin develop` editable install during local
+development (`.venv/bin/python -m pytest tests/ -q`), and against an
+installed wheel in CI's wheel-install job (see
+.github/workflows/ci.yml). Set RUSTMC_REQUIRE_SITE_PACKAGES=1 to also
+assert the module was loaded from site-packages rather than the repo --
+CI's wheel job sets this; local dev runs do not need to.
+"""
+import os
+
+import numpy as np
+import pytest
+
+
+EXPECTED_API = {
+    "ModelBuilder",
+    "ModelSpec",
+    "ParamRef",
+    "VectorParamRef",
+    "Expr",
+    "FitResult",
+    "BatchResult",
+    "sample",
+    "batch_sample",
+    "sample_prior_predictive",
+}
+
+
+def test_import(rustmc_module):
+    assert rustmc_module is not None
+
+
+def test_site_packages_when_required(rustmc_module, assert_installed_from_site_packages):
+    if os.environ.get("RUSTMC_REQUIRE_SITE_PACKAGES") != "1":
+        pytest.skip("RUSTMC_REQUIRE_SITE_PACKAGES not set; skipping strict location check")
+    mod_file = assert_installed_from_site_packages(rustmc_module)
+    print(f"rustmc loaded from: {mod_file}")
+
+
+def test_public_api_surface(rustmc_module):
+    present = {name for name in EXPECTED_API if hasattr(rustmc_module, name)}
+    missing = EXPECTED_API - present
+    assert not missing, f"rustmc is missing expected public API members: {sorted(missing)}"
+
+
+def test_numpy_interop_and_end_to_end_sampling(rustmc_module, linreg_data):
+    rmc = rustmc_module
+    data = linreg_data
+
+    builder = rmc.ModelBuilder(data={"x": data["x"], "y": data["y"]})
+    alpha = builder.normal_prior("alpha", mu=0.0, sigma=10.0)
+    beta = builder.normal_prior("beta", mu=0.0, sigma=10.0)
+    sigma = builder.half_normal_prior("sigma", sigma=2.0)
+    builder.normal_likelihood("obs", mu_expr=alpha + beta * "x", sigma=sigma, observed_key="y")
+    model = builder.build()
+
+    fit = rmc.sample(model_spec=model, chains=2, draws=200, warmup=200, seed=42)
+
+    means = fit.mean()
+    assert set(means) == {"alpha", "beta", "sigma"}
+    assert abs(means["alpha"] - data["alpha_true"]) < 1.5
+    assert abs(means["beta"] - data["beta_true"]) < 1.5
+    assert means["sigma"] > 0
+
+    samples = fit.get_samples()
+    alpha_samples = samples["alpha"]
+    assert isinstance(alpha_samples, np.ndarray)
+    assert alpha_samples.dtype == np.float64
+    assert alpha_samples.shape == (2 * 200,)
+
+    summary = fit.summary()
+    assert "alpha" in summary and "beta" in summary and "sigma" in summary


### PR DESCRIPTION
## Summary

Verifies that released wheels actually work outside the dev checkout, and adds the infrastructure to keep proving it.

- Built wheels with `maturin build` for CPython 3.9, 3.10, 3.11, 3.12, 3.13 (all classifiers in `pyproject.toml`) and installed each into a clean venv (not `.venv`, not the repo checkout) via `uv`/stdlib `venv` + `pip`.
- Every claimed version imports, exposes the expected public API, interoperates with NumPy, and completes a small end-to-end NUTS sampling run recovering the true parameters. Bonus: 3.13.14t (free-threaded) not tried, but plain 3.14 also built and worked, though it's not a classifier claim.
- Added `scripts/verify_wheel_install.py`: a standalone, dependency-light script that asserts the imported `rustmc.__file__` resolves under a `site-packages` directory -- the concrete guard against a wheel test silently importing the source tree instead.
- New pytest suite: `tests/conftest.py`, `tests/test_smoke.py` (import/API/NumPy/e2e), `tests/test_packaging.py` (wheel content + metadata checks, an `xfail` documenting missing type stubs, and a `network`-marked full build+install round trip). Config lives in `pyproject.toml`; `network` tests are deselected by default so `pytest tests/ -q` stays fast and hermetic. conftest.py makes no assumptions about being the only test module in `tests/`, since other worktrees are adding their own files there.
- New CI jobs in `.github/workflows/ci.yml`: `python-source-install` (`maturin develop` + smoke/e2e test) and `python-wheel-install` (`maturin build` + install into a venv created outside the checkout + the verification script), both matrixed over Python 3.9-3.13 on `ubuntu-latest`, structured so other OSes can be added as matrix entries later.
- `CONTRIBUTING.md`: documents Rust/Python/system prerequisites for building from source.
- Found and fixed a real version-drift defect: `Cargo.lock` still pinned `rustmc`/`rustmc_core` at `0.7.0` even though both `Cargo.toml` manifests and `pyproject.toml` already say `0.8.0`.
- Found and avoided a packaging footgun: adding a `[dependency-groups]` (PEP 735) table to `pyproject.toml` makes `maturin develop` auto-run `pip install --group ...`, which errors on pip <25.1 (the version shipped by a plain `python -m venv` + pip install here). Dev/test deps are a normal `test` extra instead.
- Found but did not fix (out of this task's ownership / scope): no `py.typed` marker or `.pyi` stubs are shipped, so type checkers see an untyped package. Documented as an `xfail` in `test_packaging.py` and as a follow-up in `CONTRIBUTING.md`.

## Test plan

- [x] `cargo test --all` -- 39 tests pass (~190s for the slowest suite)
- [x] `maturin build` produces wheels for cp39-cp313 (verified individually)
- [x] Each wheel installed into a clean env outside `.venv`/the repo, imported, sampled from, with `rustmc.__file__` asserted to live in `site-packages` (shown in report)
- [x] `.venv/bin/python -m pytest tests/ -q` -- 4 passed, 4 skipped (wheel-dependent, no prebuilt wheel present at rest), 1 deselected (network)
- [x] Reproduced the exact steps of both new CI jobs locally (source install via `maturin develop` in a fresh `python -m venv`; wheel install via `maturin build` + `python -m venv` + `pip install *.whl` from outside the checkout) before adding them to the workflow
- [x] `.github/workflows/ci.yml` YAML parses and all job names present (checked with PyYAML, no `actionlint`/`gh` workflow linter available in this sandbox)

## Known limitations / follow-ups

- No `py.typed`/stubs shipped (tracked via `xfail` test + CONTRIBUTING.md).
- CI only covers Linux; macOS/Windows wheel-build jobs already exist for tagged releases but have no install/import/sampling verification job -- flagged as a follow-up rather than guessed at, since this sandbox can't verify those platforms.
- `cargo fmt --check` / `cargo clippy -D warnings` intentionally not gated in CI -- pre-existing issues are being handled in a separate cleanup pass per the task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)