### PR TITLE
Task 1: fail loudly on unresolved parameter references

### DIFF
--- a/python_bindings/src/lib.rs
+++ b/python_bindings/src/lib.rs
@@ -1,6 +1,7 @@
 use ndarray::{Array2, Array3};
 use numpy::{PyArrayMethods, PyUntypedArrayMethods};
 use numpy::{IntoPyArray, PyArray1, PyArray2};
+use pyo3::create_exception;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -14,8 +15,40 @@ use rustmc_core::distributions::{
     Uniform,
 };
 use rustmc_core::graph::{Graph, NodeId, ParamTransform};
+use rustmc_core::param_ref::{validate_param_references, ParamRefError, ParamReference};
 use rustmc_core::sampler::{self, SampleResult, SamplerConfig, SamplerType};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+create_exception!(
+    rustmc,
+    ParameterError,
+    PyValueError,
+    "Raised when a parameter reference in a model cannot be resolved.\n\n\
+     Subclasses ``ValueError`` for backwards compatibility."
+);
+
+/// Convert a core parameter-resolution failure into the Python exception.
+fn param_error(err: ParamRefError) -> PyErr {
+    ParameterError::new_err(err.to_string())
+}
+
+/// Monotonic id handed to each `ModelBuilder` so that a `ParamRef` produced by
+/// one model can never be silently consumed by another.
+static NEXT_MODEL_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_model_id() -> u64 {
+    NEXT_MODEL_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Error for a `ParamRef`/`Expr` that belongs to a different `ModelBuilder`.
+fn foreign_param_error(name: &str, context: &str) -> PyErr {
+    ParameterError::new_err(format!(
+        "parameter '{}' used in {} belongs to a different model. \
+         A ParamRef returned by one ModelBuilder cannot be used in another.",
+        name, context
+    ))
+}
 
 #[pyclass]
 #[derive(Debug, Clone)]
@@ -134,6 +167,8 @@ impl MuExpr {
 struct VectorParamRef {
     name: String,
     _n: usize,
+    /// Id of the `ModelBuilder` that created this reference.
+    owner: u64,
 }
 
 #[pymethods]
@@ -144,6 +179,55 @@ impl VectorParamRef {
                 param_name: self.name.clone(),
                 data_key: data_key.to_string(),
             },
+            owner: Some(self.owner),
+        }
+    }
+}
+
+/// Combine the owning-model ids of two sub-expressions, rejecting mixtures.
+fn merge_owners(a: Option<u64>, b: Option<u64>, a_name: &str) -> PyResult<Option<u64>> {
+    match (a, b) {
+        (Some(x), Some(y)) if x != y => Err(ParameterError::new_err(format!(
+            "expression mixes parameters from two different models \
+             (offending parameter: '{}'). Build the whole linear predictor \
+             from a single ModelBuilder.",
+            a_name
+        ))),
+        (Some(x), _) => Ok(Some(x)),
+        (None, other) => Ok(other),
+    }
+}
+
+/// First parameter name appearing in an expression, for error messages.
+fn first_param_name(expr: &MuExpr) -> String {
+    match expr {
+        MuExpr::Const(_) => "<constant>".to_string(),
+        MuExpr::Param(name) => name.clone(),
+        MuExpr::ParamTimesData { param_name, .. } | MuExpr::MatVec { param_name, .. } => {
+            param_name.clone()
+        }
+        MuExpr::Add(a, b) => {
+            let left = first_param_name(a);
+            if left == "<constant>" {
+                first_param_name(b)
+            } else {
+                left
+            }
+        }
+    }
+}
+
+/// Collect every parameter name referenced by an expression tree.
+fn collect_expr_param_names(expr: &MuExpr, out: &mut Vec<String>) {
+    match expr {
+        MuExpr::Const(_) => {}
+        MuExpr::Param(name) => out.push(name.clone()),
+        MuExpr::ParamTimesData { param_name, .. } | MuExpr::MatVec { param_name, .. } => {
+            out.push(param_name.clone())
+        }
+        MuExpr::Add(a, b) => {
+            collect_expr_param_names(a, out);
+            collect_expr_param_names(b, out);
         }
     }
 }
@@ -151,6 +235,7 @@ impl VectorParamRef {
 #[pyclass]
 #[derive(Debug, Clone)]
 struct ModelBuilder {
+    id: u64,
     priors: Vec<PriorSpec>,
     likelihoods: Vec<LikelihoodSpec>,
     param_names: Vec<String>,
@@ -162,12 +247,17 @@ struct ModelBuilder {
 #[derive(Debug, Clone)]
 struct ParamRef {
     name: String,
+    /// Id of the `ModelBuilder` that created this reference.
+    owner: u64,
 }
 
 #[pyclass]
 #[derive(Debug, Clone)]
 struct Expr {
     inner: MuExpr,
+    /// Id of the `ModelBuilder` whose parameters this expression uses, if any.
+    /// `None` for constant-only expressions.
+    owner: Option<u64>,
 }
 
 #[pymethods]
@@ -178,25 +268,33 @@ impl ParamRef {
                 param_name: self.name.clone(),
                 data_key: data_key.to_string(),
             },
+            owner: Some(self.owner),
         }
     }
 
     fn __add__<'py>(&self, other: &Bound<'py, PyAny>) -> PyResult<Expr> {
         if let Ok(other_expr) = other.downcast::<Expr>() {
-            let rhs = other_expr.borrow().inner.clone();
+            let (rhs, rhs_owner) = {
+                let b = other_expr.borrow();
+                (b.inner.clone(), b.owner)
+            };
+            let owner = merge_owners(Some(self.owner), rhs_owner, &self.name)?;
             Ok(Expr {
-                inner: MuExpr::Add(
-                    Box::new(MuExpr::Param(self.name.clone())),
-                    Box::new(rhs),
-                ),
+                inner: MuExpr::Add(Box::new(MuExpr::Param(self.name.clone())), Box::new(rhs)),
+                owner,
             })
         } else if let Ok(other_param) = other.downcast::<ParamRef>() {
-            let rhs_name = other_param.borrow().name.clone();
+            let (rhs_name, rhs_owner) = {
+                let b = other_param.borrow();
+                (b.name.clone(), b.owner)
+            };
+            let owner = merge_owners(Some(self.owner), Some(rhs_owner), &self.name)?;
             Ok(Expr {
                 inner: MuExpr::Add(
                     Box::new(MuExpr::Param(self.name.clone())),
                     Box::new(MuExpr::Param(rhs_name)),
                 ),
+                owner,
             })
         } else if let Ok(value) = other.extract::<f64>() {
             Ok(Expr {
@@ -204,6 +302,7 @@ impl ParamRef {
                     Box::new(MuExpr::Param(self.name.clone())),
                     Box::new(MuExpr::Const(value)),
                 ),
+                owner: Some(self.owner),
             })
         } else {
             Err(PyValueError::new_err(
@@ -222,6 +321,7 @@ impl ParamRef {
                 param_name: self.name.clone(),
                 data_key: data_key.to_string(),
             },
+            owner: Some(self.owner),
         }
     }
 }
@@ -230,24 +330,32 @@ impl ParamRef {
 impl Expr {
     fn __add__<'py>(&self, other: &Bound<'py, PyAny>) -> PyResult<Expr> {
         if let Ok(other_expr) = other.downcast::<Expr>() {
-            let rhs = other_expr.borrow().inner.clone();
+            let (rhs, rhs_owner) = {
+                let b = other_expr.borrow();
+                (b.inner.clone(), b.owner)
+            };
+            let owner = merge_owners(self.owner, rhs_owner, &first_param_name(&self.inner))?;
             Ok(Expr {
                 inner: MuExpr::Add(Box::new(self.inner.clone()), Box::new(rhs)),
+                owner,
             })
         } else if let Ok(other_param) = other.downcast::<ParamRef>() {
-            let rhs_name = other_param.borrow().name.clone();
+            let (rhs_name, rhs_owner) = {
+                let b = other_param.borrow();
+                (b.name.clone(), b.owner)
+            };
+            let owner = merge_owners(self.owner, Some(rhs_owner), &rhs_name)?;
             Ok(Expr {
                 inner: MuExpr::Add(
                     Box::new(self.inner.clone()),
                     Box::new(MuExpr::Param(rhs_name)),
                 ),
+                owner,
             })
         } else if let Ok(value) = other.extract::<f64>() {
             Ok(Expr {
-                inner: MuExpr::Add(
-                    Box::new(self.inner.clone()),
-                    Box::new(MuExpr::Const(value)),
-                ),
+                inner: MuExpr::Add(Box::new(self.inner.clone()), Box::new(MuExpr::Const(value))),
+                owner: self.owner,
             })
         } else {
             Err(PyValueError::new_err(
@@ -258,22 +366,217 @@ impl Expr {
 
     fn __radd__<'py>(&self, other: &Bound<'py, PyAny>) -> PyResult<Expr> {
         if let Ok(other_param) = other.downcast::<ParamRef>() {
-            let lhs_name = other_param.borrow().name.clone();
+            let (lhs_name, lhs_owner) = {
+                let b = other_param.borrow();
+                (b.name.clone(), b.owner)
+            };
+            let owner = merge_owners(Some(lhs_owner), self.owner, &lhs_name)?;
             Ok(Expr {
                 inner: MuExpr::Add(
                     Box::new(MuExpr::Param(lhs_name)),
                     Box::new(self.inner.clone()),
                 ),
+                owner,
             })
         } else if let Ok(value) = other.extract::<f64>() {
             Ok(Expr {
-                inner: MuExpr::Add(
-                    Box::new(MuExpr::Const(value)),
-                    Box::new(self.inner.clone()),
-                ),
+                inner: MuExpr::Add(Box::new(MuExpr::Const(value)), Box::new(self.inner.clone())),
+                owner: self.owner,
             })
         } else {
             self.__add__(other)
+        }
+    }
+}
+
+/// Name a `PriorSpec` declares.
+fn prior_name(prior: &PriorSpec) -> &str {
+    match prior {
+        PriorSpec::Normal { name, .. }
+        | PriorSpec::HalfNormal { name, .. }
+        | PriorSpec::Exponential { name, .. }
+        | PriorSpec::LogNormal { name, .. }
+        | PriorSpec::StudentT { name, .. }
+        | PriorSpec::Uniform { name, .. }
+        | PriorSpec::Bernoulli { name, .. }
+        | PriorSpec::Poisson { name, .. }
+        | PriorSpec::Gamma { name, .. }
+        | PriorSpec::Beta { name, .. }
+        | PriorSpec::VectorNormal { name, .. } => name,
+    }
+}
+
+/// Hyperparameter references a `PriorSpec` makes, as `(role, name)` pairs.
+fn prior_hyper_refs(prior: &PriorSpec) -> Vec<(&'static str, &str)> {
+    let mut out = Vec::new();
+    fn push<'a>(out: &mut Vec<(&'static str, &'a str)>, role: &'static str, hp: &'a HyperParam) {
+        if let HyperParam::Param(name) = hp {
+            out.push((role, name.as_str()));
+        }
+    }
+    match prior {
+        PriorSpec::Normal { mu, sigma, .. } | PriorSpec::LogNormal { mu, sigma, .. } => {
+            push(&mut out, "mu", mu);
+            push(&mut out, "sigma", sigma);
+        }
+        PriorSpec::HalfNormal { sigma, .. } => push(&mut out, "sigma", sigma),
+        PriorSpec::Exponential { rate, .. } => push(&mut out, "rate", rate),
+        PriorSpec::StudentT { .. }
+        | PriorSpec::Uniform { .. }
+        | PriorSpec::Bernoulli { .. }
+        | PriorSpec::Poisson { .. }
+        | PriorSpec::Gamma { .. }
+        | PriorSpec::Beta { .. }
+        | PriorSpec::VectorNormal { .. } => {}
+    }
+    out
+}
+
+/// The ordered list of parameter names a model declares, plus the full set of
+/// references into it. This is the single source of truth for reference
+/// validation, shared by `ModelBuilder.build()` and `compile_python_model`.
+fn model_reference_set(
+    priors: &[PriorSpec],
+    likelihoods: &[LikelihoodSpec],
+) -> (Vec<String>, Vec<ParamReference>) {
+    let declared: Vec<String> = priors.iter().map(|p| prior_name(p).to_string()).collect();
+    let mut refs = Vec::new();
+
+    for (idx, prior) in priors.iter().enumerate() {
+        for (role, name) in prior_hyper_refs(prior) {
+            refs.push(ParamReference::ordered(
+                name,
+                format!("prior '{}' hyperparameter {}", prior_name(prior), role),
+                idx,
+            ));
+        }
+    }
+
+    for lik in likelihoods {
+        let mut names = Vec::new();
+        collect_expr_param_names(&lik.mu_expr, &mut names);
+        for name in names {
+            refs.push(ParamReference::unordered(
+                name,
+                format!("the linear predictor of likelihood '{}'", lik.name),
+            ));
+        }
+        if let Some(SigmaSpec::Param(name)) = &lik.sigma {
+            refs.push(ParamReference::unordered(
+                name.clone(),
+                format!("the scale parameter of likelihood '{}'", lik.name),
+            ));
+        }
+    }
+
+    (declared, refs)
+}
+
+/// Validate every parameter reference in a model up front, before any graph is
+/// built. Fails loudly on unknown names, out-of-order hyperparameters and
+/// duplicate declarations.
+fn validate_model_references(priors: &[PriorSpec], likelihoods: &[LikelihoodSpec]) -> PyResult<()> {
+    let (declared, refs) = model_reference_set(priors, likelihoods);
+    validate_param_references(&declared, &refs).map_err(param_error)
+}
+
+impl ModelBuilder {
+    /// A reference to one of this model's parameters, tagged with the model id.
+    fn param_ref(&self, name: &str) -> ParamRef {
+        ParamRef {
+            name: name.to_string(),
+            owner: self.id,
+        }
+    }
+
+    /// Names declared so far, in declaration order.
+    fn declared_names(&self) -> Vec<String> {
+        self.priors.iter().map(|p| prior_name(p).to_string()).collect()
+    }
+
+    /// Parse a hyperparameter argument, rejecting references that belong to a
+    /// different model or that are not yet declared in this one.
+    fn hyper_arg(
+        &self,
+        obj: &Bound<'_, PyAny>,
+        arg_name: &str,
+        new_prior_name: &str,
+    ) -> PyResult<HyperParam> {
+        let hp = extract_hyper(obj, arg_name)?;
+        if let HyperParam::Param(ref name) = hp {
+            let context = format!("prior '{}' hyperparameter {}", new_prior_name, arg_name);
+            if let Ok(p) = obj.downcast::<ParamRef>() {
+                if p.borrow().owner != self.id {
+                    return Err(foreign_param_error(name, &context));
+                }
+            }
+            let declared = self.declared_names();
+            let position = declared.len();
+            validate_param_references(
+                &declared,
+                &[ParamReference::ordered(name.clone(), context, position)],
+            )
+            .map_err(param_error)?;
+        }
+        Ok(hp)
+    }
+
+    /// Parse a likelihood predictor argument (`Expr` or bare `ParamRef`),
+    /// rejecting references that belong to a different model.
+    fn likelihood_expr(
+        &self,
+        value: &Bound<'_, PyAny>,
+        arg_name: &str,
+        lik_name: &str,
+    ) -> PyResult<MuExpr> {
+        let (expr, owner) = if let Ok(e) = value.downcast::<Expr>() {
+            let b = e.borrow();
+            (b.inner.clone(), b.owner)
+        } else if let Ok(p) = value.downcast::<ParamRef>() {
+            let b = p.borrow();
+            (MuExpr::Param(b.name.clone()), Some(b.owner))
+        } else {
+            return Err(PyValueError::new_err(format!(
+                "{} must be an Expr (e.g. beta * 'x') or a ParamRef",
+                arg_name
+            )));
+        };
+        let context = format!("the linear predictor of likelihood '{}'", lik_name);
+        self.check_owner(owner, &first_param_name(&expr), &context)?;
+        Ok(expr)
+    }
+
+    /// Parse a likelihood scale argument (float or `ParamRef`), rejecting
+    /// references that belong to a different model.
+    fn scale_spec(
+        &self,
+        value: &Bound<'_, PyAny>,
+        arg_name: &str,
+        lik_name: &str,
+    ) -> PyResult<SigmaSpec> {
+        if let Ok(v) = value.extract::<f64>() {
+            Ok(SigmaSpec::Const(v))
+        } else if let Ok(p) = value.downcast::<ParamRef>() {
+            let (name, owner) = {
+                let b = p.borrow();
+                (b.name.clone(), b.owner)
+            };
+            let context = format!("the {} of likelihood '{}'", arg_name, lik_name);
+            self.check_owner(Some(owner), &name, &context)?;
+            Ok(SigmaSpec::Param(name))
+        } else {
+            Err(PyValueError::new_err(format!(
+                "{} must be a float or a ParamRef (e.g. from half_normal_prior)",
+                arg_name
+            )))
+        }
+    }
+
+    /// Reject a `ParamRef`/`Expr` produced by a different `ModelBuilder`.
+    fn check_owner(&self, owner: Option<u64>, name: &str, context: &str) -> PyResult<()> {
+        match owner {
+            Some(id) if id != self.id => Err(foreign_param_error(name, context)),
+            _ => Ok(()),
         }
     }
 }
@@ -288,6 +591,7 @@ impl ModelBuilder {
             None => (HashMap::new(), HashMap::new()),
         };
         Ok(Self {
+            id: next_model_id(),
             priors: Vec::new(),
             likelihoods: Vec::new(),
             param_names: Vec::new(),
@@ -303,15 +607,15 @@ impl ModelBuilder {
         mu: &Bound<'_, PyAny>,
         sigma: &Bound<'_, PyAny>,
     ) -> PyResult<ParamRef> {
-        let mu_hp = extract_hyper(mu, "mu")?;
-        let sigma_hp = extract_hyper(sigma, "sigma")?;
+        let mu_hp = self.hyper_arg(mu, "mu", name)?;
+        let sigma_hp = self.hyper_arg(sigma, "sigma", name)?;
         self.priors.push(PriorSpec::Normal {
             name: name.to_string(),
             mu: mu_hp,
             sigma: sigma_hp,
         });
         self.param_names.push(name.to_string());
-        Ok(ParamRef { name: name.to_string() })
+        Ok(self.param_ref(name))
     }
 
     #[pyo3(signature = (name, sigma))]
@@ -320,10 +624,10 @@ impl ModelBuilder {
         name: &str,
         sigma: &Bound<'_, PyAny>,
     ) -> PyResult<ParamRef> {
-        let sigma_hp = extract_hyper(sigma, "sigma")?;
+        let sigma_hp = self.hyper_arg(sigma, "sigma", name)?;
         self.priors.push(PriorSpec::HalfNormal { name: name.to_string(), sigma: sigma_hp });
         self.param_names.push(name.to_string());
-        Ok(ParamRef { name: name.to_string() })
+        Ok(self.param_ref(name))
     }
 
     #[pyo3(signature = (name, rate))]
@@ -332,13 +636,13 @@ impl ModelBuilder {
         name: &str,
         rate: &Bound<'_, PyAny>,
     ) -> PyResult<ParamRef> {
-        let rate_hp = extract_hyper(rate, "rate")?;
+        let rate_hp = self.hyper_arg(rate, "rate", name)?;
         self.priors.push(PriorSpec::Exponential {
             name: name.to_string(),
             rate: rate_hp,
         });
         self.param_names.push(name.to_string());
-        Ok(ParamRef { name: name.to_string() })
+        Ok(self.param_ref(name))
     }
 
     #[pyo3(signature = (name, mu, sigma))]
@@ -348,57 +652,57 @@ impl ModelBuilder {
         mu: &Bound<'_, PyAny>,
         sigma: &Bound<'_, PyAny>,
     ) -> PyResult<ParamRef> {
-        let mu_hp = extract_hyper(mu, "mu")?;
-        let sigma_hp = extract_hyper(sigma, "sigma")?;
+        let mu_hp = self.hyper_arg(mu, "mu", name)?;
+        let sigma_hp = self.hyper_arg(sigma, "sigma", name)?;
         self.priors.push(PriorSpec::LogNormal {
             name: name.to_string(),
             mu: mu_hp,
             sigma: sigma_hp,
         });
         self.param_names.push(name.to_string());
-        Ok(ParamRef { name: name.to_string() })
+        Ok(self.param_ref(name))
     }
 
     #[pyo3(signature = (name, nu, mu=0.0, sigma=1.0))]
     fn student_t_prior(&mut self, name: &str, nu: f64, mu: f64, sigma: f64) -> ParamRef {
         self.priors.push(PriorSpec::StudentT { name: name.to_string(), nu, mu, sigma });
         self.param_names.push(name.to_string());
-        ParamRef { name: name.to_string() }
+        self.param_ref(name)
     }
 
     #[pyo3(signature = (name, lower=0.0, upper=1.0))]
     fn uniform_prior(&mut self, name: &str, lower: f64, upper: f64) -> ParamRef {
         self.priors.push(PriorSpec::Uniform { name: name.to_string(), lower, upper });
         self.param_names.push(name.to_string());
-        ParamRef { name: name.to_string() }
+        self.param_ref(name)
     }
 
     #[pyo3(signature = (name, p=0.5))]
     fn bernoulli_prior(&mut self, name: &str, p: f64) -> ParamRef {
         self.priors.push(PriorSpec::Bernoulli { name: name.to_string(), p });
         self.param_names.push(name.to_string());
-        ParamRef { name: name.to_string() }
+        self.param_ref(name)
     }
 
     #[pyo3(signature = (name, lam))]
     fn poisson_prior(&mut self, name: &str, lam: f64) -> ParamRef {
         self.priors.push(PriorSpec::Poisson { name: name.to_string(), lam });
         self.param_names.push(name.to_string());
-        ParamRef { name: name.to_string() }
+        self.param_ref(name)
     }
 
     #[pyo3(signature = (name, alpha, beta))]
     fn gamma_prior(&mut self, name: &str, alpha: f64, beta: f64) -> ParamRef {
         self.priors.push(PriorSpec::Gamma { name: name.to_string(), alpha, beta });
         self.param_names.push(name.to_string());
-        ParamRef { name: name.to_string() }
+        self.param_ref(name)
     }
 
     #[pyo3(signature = (name, alpha, beta))]
     fn beta_prior(&mut self, name: &str, alpha: f64, beta: f64) -> ParamRef {
         self.priors.push(PriorSpec::Beta { name: name.to_string(), alpha, beta });
         self.param_names.push(name.to_string());
-        ParamRef { name: name.to_string() }
+        self.param_ref(name)
     }
 
     #[pyo3(signature = (name, n, mu=0.0, sigma=1.0))]
@@ -415,7 +719,11 @@ impl ModelBuilder {
             mu,
             sigma,
         });
-        VectorParamRef { name: name.to_string(), _n: n }
+        VectorParamRef {
+            name: name.to_string(),
+            _n: n,
+            owner: self.id,
+        }
     }
 
     #[pyo3(signature = (name, mu_expr, sigma, observed_key))]
@@ -426,26 +734,8 @@ impl ModelBuilder {
         sigma: &Bound<'_, PyAny>,
         observed_key: &str,
     ) -> PyResult<()> {
-        let _ = name;
-        // Accept either an Expr or a bare ParamRef as mu_expr
-        let inner_expr = if let Ok(e) = mu_expr.downcast::<Expr>() {
-            e.borrow().inner.clone()
-        } else if let Ok(p) = mu_expr.downcast::<ParamRef>() {
-            MuExpr::Param(p.borrow().name.clone())
-        } else {
-            return Err(PyValueError::new_err(
-                "mu_expr must be an Expr (e.g. beta * 'x') or a ParamRef",
-            ));
-        };
-        let sigma_spec = if let Ok(v) = sigma.extract::<f64>() {
-            SigmaSpec::Const(v)
-        } else if let Ok(p) = sigma.downcast::<ParamRef>() {
-            SigmaSpec::Param(p.borrow().name.clone())
-        } else {
-            return Err(PyValueError::new_err(
-                "sigma must be a float or a ParamRef (e.g. from half_normal_prior)",
-            ));
-        };
+        let inner_expr = self.likelihood_expr(mu_expr, "mu_expr", name)?;
+        let sigma_spec = self.scale_spec(sigma, "sigma", name)?;
         if !self.bound_data_1d.is_empty() || !self.bound_data_2d.is_empty() {
             validate_data_keys(
                 &inner_expr,
@@ -471,7 +761,7 @@ impl ModelBuilder {
         eta_expr: &Bound<'_, PyAny>,
         observed_key: &str,
     ) -> PyResult<()> {
-        let inner_expr = parse_likelihood_expr(eta_expr, "eta_expr")?;
+        let inner_expr = self.likelihood_expr(eta_expr, "eta_expr", name)?;
         if !self.bound_data_1d.is_empty() || !self.bound_data_2d.is_empty() {
             validate_data_keys(
                 &inner_expr,
@@ -497,7 +787,7 @@ impl ModelBuilder {
         eta_expr: &Bound<'_, PyAny>,
         observed_key: &str,
     ) -> PyResult<()> {
-        let inner_expr = parse_likelihood_expr(eta_expr, "eta_expr")?;
+        let inner_expr = self.likelihood_expr(eta_expr, "eta_expr", name)?;
         if !self.bound_data_1d.is_empty() || !self.bound_data_2d.is_empty() {
             validate_data_keys(
                 &inner_expr,
@@ -523,7 +813,7 @@ impl ModelBuilder {
         eta_expr: &Bound<'_, PyAny>,
         observed_key: &str,
     ) -> PyResult<()> {
-        let inner_expr = parse_likelihood_expr(eta_expr, "eta_expr")?;
+        let inner_expr = self.likelihood_expr(eta_expr, "eta_expr", name)?;
         if !self.bound_data_1d.is_empty() || !self.bound_data_2d.is_empty() {
             validate_data_keys(
                 &inner_expr,
@@ -550,16 +840,8 @@ impl ModelBuilder {
         sigma: &Bound<'_, PyAny>,
         observed_key: &str,
     ) -> PyResult<()> {
-        let inner_expr = parse_likelihood_expr(mu_expr, "mu_expr")?;
-        let sigma_spec = if let Ok(v) = sigma.extract::<f64>() {
-            SigmaSpec::Const(v)
-        } else if let Ok(p) = sigma.downcast::<ParamRef>() {
-            SigmaSpec::Param(p.borrow().name.clone())
-        } else {
-            return Err(PyValueError::new_err(
-                "sigma must be a float or a ParamRef",
-            ));
-        };
+        let inner_expr = self.likelihood_expr(mu_expr, "mu_expr", name)?;
+        let sigma_spec = self.scale_spec(sigma, "sigma", name)?;
         if !self.bound_data_1d.is_empty() || !self.bound_data_2d.is_empty() {
             validate_data_keys(
                 &inner_expr,
@@ -586,16 +868,8 @@ impl ModelBuilder {
         alpha: &Bound<'_, PyAny>,
         observed_key: &str,
     ) -> PyResult<()> {
-        let inner_expr = parse_likelihood_expr(eta_expr, "eta_expr")?;
-        let alpha_spec = if let Ok(v) = alpha.extract::<f64>() {
-            SigmaSpec::Const(v)
-        } else if let Ok(p) = alpha.downcast::<ParamRef>() {
-            SigmaSpec::Param(p.borrow().name.clone())
-        } else {
-            return Err(PyValueError::new_err(
-                "alpha must be a float or a ParamRef",
-            ));
-        };
+        let inner_expr = self.likelihood_expr(eta_expr, "eta_expr", name)?;
+        let alpha_spec = self.scale_spec(alpha, "alpha", name)?;
         if !self.bound_data_1d.is_empty() || !self.bound_data_2d.is_empty() {
             validate_data_keys(
                 &inner_expr,
@@ -614,13 +888,16 @@ impl ModelBuilder {
         Ok(())
     }
 
-    fn build(&self) -> ModelSpec {
-        ModelSpec {
+    /// Finalise the model. Validates every parameter reference up front so an
+    /// unresolvable name fails here rather than mid-sample.
+    fn build(&self) -> PyResult<ModelSpec> {
+        validate_model_references(&self.priors, &self.likelihoods)?;
+        Ok(ModelSpec {
             priors: self.priors.clone(),
             likelihoods: self.likelihoods.clone(),
             bound_data_1d: self.bound_data_1d.clone(),
             bound_data_2d: self.bound_data_2d.clone(),
-        }
+        })
     }
 }
 
@@ -713,19 +990,6 @@ fn validate_data_keys(
         )));
     }
     validate_expr_keys(expr, data_1d, data_2d)
-}
-
-fn parse_likelihood_expr(value: &Bound<'_, PyAny>, arg_name: &str) -> PyResult<MuExpr> {
-    if let Ok(e) = value.downcast::<Expr>() {
-        Ok(e.borrow().inner.clone())
-    } else if let Ok(p) = value.downcast::<ParamRef>() {
-        Ok(MuExpr::Param(p.borrow().name.clone()))
-    } else {
-        Err(PyValueError::new_err(format!(
-            "{} must be an Expr (e.g. beta * 'x') or a ParamRef",
-            arg_name
-        )))
-    }
 }
 
 fn validate_expr_keys(
@@ -987,27 +1251,38 @@ fn resolve_hyper(
 ) -> Result<NodeId, PyErr> {
     match hp {
         HyperParam::Const(v) => Ok(graph.add_constant(*v)),
-        HyperParam::Param(name) => {
-            value_node_map.get(name.as_str()).copied().ok_or_else(|| {
-                PyValueError::new_err(format!(
-                    "Hyperparameter '{}' not found. Declare it before the prior that references it.",
-                    name
-                ))
-            })
-        }
+        HyperParam::Param(name) => value_node_map.get(name.as_str()).copied().ok_or_else(|| {
+            ParameterError::new_err(format!(
+                "hyperparameter '{}' has no value node. Declare it before the prior \
+                 that references it.",
+                name
+            ))
+        }),
     }
 }
 
+/// Resolve a `HyperParam` against already-computed parameter values.
+///
+/// `context` names the model location doing the referencing, so the error can
+/// say *which* prior or derived parameter is broken. There is deliberately no
+/// default value: a missing hyperparameter must never be silently replaced.
 fn resolve_hyper_value(
     hp: &HyperParam,
     values: &HashMap<String, f64>,
+    context: &str,
 ) -> Result<f64, PyErr> {
     match hp {
         HyperParam::Const(v) => Ok(*v),
         HyperParam::Param(name) => values.get(name).copied().ok_or_else(|| {
-            PyValueError::new_err(format!(
-                "Derived parameter depends on '{}' before it is available",
-                name
+            let mut available: Vec<&str> = values.keys().map(String::as_str).collect();
+            available.sort_unstable();
+            ParameterError::new_err(format!(
+                "parameter '{}' referenced by {} has no value yet. It must be \
+                 declared before the parameter that depends on it. \
+                 Available at this point: [{}]",
+                name,
+                context,
+                available.join(", ")
             ))
         }),
     }
@@ -1053,6 +1328,7 @@ fn build_likelihood_into_graph(
         data_map,
         matrix_map,
         vector_param_map,
+        value_node_map,
     )?;
     let linpred_node = if lik.mu_expr.is_scalar() {
         graph.scalar_broadcast(linpred_node)
@@ -1329,14 +1605,16 @@ fn resolve_sigma(
 ) -> Result<NodeId, PyErr> {
     match spec {
         SigmaSpec::Const(v) => Ok(graph.add_constant(*v)),
-        SigmaSpec::Param(name) => {
-            value_node_map.get(name.as_str()).copied().ok_or_else(|| {
-                PyValueError::new_err(format!(
-                    "sigma parameter '{}' not found. Did you declare it as a prior?",
-                    name
-                ))
-            })
-        }
+        SigmaSpec::Param(name) => value_node_map.get(name.as_str()).copied().ok_or_else(|| {
+            let mut available: Vec<&str> = value_node_map.keys().map(String::as_str).collect();
+            available.sort_unstable();
+            ParameterError::new_err(format!(
+                "scale parameter '{}' is not a scalar parameter of this model. \
+                 Scalar parameters: [{}]",
+                name,
+                available.join(", ")
+            ))
+        }),
     }
 }
 
@@ -1426,7 +1704,35 @@ fn collect_matvec_params(
     Ok(result)
 }
 
+/// Look up the post-transform value node for a scalar parameter.
+///
+/// Fails loudly — never substitutes a default — when the name is not a scalar
+/// parameter of this model.
+fn lookup_param_value_node(
+    name: &str,
+    value_node_map: &HashMap<String, NodeId>,
+    context: &str,
+) -> Result<NodeId, PyErr> {
+    value_node_map.get(name).copied().ok_or_else(|| {
+        let mut available: Vec<&str> = value_node_map.keys().map(String::as_str).collect();
+        available.sort_unstable();
+        ParameterError::new_err(format!(
+            "parameter '{}' used in {} is not a scalar parameter of this model. \
+             Scalar parameters: [{}]",
+            name,
+            context,
+            available.join(", ")
+        ))
+    })
+}
+
 /// Compile a MuExpr tree into graph nodes.
+///
+/// Parameters are resolved through `value_node_map`, which holds the
+/// *post-transform* value node for every scalar parameter. Resolving via
+/// `Graph::node_by_name` instead would return the unconstrained raw node for
+/// any transformed prior (HalfNormal, Exponential, LogNormal, Uniform, Gamma,
+/// Beta), silently putting a log-scale value into the linear predictor.
 ///
 /// When the tree is a pure linear combination (Σ βₖ xₖ + optional intercept),
 /// this emits a single FusedLinearMu op instead of individual
@@ -1437,6 +1743,7 @@ fn build_mu_expr(
     data_map: &HashMap<String, Vec<f64>>,
     matrix_map: &HashMap<String, (Vec<f64>, usize, usize)>,
     vector_param_map: &HashMap<String, (usize, usize)>,
+    value_node_map: &HashMap<String, NodeId>,
 ) -> Result<NodeId, PyErr> {
     // Fast path: fuse linear combinations into a single op
     if let Some((terms, intercept_name)) = try_extract_linear(expr) {
@@ -1444,9 +1751,7 @@ fn build_mu_expr(
         let mut data_indices = Vec::with_capacity(terms.len());
 
         for (param_name, data_key) in &terms {
-            let pn = graph
-                .node_by_name(param_name)
-                .ok_or_else(|| PyValueError::new_err(format!("Unknown param: {}", param_name)))?;
+            let pn = lookup_param_value_node(param_name, value_node_map, "a linear predictor")?;
             param_nodes.push(pn);
 
             let data_vec = data_map
@@ -1469,11 +1774,11 @@ fn build_mu_expr(
                     })?;
                 Some(graph.add_constant(value))
             }
-            Some(ref name) => Some(
-                graph
-                    .node_by_name(name)
-                    .ok_or_else(|| PyValueError::new_err(format!("Unknown param: {}", name)))?,
-            ),
+            Some(ref name) => Some(lookup_param_value_node(
+                name,
+                value_node_map,
+                "the intercept of a linear predictor",
+            )?),
             None => None,
         };
 
@@ -1487,9 +1792,8 @@ fn build_mu_expr(
             param_name,
             data_key,
         } => {
-            let param_node = graph
-                .node_by_name(param_name)
-                .ok_or_else(|| PyValueError::new_err(format!("Unknown param: {}", param_name)))?;
+            let param_node =
+                lookup_param_value_node(param_name, value_node_map, "a linear predictor")?;
             let data_vec = data_map
                 .get(data_key)
                 .ok_or_else(|| PyValueError::new_err(format!("Missing data key: {}", data_key)))?
@@ -1497,12 +1801,7 @@ fn build_mu_expr(
             let data_node = graph.add_data(data_key, data_vec);
             Ok(graph.scalar_mul_data(param_node, data_node))
         }
-        MuExpr::Param(name) => {
-            let param_node = graph
-                .node_by_name(name)
-                .ok_or_else(|| PyValueError::new_err(format!("Unknown param: {}", name)))?;
-            Ok(param_node)
-        }
+        MuExpr::Param(name) => lookup_param_value_node(name, value_node_map, "a linear predictor"),
         MuExpr::MatVec { param_name, data_key } => {
             let &(param_start, n_params) = vector_param_map.get(param_name.as_str())
                 .ok_or_else(|| PyValueError::new_err(
@@ -1516,8 +1815,8 @@ fn build_mu_expr(
             Ok(graph.mat_vec_mul(matrix_idx, param_start, n_params, None))
         }
         MuExpr::Add(a, b) => {
-            let na = build_mu_expr(graph, a, data_map, matrix_map, vector_param_map)?;
-            let nb = build_mu_expr(graph, b, data_map, matrix_map, vector_param_map)?;
+            let na = build_mu_expr(graph, a, data_map, matrix_map, vector_param_map, value_node_map)?;
+            let nb = build_mu_expr(graph, b, data_map, matrix_map, vector_param_map, value_node_map)?;
             let a_scalar = a.is_scalar();
             let b_scalar = b.is_scalar();
             if a_scalar && !b_scalar {
@@ -1559,6 +1858,13 @@ fn compile_python_model(
     let mut vector_param_map: HashMap<String, (usize, usize)> = HashMap::new();
     let mut value_node_map: HashMap<String, NodeId> = HashMap::new();
     let mut display_params = Vec::new();
+
+    // Defence in depth: `ModelBuilder.build()` already validated these, but a
+    // `ModelSpec` can reach here by other routes (pickling, batch_sample).
+    // Validating before touching the graph guarantees an unresolvable reference
+    // never becomes a silently-defaulted value at sampling time.
+    validate_model_references(&model_spec.priors, &model_spec.likelihoods)?;
+
     let auto_vector_params = collect_matvec_params(&model_spec.likelihoods, matrix_map)?;
 
     for prior in &model_spec.priors {
@@ -1614,8 +1920,9 @@ fn derive_display_draw(
                 mu,
                 sigma,
             } => {
-                let mu_v = resolve_hyper_value(mu, &values)?;
-                let sigma_v = resolve_hyper_value(sigma, &values)?;
+                let context = format!("non-centered parameter '{}'", name);
+                let mu_v = resolve_hyper_value(mu, &values, &context)?;
+                let sigma_v = resolve_hyper_value(sigma, &values, &context)?;
                 let value = mu_v + sigma_v * raw_draw[*raw_index];
                 values.insert(name.clone(), value);
                 value
@@ -2491,11 +2798,11 @@ fn sample_prior_raw(
     // Track post-transform values for HyperParam::Param resolution
     let mut sampled_values: HashMap<String, f64> = HashMap::new();
 
-    let resolve = |hp: &HyperParam, sv: &HashMap<String, f64>| -> f64 {
-        match hp {
-            HyperParam::Const(v) => *v,
-            HyperParam::Param(name) => *sv.get(name.as_str()).unwrap_or(&1.0),
-        }
+    // A hyperparameter that is not yet available is a broken model, not a
+    // reason to substitute 1.0: doing so returns plausible-but-wrong prior
+    // predictive draws with no warning.
+    let resolve = |hp: &HyperParam, sv: &HashMap<String, f64>, owner: &str| -> Result<f64, PyErr> {
+        resolve_hyper_value(hp, sv, &format!("prior '{}'", owner))
     };
 
     for prior in priors {
@@ -2503,20 +2810,20 @@ fn sample_prior_raw(
             PriorSpec::Normal { name, mu, sigma } => {
                 if should_auto_noncenter(prior, auto_vector_params) {
                     let z = NormalDist::new(0.0, 1.0).unwrap().sample(rng);
-                    let mu_v = resolve(mu, &sampled_values);
-                    let sigma_v = resolve(sigma, &sampled_values);
+                    let mu_v = resolve(mu, &sampled_values, name)?;
+                    let sigma_v = resolve(sigma, &sampled_values, name)?;
                     sampled_values.insert(name.clone(), mu_v + sigma_v * z);
                     raw.push(z);
                 } else {
-                    let mu_v = resolve(mu, &sampled_values);
-                    let sigma_v = resolve(sigma, &sampled_values).abs().max(1e-12);
+                    let mu_v = resolve(mu, &sampled_values, name)?;
+                    let sigma_v = resolve(sigma, &sampled_values, name)?.abs().max(1e-12);
                     let x = NormalDist::new(mu_v, sigma_v).unwrap().sample(rng);
                     sampled_values.insert(name.clone(), x);
                     raw.push(x); // identity transform
                 }
             }
             PriorSpec::HalfNormal { name, sigma } => {
-                let sigma_v = resolve(sigma, &sampled_values).abs().max(1e-12);
+                let sigma_v = resolve(sigma, &sampled_values, name)?.abs().max(1e-12);
                 let z = NormalDist::new(0.0_f64, sigma_v).unwrap().sample(rng);
                 let x = z.abs().max(1e-12);
                 sampled_values.insert(name.clone(), x);
@@ -2524,7 +2831,7 @@ fn sample_prior_raw(
             }
             PriorSpec::Exponential { name, rate } => {
                 if let Some(&n) = auto_vector_params.get(name) {
-                    let rate_v = resolve(rate, &sampled_values).abs().max(1e-12);
+                    let rate_v = resolve(rate, &sampled_values, name)?.abs().max(1e-12);
                     for k in 0..n {
                         let u = rng.gen::<f64>().clamp(1e-12, 1.0 - 1e-12);
                         let x = (-u.ln() / rate_v).max(1e-12);
@@ -2534,7 +2841,7 @@ fn sample_prior_raw(
                         raw.push(x.ln());
                     }
                 } else {
-                    let rate_v = resolve(rate, &sampled_values).abs().max(1e-12);
+                    let rate_v = resolve(rate, &sampled_values, name)?.abs().max(1e-12);
                     let u = rng.gen::<f64>().clamp(1e-12, 1.0 - 1e-12);
                     let x = (-u.ln() / rate_v).max(1e-12);
                     sampled_values.insert(name.clone(), x);
@@ -2543,8 +2850,8 @@ fn sample_prior_raw(
             }
             PriorSpec::LogNormal { name, mu, sigma } => {
                 if let Some(&n) = auto_vector_params.get(name) {
-                    let mu_v = resolve(mu, &sampled_values);
-                    let sigma_v = resolve(sigma, &sampled_values).abs().max(1e-12);
+                    let mu_v = resolve(mu, &sampled_values, name)?;
+                    let sigma_v = resolve(sigma, &sampled_values, name)?.abs().max(1e-12);
                     let dist = NormalDist::new(mu_v, sigma_v).unwrap();
                     for k in 0..n {
                         let raw_draw = dist.sample(rng);
@@ -2554,8 +2861,8 @@ fn sample_prior_raw(
                         raw.push(raw_draw);
                     }
                 } else {
-                    let mu_v = resolve(mu, &sampled_values);
-                    let sigma_v = resolve(sigma, &sampled_values).abs().max(1e-12);
+                    let mu_v = resolve(mu, &sampled_values, name)?;
+                    let sigma_v = resolve(sigma, &sampled_values, name)?.abs().max(1e-12);
                     let raw_draw = NormalDist::new(mu_v, sigma_v).unwrap().sample(rng);
                     let x = raw_draw.exp();
                     sampled_values.insert(name.clone(), x);
@@ -2623,6 +2930,7 @@ fn rustmc(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Expr>()?;
     m.add_class::<FitResult>()?;
     m.add_class::<BatchResult>()?;
+    m.add("ParameterError", m.py().get_type::<ParameterError>())?;
     m.add_function(wrap_pyfunction!(sample, m)?)?;
     m.add_function(wrap_pyfunction!(batch_sample, m)?)?;
     m.add_function(wrap_pyfunction!(sample_prior_predictive, m)?)?;

--- a/rust_core/src/graph.rs
+++ b/rust_core/src/graph.rs
@@ -54,7 +54,6 @@ pub enum ObsFamily {
 /// Metadata for an observation term in the graph.
 #[derive(Debug, Clone)]
 pub struct ObservationHead {
-    pub name: String,
     pub family: ObsFamily,
     pub linpred: NodeId,
     pub aux: Option<NodeId>,
@@ -534,7 +533,6 @@ impl Graph {
                 } = &n.op
                 {
                     Some(ObservationHead {
-                        name: n.name.clone().unwrap_or_default(),
                         family: *family,
                         linpred: *linpred_vec,
                         aux: *aux,

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod graph;
 pub mod hmc;
 pub mod mass_matrix;
 pub mod nuts;
+pub mod param_ref;
 pub mod progress;
 pub mod sampler;
 
@@ -13,6 +14,7 @@ pub use compiled_model::{
     ArtifactError, CompiledModelArtifact, CompiledModelRuntime, ModelMetadata, ModelStep,
     NodeRef, ParameterBlock, SerializableObsFamily, SerializableParamTransform,
 };
+pub use param_ref::{validate_param_references, ParamRefError, ParamReference};
 
 // Future: GPU-accelerated log-probability evaluation via wgpu.
 //

--- a/rust_core/src/param_ref.rs
+++ b/rust_core/src/param_ref.rs
@@ -1,0 +1,354 @@
+//! Build-time validation of parameter references.
+//!
+//! A model is described by an ordered list of *parameter declarations* (priors,
+//! in declaration order) and a set of *parameter references* (hyperparameters of
+//! other priors, likelihood scale parameters, terms in a linear predictor).
+//!
+//! Every reference must resolve to a declaration. Some references additionally
+//! carry an ordering constraint: a prior's hyperparameter must have been
+//! declared *before* the prior that uses it, because the computation graph is
+//! built in declaration order.
+//!
+//! Validating this once, up front, is strictly better than discovering it
+//! half-way through building a graph — or worse, silently substituting a
+//! default value and returning a plausible-but-wrong posterior.
+
+use std::fmt;
+
+/// A single use of a parameter name somewhere in a model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParamReference {
+    /// The referenced parameter name.
+    pub name: String,
+    /// Human-readable description of *where* the reference occurs, e.g.
+    /// `"prior 'theta' hyperparameter mu"`. Used verbatim in error messages.
+    pub context: String,
+    /// If `Some(i)`, the referenced parameter must be declared strictly before
+    /// declaration index `i`. `None` means order does not matter.
+    pub must_precede: Option<usize>,
+}
+
+impl ParamReference {
+    /// A reference with no ordering constraint (e.g. a likelihood term).
+    pub fn unordered(name: impl Into<String>, context: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            context: context.into(),
+            must_precede: None,
+        }
+    }
+
+    /// A reference that must resolve to a declaration made before index
+    /// `declaration_index`.
+    pub fn ordered(
+        name: impl Into<String>,
+        context: impl Into<String>,
+        declaration_index: usize,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            context: context.into(),
+            must_precede: Some(declaration_index),
+        }
+    }
+}
+
+/// Why a parameter reference could not be resolved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParamRefError {
+    /// The name does not appear anywhere in the model.
+    Undeclared {
+        name: String,
+        context: String,
+        available: Vec<String>,
+        suggestion: Option<String>,
+    },
+    /// The name exists, but is declared after the point where it is used.
+    UsedBeforeDeclared {
+        name: String,
+        context: String,
+        /// Zero-based declaration index of the referenced parameter.
+        declared_at: usize,
+        /// Zero-based declaration index of the declaration doing the referencing.
+        used_at: usize,
+    },
+    /// Two declarations share a name, so a reference to it is ambiguous.
+    DuplicateDeclaration {
+        name: String,
+        first: usize,
+        second: usize,
+    },
+}
+
+impl ParamRefError {
+    /// The offending parameter name. Always present, in every variant, so that
+    /// callers (and tests) can rely on the message naming it.
+    pub fn param_name(&self) -> &str {
+        match self {
+            ParamRefError::Undeclared { name, .. }
+            | ParamRefError::UsedBeforeDeclared { name, .. }
+            | ParamRefError::DuplicateDeclaration { name, .. } => name,
+        }
+    }
+}
+
+impl fmt::Display for ParamRefError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParamRefError::Undeclared {
+                name,
+                context,
+                available,
+                suggestion,
+            } => {
+                write!(f, "unknown parameter '{}' referenced by {}.", name, context)?;
+                if let Some(s) = suggestion {
+                    write!(f, " Did you mean '{}'?", s)?;
+                }
+                if available.is_empty() {
+                    write!(f, " This model declares no parameters.")
+                } else {
+                    write!(f, " Declared parameters: [{}]", available.join(", "))
+                }
+            }
+            ParamRefError::UsedBeforeDeclared {
+                name,
+                context,
+                declared_at,
+                used_at,
+            } => write!(
+                f,
+                "parameter '{}' is referenced by {} but is declared later \
+                 (declaration #{} references declaration #{}). Declare '{}' \
+                 before the prior that uses it.",
+                name, context, used_at, declared_at, name
+            ),
+            ParamRefError::DuplicateDeclaration {
+                name,
+                first,
+                second,
+            } => write!(
+                f,
+                "parameter '{}' is declared twice (declarations #{} and #{}); \
+                 references to it would be ambiguous.",
+                name, first, second
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ParamRefError {}
+
+/// Check that every reference in `refs` resolves to a declaration in
+/// `declared`, respecting ordering constraints.
+///
+/// `declared` is the ordered list of parameter names the model declares.
+pub fn validate_param_references(
+    declared: &[String],
+    refs: &[ParamReference],
+) -> Result<(), ParamRefError> {
+    // First declaration index for each name (and a duplicate check).
+    let mut index_of: Vec<(&str, usize)> = Vec::with_capacity(declared.len());
+    for (i, name) in declared.iter().enumerate() {
+        if let Some(&(_, first)) = index_of.iter().find(|(n, _)| *n == name.as_str()) {
+            return Err(ParamRefError::DuplicateDeclaration {
+                name: name.clone(),
+                first,
+                second: i,
+            });
+        }
+        index_of.push((name.as_str(), i));
+    }
+
+    for reference in refs {
+        let found = index_of
+            .iter()
+            .find(|(n, _)| *n == reference.name.as_str())
+            .map(|&(_, i)| i);
+
+        match found {
+            None => {
+                return Err(ParamRefError::Undeclared {
+                    name: reference.name.clone(),
+                    context: reference.context.clone(),
+                    available: declared.to_vec(),
+                    suggestion: suggest(&reference.name, declared),
+                })
+            }
+            Some(declared_at) => {
+                if let Some(used_at) = reference.must_precede {
+                    if declared_at >= used_at {
+                        return Err(ParamRefError::UsedBeforeDeclared {
+                            name: reference.name.clone(),
+                            context: reference.context.clone(),
+                            declared_at,
+                            used_at,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Closest declared name within a small edit distance, for "did you mean".
+fn suggest(name: &str, candidates: &[String]) -> Option<String> {
+    let budget = (name.chars().count() / 3).clamp(1, 3);
+    candidates
+        .iter()
+        .map(|c| (levenshtein(name, c), c))
+        .filter(|(d, _)| *d <= budget)
+        .min_by_key(|(d, _)| *d)
+        .map(|(_, c)| c.clone())
+}
+
+/// Plain Levenshtein edit distance (two-row dynamic program).
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            cur[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(cur[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn resolves_valid_references() {
+        let declared = names(&["mu_pop", "sigma_pop", "theta", "sigma"]);
+        let refs = vec![
+            ParamReference::ordered("mu_pop", "prior 'theta' hyperparameter mu", 2),
+            ParamReference::ordered("sigma_pop", "prior 'theta' hyperparameter sigma", 2),
+            ParamReference::unordered("sigma", "likelihood 'y' sigma"),
+        ];
+        assert!(validate_param_references(&declared, &refs).is_ok());
+    }
+
+    #[test]
+    fn missing_hyperparameter_is_named() {
+        let declared = names(&["theta"]);
+        let refs = vec![ParamReference::ordered(
+            "sigma_pop",
+            "prior 'theta' hyperparameter sigma",
+            0,
+        )];
+        let err = validate_param_references(&declared, &refs).unwrap_err();
+        assert_eq!(err.param_name(), "sigma_pop");
+        let msg = err.to_string();
+        assert!(msg.contains("sigma_pop"), "{}", msg);
+        assert!(
+            msg.contains("prior 'theta' hyperparameter sigma"),
+            "{}",
+            msg
+        );
+    }
+
+    #[test]
+    fn misspelled_name_gets_a_suggestion() {
+        let declared = names(&["sigma_pop", "theta"]);
+        let refs = vec![ParamReference::unordered(
+            "sigma_pip",
+            "likelihood 'y' sigma",
+        )];
+        let err = validate_param_references(&declared, &refs).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("sigma_pip"), "{}", msg);
+        assert!(msg.contains("Did you mean 'sigma_pop'?"), "{}", msg);
+    }
+
+    #[test]
+    fn wildly_wrong_name_gets_no_suggestion_but_lists_available() {
+        let declared = names(&["alpha", "beta"]);
+        let refs = vec![ParamReference::unordered(
+            "qqqqqqqq",
+            "likelihood 'y' sigma",
+        )];
+        let err = validate_param_references(&declared, &refs).unwrap_err();
+        let msg = err.to_string();
+        assert!(!msg.contains("Did you mean"), "{}", msg);
+        assert!(msg.contains("alpha, beta"), "{}", msg);
+    }
+
+    #[test]
+    fn declaration_order_is_enforced_for_hyperparameters() {
+        // theta declared at 0, references sigma_pop declared at 1.
+        let declared = names(&["theta", "sigma_pop"]);
+        let refs = vec![ParamReference::ordered(
+            "sigma_pop",
+            "prior 'theta' hyperparameter sigma",
+            0,
+        )];
+        let err = validate_param_references(&declared, &refs).unwrap_err();
+        assert!(matches!(err, ParamRefError::UsedBeforeDeclared { .. }));
+        let msg = err.to_string();
+        assert!(msg.contains("sigma_pop"), "{}", msg);
+        assert!(msg.contains("declared later"), "{}", msg);
+    }
+
+    #[test]
+    fn self_reference_is_rejected() {
+        let declared = names(&["theta"]);
+        let refs = vec![ParamReference::ordered(
+            "theta",
+            "prior 'theta' hyperparameter mu",
+            0,
+        )];
+        assert!(matches!(
+            validate_param_references(&declared, &refs).unwrap_err(),
+            ParamRefError::UsedBeforeDeclared { .. }
+        ));
+    }
+
+    #[test]
+    fn unordered_references_ignore_position() {
+        let declared = names(&["theta", "sigma"]);
+        let refs = vec![ParamReference::unordered("sigma", "likelihood 'y' sigma")];
+        assert!(validate_param_references(&declared, &refs).is_ok());
+    }
+
+    #[test]
+    fn duplicate_declarations_are_rejected() {
+        let declared = names(&["theta", "theta"]);
+        let err = validate_param_references(&declared, &[]).unwrap_err();
+        assert!(matches!(err, ParamRefError::DuplicateDeclaration { .. }));
+        assert!(err.to_string().contains("theta"));
+    }
+
+    #[test]
+    fn empty_model_reports_no_declared_parameters() {
+        let refs = vec![ParamReference::unordered("theta", "likelihood 'y' sigma")];
+        let err = validate_param_references(&[], &refs).unwrap_err();
+        assert!(err.to_string().contains("declares no parameters"));
+    }
+
+    #[test]
+    fn levenshtein_basics() {
+        assert_eq!(levenshtein("", "abc"), 3);
+        assert_eq!(levenshtein("abc", ""), 3);
+        assert_eq!(levenshtein("abc", "abc"), 0);
+        assert_eq!(levenshtein("sigma", "sigmma"), 1);
+        assert_eq!(levenshtein("kitten", "sitting"), 3);
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Shared pytest configuration for the rustmc test suite."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Allow the suite to run against a wheel that was built but not installed
+# (``maturin build --release`` + extraction into ``target/extmod``), which is
+# useful in sandboxes where ``maturin develop`` cannot write to the venv.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_LOCAL_EXT = os.path.join(_REPO_ROOT, "target", "extmod")
+if os.path.isdir(_LOCAL_EXT) and _LOCAL_EXT not in sys.path:
+    sys.path.insert(0, _LOCAL_EXT)
+
+
+@pytest.fixture(scope="session")
+def rustmc():
+    """The compiled extension module."""
+    return pytest.importorskip(
+        "rustmc",
+        reason="build the extension first: `maturin develop --release`",
+    )

--- a/tests/test_param_resolution.py
+++ b/tests/test_param_resolution.py
@@ -1,0 +1,237 @@
+"""Parameter references must resolve, or fail loudly.
+
+The failure mode these tests guard against is a *silent* one: a parameter
+reference that cannot be resolved being replaced by a default value, producing
+a posterior (or prior predictive draw) that looks plausible but is wrong.
+
+Every assertion below therefore checks two things: that an error is raised, and
+that the message names the offending parameter.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def linear_data():
+    rng = np.random.default_rng(20240725)
+    x = rng.normal(size=200)
+    y = 1.5 + 2.0 * x + rng.normal(scale=0.3, size=200)
+    return {"x": x, "y": y}
+
+
+def _simple_model(rustmc, data):
+    """alpha + beta * x, sigma ~ HalfNormal — the canonical valid model."""
+    b = rustmc.ModelBuilder(data)
+    alpha = b.normal_prior("alpha", 0.0, 10.0)
+    beta = b.normal_prior("beta", 0.0, 10.0)
+    sigma = b.half_normal_prior("sigma", 1.0)
+    b.normal_likelihood("y", alpha + beta * "x", sigma, "y")
+    return b
+
+
+# ── the exception type ────────────────────────────────────────────────────
+
+
+def test_parameter_error_is_exported_and_subclasses_value_error(rustmc):
+    assert issubclass(rustmc.ParameterError, ValueError)
+
+
+def test_valid_model_builds_and_samples(rustmc, linear_data):
+    spec = _simple_model(rustmc, linear_data).build()
+    fit = rustmc.sample(spec, chains=2, draws=400, warmup=400, show_progress=False)
+    means = fit.mean()
+    assert means["alpha"] == pytest.approx(1.5, abs=0.15)
+    assert means["beta"] == pytest.approx(2.0, abs=0.15)
+
+
+# ── references belonging to a different model ─────────────────────────────
+
+
+def test_hyperparameter_from_another_model_is_rejected(rustmc):
+    """A ParamRef minted by one builder must not resolve inside another."""
+    other = rustmc.ModelBuilder()
+    foreign_sigma = other.half_normal_prior("sigma_pop", 1.0)
+
+    b = rustmc.ModelBuilder()
+    with pytest.raises(rustmc.ParameterError) as exc:
+        b.normal_prior("theta", 0.0, foreign_sigma)
+
+    message = str(exc.value)
+    assert "sigma_pop" in message
+    assert "different model" in message
+
+
+def test_same_named_parameter_from_another_model_is_still_rejected(rustmc, linear_data):
+    """The dangerous case: the name exists in both models, so name-based
+    resolution would silently succeed against the wrong declaration."""
+    other = rustmc.ModelBuilder()
+    foreign_sigma = other.half_normal_prior("sigma", 1.0)
+
+    b = rustmc.ModelBuilder(linear_data)
+    b.normal_prior("alpha", 0.0, 10.0)
+    b.half_normal_prior("sigma", 1.0)  # same name, different model
+
+    with pytest.raises(rustmc.ParameterError) as exc:
+        b.normal_prior("theta", 0.0, foreign_sigma)
+    assert "sigma" in str(exc.value)
+
+
+def test_likelihood_scale_from_another_model_is_rejected(rustmc, linear_data):
+    other = rustmc.ModelBuilder()
+    foreign_sigma = other.half_normal_prior("sigma_other", 1.0)
+
+    b = rustmc.ModelBuilder(linear_data)
+    alpha = b.normal_prior("alpha", 0.0, 10.0)
+    with pytest.raises(rustmc.ParameterError) as exc:
+        b.normal_likelihood("y", alpha, foreign_sigma, "y")
+
+    message = str(exc.value)
+    assert "sigma_other" in message
+    assert "different model" in message
+
+
+def test_predictor_from_another_model_is_rejected(rustmc, linear_data):
+    other = rustmc.ModelBuilder()
+    foreign_beta = other.normal_prior("beta_other", 0.0, 1.0)
+
+    b = rustmc.ModelBuilder(linear_data)
+    sigma = b.half_normal_prior("sigma", 1.0)
+    with pytest.raises(rustmc.ParameterError) as exc:
+        b.normal_likelihood("y", foreign_beta * "x", sigma, "y")
+
+    message = str(exc.value)
+    assert "beta_other" in message
+    assert "different model" in message
+
+
+def test_expression_mixing_two_models_is_rejected(rustmc):
+    a = rustmc.ModelBuilder()
+    beta_a = a.normal_prior("beta_a", 0.0, 1.0)
+
+    b = rustmc.ModelBuilder()
+    beta_b = b.normal_prior("beta_b", 0.0, 1.0)
+
+    with pytest.raises(rustmc.ParameterError) as exc:
+        _ = beta_a * "x" + beta_b * "x"
+
+    message = str(exc.value)
+    assert "two different models" in message
+    assert "beta_a" in message or "beta_b" in message
+
+
+def test_reverse_add_also_rejects_mixed_models(rustmc):
+    a = rustmc.ModelBuilder()
+    alpha_a = a.normal_prior("alpha_a", 0.0, 1.0)
+
+    b = rustmc.ModelBuilder()
+    beta_b = b.normal_prior("beta_b", 0.0, 1.0)
+
+    with pytest.raises(rustmc.ParameterError) as exc:
+        _ = alpha_a + beta_b * "x"
+    assert "alpha_a" in str(exc.value) or "beta_b" in str(exc.value)
+
+
+# ── unresolvable references inside one model ──────────────────────────────
+
+
+def test_duplicate_parameter_declaration_is_rejected(rustmc, linear_data):
+    """Two priors with the same name make every reference to it ambiguous."""
+    b = rustmc.ModelBuilder(linear_data)
+    alpha = b.normal_prior("alpha", 0.0, 10.0)
+    b.normal_prior("alpha", 0.0, 1.0)
+    sigma = b.half_normal_prior("sigma", 1.0)
+    b.normal_likelihood("y", alpha, sigma, "y")
+
+    with pytest.raises(rustmc.ParameterError) as exc:
+        b.build()
+    message = str(exc.value)
+    assert "alpha" in message
+    assert "declared twice" in message
+
+
+def test_scalar_use_of_a_vector_promoted_parameter_is_rejected(rustmc):
+    """`beta @ 'X'` promotes beta to a vector parameter; using the same name as
+    a scalar coefficient can no longer resolve, and must not fall back."""
+    rng = np.random.default_rng(0)
+    data = {
+        "X": rng.normal(size=(50, 3)),
+        "x": rng.normal(size=50),
+        "y": rng.normal(size=50),
+    }
+    b = rustmc.ModelBuilder(data)
+    beta = b.normal_prior("beta", 0.0, 1.0)
+    sigma = b.half_normal_prior("sigma", 1.0)
+    b.normal_likelihood("y", beta @ "X" + beta * "x", sigma, "y")
+    spec = b.build()
+
+    with pytest.raises(rustmc.ParameterError) as exc:
+        rustmc.sample(spec, chains=1, draws=10, warmup=10, show_progress=False)
+    assert "beta" in str(exc.value)
+
+
+# ── resolution must be correct, not merely present ────────────────────────
+
+
+def test_constrained_parameter_in_predictor_uses_its_constrained_value(rustmc):
+    """A positive-support parameter used as a coefficient must contribute its
+    constrained value, not the unconstrained (log-scale) sampling variable.
+
+    Regression test: resolving through `Graph::node_by_name` returned the raw
+    node for transformed priors, so a HalfNormal coefficient silently entered
+    the linear predictor as log(beta) and the posterior was wrong.
+    """
+    rng = np.random.default_rng(7)
+    x = rng.normal(size=300)
+    beta_true = 2.5
+    y = beta_true * x + rng.normal(scale=0.2, size=300)
+
+    b = rustmc.ModelBuilder({"x": x, "y": y})
+    beta = b.half_normal_prior("beta", 5.0)
+    sigma = b.half_normal_prior("sigma", 1.0)
+    b.normal_likelihood("y", beta * "x", sigma, "y")
+    fit = rustmc.sample(b.build(), chains=2, draws=500, warmup=500, show_progress=False)
+
+    assert fit.mean()["beta"] == pytest.approx(beta_true, abs=0.15)
+
+
+def test_hierarchical_prior_predictive_resolves_its_hyperparameter(rustmc):
+    """Prior predictive draws must use the sampled hyperparameter value.
+
+    The removed defect substituted 1.0 for an unresolved hyperparameter, which
+    would place `theta` near 1 instead of near `mu_pop`.
+    """
+    n = 40
+    data = {"x": np.zeros(n), "y": np.zeros(n)}
+
+    b = rustmc.ModelBuilder(data)
+    mu_pop = b.normal_prior("mu_pop", 100.0, 0.5)
+    theta = b.normal_prior("theta", mu_pop, 1.0)
+    sigma = b.half_normal_prior("sigma", 1.0)
+    b.normal_likelihood("y", theta, sigma, "y")
+
+    draws = rustmc.sample_prior_predictive(b.build(), n_samples=400, seed=1)
+    assert draws["theta"].mean() == pytest.approx(100.0, abs=1.0)
+    assert abs(draws["theta"].mean() - 1.0) > 50.0
+
+
+def test_hierarchical_model_still_samples(rustmc):
+    """Ordering-sensitive hierarchical models keep working end to end."""
+    rng = np.random.default_rng(11)
+    y = rng.normal(loc=3.0, scale=1.0, size=200)
+    data = {"y": y}
+
+    b = rustmc.ModelBuilder(data)
+    mu_pop = b.normal_prior("mu_pop", 0.0, 10.0)
+    sigma_pop = b.half_normal_prior("sigma_pop", 5.0)
+    theta = b.normal_prior("theta", mu_pop, sigma_pop)
+    sigma = b.half_normal_prior("sigma", 5.0)
+    b.normal_likelihood("y", theta, sigma, "y")
+
+    fit = rustmc.sample(b.build(), chains=2, draws=400, warmup=400, show_progress=False)
+    assert fit.mean()["theta"] == pytest.approx(3.0, abs=0.3)


### PR DESCRIPTION
## Goal

Invalid or unresolvable parameter references must fail with a structured error that names the offending parameter, never silently substitute a default that produces a plausible-but-wrong posterior.

## The confirmed defect

`python_bindings/src/lib.rs:2497`

```rust
HyperParam::Param(name) => *sv.get(name.as_str()).unwrap_or(&1.0),
```

In the prior-predictive path, a hyperparameter missing from the sample vector silently became `1.0`. Now it raises `ParameterError`, naming both the missing parameter and the prior that references it.

## A second, worse defect found during the audit

`build_mu_expr` resolved linear-predictor parameters via `Graph::node_by_name`, which returns the **unconstrained raw** node for any transformed prior (HalfNormal, Exponential, LogNormal, Uniform, Gamma, Beta). A positive-support coefficient therefore entered the linear predictor as `log(beta)`.

Measured on the model in `tests/test_param_resolution.py::test_constrained_parameter_in_predictor_uses_its_constrained_value` (true coefficient 2.5):

| build | posterior mean of `beta` |
| --- | --- |
| before | **12.14** (= exp(2.496)) |
| after | **2.50** |

Linear predictors now resolve through the post-transform value-node map, which is what `resolve_sigma` already did correctly.

## Changes

**`rust_core/src/param_ref.rs` (new)** — `ParamReference`, `ParamRefError`, `validate_param_references`. Validates an ordered declaration list against a reference set. Detects unknown names (with a Levenshtein "did you mean"), hyperparameters declared after the prior that uses them, and duplicate declarations. 10 unit tests.

**`rust_core/src/graph.rs`** — removed `ObservationHead::name`. It was always `""` (`ObsLogP` nodes are constructed with `name: None` in all six constructors) and was read nowhere, so `n.name.clone().unwrap_or_default()` was dead code hiding a fallback rather than a live bug.

**`python_bindings/src/lib.rs`**
- New `rustmc.ParameterError`, subclassing `ValueError`, for every parameter-resolution failure.
- **Build-time validation.** `ModelBuilder.build()` now validates the entire reference set before any graph is built; `compile_python_model` re-validates as defence in depth. Hyperparameter arguments are additionally checked at the `*_prior()` call site, the earliest possible point.
- **Model identity.** Each `ModelBuilder` gets a unique id; `ParamRef` / `VectorParamRef` / `Expr` carry it. A reference minted by one model can no longer resolve inside another *even when the names coincide* — previously the silent-success case.
- Error messages list the available parameters and name the model location (`prior 'theta' hyperparameter sigma`, `the linear predictor of likelihood 'y'`).

## Tests

```
cargo test --all      # 49 passed (was 39): 37 core unit + 12 recovery suite
pytest tests/ -q      # 13 passed
```

Every new error path asserts both that the error is raised and that the message names the offending parameter.

## Backward compatibility

`ParameterError` subclasses `ValueError`, so existing `except ValueError` handlers keep working. Three previously-"working" model shapes now error, each of which was silently wrong:

1. A `ParamRef` reused across two `ModelBuilder`s (previously resolved by name if the name happened to exist in the second model).
2. Two priors declared with the same name (ambiguous; `name_to_node` kept only the last).
3. A parameter used both as `@` (vector-promoted) and as a scalar coefficient.

Posterior values change for any model that used a constrained-support parameter as a coefficient in a linear predictor — those were previously wrong.

Out of scope and untouched: the pre-existing `cargo fmt` drift and the 27 pre-existing clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)