### PR TITLE
Task 3: statistical validation suite

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -2,6 +2,11 @@
 
 This document defines the validation stack rustmc needs before it can be treated as a production Bayesian engine.
 
+> **Status:** workstreams 1, 2 and 6 are now implemented. See
+> [`VALIDATION_RESULTS.md`](VALIDATION_RESULTS.md) for the measured results,
+> the tolerance methodology, the defects the suite uncovered, and what is still
+> uncovered. Workstreams 3 (benchmark regression) and 5 (packaging) remain open.
+
 ## What Exists Today
 
 - Core autodiff unit tests in `rust_core/src/autodiff.rs`
@@ -12,18 +17,34 @@ This document defines the validation stack rustmc needs before it can be treated
 
 ## What Is Missing
 
-- Statistical recovery tests for each supported model family
-- Calibration tests for prior predictive and posterior predictive behavior
+- ~~Statistical recovery tests for each supported model family~~ — done
+  (`rust_core/tests/{analytic_posterior,prior_recovery,likelihood_recovery,sbc}.rs`)
+- ~~Calibration tests for prior predictive and posterior predictive behavior~~ — done
+  (`rust_core/tests/sbc.rs`, `tests/test_statistical_predictive.py`)
 - Benchmark suites that track speed, ESS/s, divergences, and memory use over time
-- Python integration tests that exercise the actual wheel, not just Rust internals
+- ~~Python integration tests that exercise the actual wheel, not just Rust internals~~ —
+  partially done (`tests/test_statistical_*.py`); packaging-level tests still missing
 - Packaging and release validation for wheels, version sync, and import compatibility
-- Failure-mode tests for invalid data, incompatible shapes, thread configuration, and divergence-heavy models
+- ~~Failure-mode tests for invalid data, incompatible shapes, thread configuration,
+  and divergence-heavy models~~ — done (`rust_core/tests/numerical_stability.rs`,
+  `tests/test_statistical_engine_bugs.py`)
+- Statistical validation of `batch_sample` and of `compiled_model` artifact round-trips
 
 ## Priority Workstreams
 
-### 1. Statistical Recovery
+### 1. Statistical Recovery — IMPLEMENTED
 
 Goal: prove the sampler recovers known parameters on synthetic data.
+
+Implemented as analytic-posterior comparison (stronger than recovery: the
+posterior mean *and* sd are asserted against exact values), plus recovery for
+the families with no conjugate reference, plus simulation-based calibration.
+Results and tolerance derivations: `VALIDATION_RESULTS.md`.
+
+Note on acceptance criteria: "divergences remain bounded" cannot be evaluated
+against the number the engine reports, because it includes warmup divergences
+(DEFECT 3 in `VALIDATION_RESULTS.md`). The suite computes post-warmup
+divergences itself from `SampleResult::transitions`.
 
 Start with:
 
@@ -39,7 +60,7 @@ Acceptance criteria:
 - Divergences remain bounded on the reference problems
 - R-hat and ESS stay within explicit thresholds
 
-### 2. Calibration
+### 2. Calibration — IMPLEMENTED
 
 Goal: prove the posterior and predictive outputs are well-calibrated.
 
@@ -118,7 +139,7 @@ Acceptance criteria:
 - Version mismatches fail the release pipeline
 - Packaging artifacts are reproducible
 
-### 6. Failure Modes
+### 6. Failure Modes — IMPLEMENTED
 
 Goal: make bad inputs and unstable sampling behavior obvious.
 
@@ -138,9 +159,12 @@ Acceptance criteria:
 
 ## Recommended File Additions
 
-- `tests/` for integration and regression tests once Python-side test execution is wired up
+- ~~`tests/` for integration and regression tests once Python-side test execution is wired up~~ — added
 - `benchmarks/` or `scripts/` for repeatable benchmark entrypoints
 - `validation/` or `tests/fixtures/` for seeded datasets and golden outputs
+  (not needed so far: every dataset in the suite is generated from a seeded
+  deterministic RNG defined in `rust_core/tests/common/mod.rs`, so there are no
+  fixture files to drift)
 
 ## Current Code References
 

--- a/VALIDATION_RESULTS.md
+++ b/VALIDATION_RESULTS.md
@@ -1,0 +1,431 @@
+# Statistical Validation Results
+
+Results of the statistical validation suite added in `Task 3: statistical
+validation suite`. Everything below was measured on this branch; nothing is
+projected or assumed.
+
+**Bottom line.** The inference engine is statistically correct on every model
+family it supports, verified against closed-form posteriors and by
+simulation-based calibration. Two real defects were found in the *Python
+bindings* (one of which makes hierarchical models unusable) and one genuine
+sampling miscalibration was reproduced and quantified (the centered
+hierarchical parameterisation). No bias was found in the autodiff, in any
+log-density, in any constraining transform, or in the NUTS kernel on
+well-conditioned targets.
+
+---
+
+## 1. What the suite is
+
+| File | Tests | What it establishes |
+|---|---|---|
+| `rust_core/tests/gradient_check.rs` | 8 | `grad_logp` equals the finite-difference gradient of `eval_logp` for every op, prior, likelihood and transform |
+| `rust_core/tests/prior_recovery.rs` | 15 | prior-only sampling reproduces each family's closed-form mean and sd — i.e. every constraining transform's Jacobian is right |
+| `rust_core/tests/analytic_posterior.rs` | 6 | posterior mean **and** sd match exact conjugate / linear-Gaussian references |
+| `rust_core/tests/sbc.rs` | 3 fast + 6 opt-in | simulation-based calibration; posterior credible-interval coverage; a live negative control |
+| `rust_core/tests/likelihood_recovery.rs` | 5 | parameter recovery for Exponential / LogNormal / NegativeBinomial GLMs, high-dimensional `MatVecMul`, hierarchical shrinkage |
+| `rust_core/tests/numerical_stability.rs` | 12 | determinism, thread-independence, extreme scales, `n = 1`, large `n`, collinearity, shape-error handling |
+| `tests/test_statistical_conjugate.py` | 6 | the same analytic references reached through the public Python DSL |
+| `tests/test_statistical_predictive.py` | 7 | prior-predictive moments, posterior-predictive interval coverage, analytic predictive checks |
+| `tests/test_statistical_engine_bugs.py` | 10 | pinned defects (xfail) plus failure-mode assertions |
+
+## 2. Tolerance methodology
+
+No tolerance in this suite was chosen by running the test and widening until it
+passed. Every one is derived:
+
+* **Posterior mean.** `|mean_hat - exact| <= 4 * mcse_mean`, using the MCSE the
+  engine itself reports (`posterior sd / sqrt(ess_bulk)`). A single such
+  assertion has a ~6e-5 two-sided false-alarm rate.
+* **Posterior sd.** `|sd_hat - exact| <= 5 * exact * sqrt((kurtosis - 1) / (4 * ess_bulk))`,
+  the delta-method standard error of a sample standard deviation. For a
+  Gaussian (`kurtosis = 3`) this is `5 * exact / sqrt(2 * ess)`. The true
+  kurtosis is supplied for skewed families (LogNormal, Exponential, Gamma,
+  Beta, Uniform, StudentT, HalfNormal) so heavy tails widen the bound honestly
+  rather than by fiat. **Detectable effect size:** at `ess = 2000` this is a
+  ~7.9% relative sd error, so a `sqrt(2)`- or `2x`-style scale bug is caught
+  and a 1% one is not.
+* **Every MCSE-based assertion also gates on `ess_bulk`**, because a tolerance
+  derived from an unreliable MCSE would be vacuous.
+* **Finite differences.** Relative `1e-5` plus an absolute floor plus an
+  explicit cancellation term `8 * eps * |logp| / h`, which dominates at extreme
+  parameter values where `|logp|` reaches `1e8`.
+* **SBC.** Chi-square against uniformity, `df = 7`, rejecting below `p = 1e-3`.
+* **Coverage.** 3.5 binomial standard errors, or (for the Python
+  posterior-predictive test) 4 *empirical* standard errors measured across
+  independent replicates.
+* **Recovery tests.** `|mean - truth| <= 3 * posterior_sd + 4 * mcse`: three
+  posterior sds is the sampling variability of the estimate given one seeded
+  dataset.
+
+## 3. Results
+
+### 3.1 Autodiff — clean
+
+All 8 gradient-check tests pass. Every `Op`, every prior family, every
+`Vector*LogP`, every observation family, `MatVecMul` with and without an
+intercept, hierarchical wiring, and extreme parameter values (linear predictors
+at ±25, `sigma` from 1.2e-4 to 8100) agree with central differences.
+
+### 3.2 Constraining transforms — clean
+
+All 15 prior-recovery tests pass. Sampling from a prior-only model reproduces
+the closed-form mean and sd for Normal, HalfNormal, LogNormal, Exponential,
+Gamma, Beta, Uniform and StudentT, and for all six `Vector*LogP` ops. This is
+the test that catches a wrong or missing Jacobian; none is wrong.
+
+### 3.3 Analytic posteriors — clean
+
+All 6 pass with **zero post-warmup divergences**:
+
+* conjugate Normal-Normal (data-dominated and prior-dominated),
+* linear Gaussian regression through `FusedLinearMu`,
+* the same posterior through faer `MatVecMul` + `VectorNormalLogP`,
+* a two-level linear-Gaussian hierarchy with known variance components
+  (7 parameters, exact joint Gaussian, every marginal mean and sd asserted),
+* near-collinear predictors (empirical correlation ~0.999).
+
+### 3.4 Simulation-based calibration
+
+Full run: `cargo test -p rustmc_core --test sbc --release -- --ignored --nocapture`
+(512 replicates, `L = 63` draws thinned by 8, 8 rank bins, `df = 7`).
+
+```
+model                              param     chi2    p        coverage (nom 75% / 91%)
+location N(0,1) / N(mu,1)          mu        9.00    0.2527   0.770 / 0.893
+scale HalfNormal(1) / N(0,sigma)   sigma     9.31    0.2310   0.723 / 0.912
+regression a + b x, learned sigma  a         6.72    0.4587   0.742 / 0.898
+                                   b        12.56    0.0835   0.762 / 0.906
+                                   sigma     5.44    0.6067   0.766 / 0.896
+hierarchical NON-centered          mu        4.19    0.7579   0.752 / 0.908
+                                   tau       3.56    0.8286   0.744 / 0.904
+                                   z_0       9.78    0.2013   0.732 / 0.916
+matvec X @ beta                    beta[0]   2.47    0.9294   0.758 / 0.916
+                                   beta[1]   7.41    0.3878   0.764 / 0.914
+hierarchical CENTERED (funnel)     mu       13.16    0.0684   0.719 / 0.896
+                                   tau      51.75    1.5e-8   0.656 / 0.805   <-- MISCALIBRATED
+                                   theta_0   3.53    0.8319   0.734 / 0.918
+```
+
+Everything except the centered funnel is calibrated. Minimum p-value among the
+calibrated models is 0.068.
+
+**SBC power.** The chi-square non-centrality is
+`N * sum_k (p_k - 1/8)^2 / (1/8)`; rejection at `p < 1e-3` needs `chi2 > 24.3`:
+
+| perturbation | detected at 128 reps | at 512 reps |
+|---|---|---|
+| posterior mean shifted by `d` sd | `d >= 0.45` | `d >= 0.22` |
+| posterior sd inflated by factor `c` | `c >= 1.5` | `c >= 1.22` |
+
+So SBC here rules out gross bias, not a 5% scale error. That limit is stated in
+the test module and is a property of the replicate count, not of the assertion.
+
+### 3.5 Predictive calibration — clean
+
+* Prior draws for all eight scalar families match closed-form mean and sd
+  (40,000 draws each). `sample_prior_raw` is a *separate* implementation from
+  the sampler, so this is an independent check.
+* The prior predictive of `y` for `mu ~ N(m0, s0)`, `y ~ N(mu, sigma)` matches
+  `N(m0, sqrt(s0^2 + sigma^2))`.
+* Bernoulli / Poisson / Exponential prior-predictive draws respect their
+  support.
+* Posterior-predictive central 50% and 90% intervals attain nominal coverage
+  across 16 replicates whose true coefficients are drawn from the prior (so
+  nominal coverage is exact).
+* Posterior-predictive means and sds match the analytic predictive
+  `N(x_i' m, sigma^2 + x_i' C x_i)` observation by observation.
+
+### 3.6 Numerical stability and determinism — clean
+
+All 12 pass: bit-identical draws for a fixed seed; results independent of the
+Rayon thread count; observation sd from `1e-4` to `1e4`; `n = 1`; `n = 6000`;
+perfectly collinear predictors (posterior still exactly Gaussian and matched);
+predictors of magnitude `1e6`; shape errors rejected with actionable messages
+before sampling.
+
+---
+
+## 4. Defects found (pinned, not fixed)
+
+This worktree owns tests only. Each defect has a test that reproduces it.
+
+### DEFECT 1 — hierarchical models cannot be fitted through the Python DSL (blocking)
+
+`ValueError: Unknown param: mu_0`
+
+`build_prior_into_graph`'s auto-non-centering path (`should_auto_noncenter`,
+`python_bindings/src/lib.rs`) registers the sampled parameter as
+`"<name>__raw"` and stores the derived value node only in `value_node_map`.
+`build_mu_expr` resolves parameter names through `Graph::node_by_name`, which
+only sees graph-level parameter nodes, so any attempt to use a hierarchical
+parameter in a likelihood fails.
+
+Consequence: **every** hierarchical model expressible in the DSL is broken,
+including `examples/hierarchical_example.py` and the shipped
+`examples/hierarchical_templates.py` template. Both the centered
+(`normal_prior(name, mu=ParamRef, sigma=ParamRef)`) and the constant-sigma
+(`normal_prior(name, mu=ParamRef, sigma=1.0)`) forms fail.
+
+Pinned by:
+* `tests/test_statistical_engine_bugs.py::test_hierarchical_parameter_can_be_used_in_a_likelihood`
+* `tests/test_statistical_conjugate.py::test_hierarchical_known_variances_matches_analytic_posterior`
+  (the analytic reference the fix should be validated against)
+
+This is Task 1's parameter-resolution area.
+
+### DEFECT 2 — `sample_prior_predictive` panics on auto-promoted vector parameters
+
+`pyo3_runtime.PanicException: index out of bounds: the len is 1 but the index is 1`
+
+`sample_prior_raw` pushes exactly one raw value for `PriorSpec::Normal`,
+`HalfNormal`, `StudentT`, `Uniform`, `Gamma` and `Beta` regardless of
+`auto_vector_params`, so when a scalar prior has been promoted to length `n` by
+the `@` operator the raw vector is `n - 1` values short and
+`derive_display_draw` indexes past the end. Only the `Exponential` and
+`LogNormal` branches loop over `n`; `PriorSpec::VectorNormal` (the explicit
+`vector_normal_prior`) is correct.
+
+It surfaces as a Rust panic rather than a Python exception.
+
+Pinned by `tests/test_statistical_engine_bugs.py::test_prior_predictive_supports_auto_promoted_vector_parameters`,
+with `test_prior_predictive_works_with_an_explicit_vector_prior` as the
+positive control that localises it.
+
+### DEFECT 3 — the reported divergence count includes warmup
+
+`SampleResult::divergences` (and hence `DiagnosticsReport::divergences`,
+`FitResult.divergences()`, and the `summary()` warning) accumulates
+`n_divergences` over **all** iterations in `nuts::run_chain`, warmup included.
+Stan and PyMC report post-warmup divergences only.
+
+Measured impact: on the 1-parameter conjugate Normal-Normal model the reported
+count is 21 while the true post-warmup count is **0**. On the HalfNormal
+prior-only model it is ~230 warmup vs ~17 post-warmup. Users following the
+documented "divergences indicate unreliable results" advice will chase
+non-problems, and the existing `recovery_suite.rs` thresholds (up to 130
+allowed divergences) are inflated for the same reason.
+
+The per-transition flags needed to split the count already exist in
+`SampleResult::transitions` (`TransitionStats { is_warmup, divergent }`); the
+new `common::divergence_split` helper does exactly this.
+
+Pinned by `tests/test_statistical_engine_bugs.py::test_divergence_count_excludes_warmup`.
+
+### DEFECT 4 — `to_arviz()` discards per-draw divergence flags
+
+`FitResult::to_arviz` warns that "exact per-draw divergence flags are not
+stored" and omits `sample_stats["diverging"]`. They *are* stored:
+`self.raw_result.transitions[chain][i].divergent` with `is_warmup` to select
+the post-warmup subset. As shipped, `az.plot_pair(divergences=True)` and every
+ArviZ divergence diagnostic are unavailable.
+
+Pinned by `tests/test_statistical_engine_bugs.py::test_arviz_export_includes_per_draw_divergence_flags`.
+
+### OBSERVATION 5 — NUTS rejects the whole transition on divergence
+
+`nuts::run_chain`:
+
+```rust
+if !tree_stats.diverging {
+    current.q.copy_from_slice(&proposal.q);
+    ...
+}
+```
+
+When any subtree diverges, `build_tree_iterative` breaks *and* the caller
+discards the proposal accumulated from the already-valid subtrees, leaving the
+chain at its starting point. Stan stops the doubling but keeps the proposal
+from the valid part of the trajectory. Whether a trajectory "diverges" depends
+on `h0 = H(initial)`, so this rejection is not symmetric across the trajectory
+and is not obviously reversible.
+
+**Evidence bound:** SBC at 512 replicates finds no calibration failure on any
+model with a low divergence rate, and the analytic-posterior tests run at zero
+post-warmup divergences. So if this introduces bias, it is below the ~0.22 sd /
+~1.22x detection threshold on those models. It is called out because it is a
+deviation from the reference algorithm, not because a bias has been measured
+here.
+
+### OBSERVATION 6 — the accept statistic fed to dual averaging is non-standard
+
+`build_tree_iterative` accumulates
+`sum_accept_stat += subtree.log_sum_weight.exp().min(n_leaves)`, i.e.
+`min(sum_i w_i, n_leaves)` rather than Stan's `sum_i min(1, w_i)`. Leaves from
+a divergent subtree contribute to neither sum. The two statistics differ
+whenever the trajectory has both very high and very low weight leaves, so the
+step size dual averaging converges to is targeting a slightly different
+quantity than `target_accept`. This is consistent with the observed warmup
+divergence rates (10-20% of warmup iterations on log-scale parameters) and the
+wide spread of adapted step sizes across chains (0.38 to 1.06 on an identical
+1-parameter model).
+
+Not a correctness bug — the post-warmup chains are calibrated — but it is the
+most likely explanation for the divergence counts and for the modest ESS/step
+sizes.
+
+---
+
+## 5. Reproduced miscalibration: the centered hierarchical parameterisation
+
+The centered form `theta_j ~ N(mu, tau)` with `tau ~ HalfNormal(1)` is the
+classic Neal funnel. SBC at 512 replicates:
+
+```
+tau: chi2 = 51.75, df = 7, p = 1.5e-8
+     rank histogram [113, 50, 49, 46, 60, 57, 74, 63]  (uniform would be ~64 each)
+     central 75% credible interval covers 65.6%  (4.9 binomial se low)
+     central 91% credible interval covers 80.5%
+```
+
+The excess in the lowest rank bin means the true `tau` falls *below* the
+sampled posterior far more often than it should: the sampler cannot reach the
+neck of the funnel, so `tau`'s posterior is truncated from below and its
+credible intervals under-cover. `mu` and `theta_0` are calibrated.
+
+The **non-centered** version of the same model is fully calibrated (see the
+table above), which localises this to the parameterisation rather than to the
+engine. Stan has the same limitation with the same model.
+
+Why it matters here: `examples/hierarchical_templates.py` builds the *centered*
+form, and the DSL's automatic non-centering — which would avoid this — is
+unreachable because of DEFECT 1. So today the only hierarchical
+parameterisation rustmc documents is the miscalibrated one, and it does not run
+at all.
+
+Characterisation test:
+`rust_core/tests/sbc.rs::sbc_centered_hierarchical_model_is_known_miscalibrated`
+(opt-in). It asserts the under-coverage is *still present*; if it starts
+passing, the geometry handling improved and the test plus the hierarchical docs
+should be updated.
+
+---
+
+## 6. Negative-control verification
+
+To confirm the suite can actually detect the failures it targets, a 15% scale
+error was injected into `Normal::prior` in `rust_core/src/distributions.rs`
+(`add_constant(sigma)` -> `add_constant(sigma * 1.15)`) and the suite re-run:
+
+```
+prior_recovery::normal_prior_reproduces_its_own_distribution        FAILED
+  x: posterior sd 1.599142 differs from analytic 1.400000 by 0.199142
+     (14.22% relative), tolerance 0.063912 (4.57% relative, ess_bulk 5998)
+
+prior_recovery::hierarchical_prior_marginal_matches_closed_form     FAILED
+  mu: posterior sd 1.770815 differs from analytic 1.500000 by 0.270815
+      (18.05% relative), tolerance 0.157605 (10.51% relative, ess_bulk 1132)
+
+analytic_posterior::conjugate_normal_normal_prior_dominated_...     FAILED
+```
+
+The change was then reverted (`git diff rust_core/src/` is empty). SBC at 128
+replicates did **not** flag the 15% error, exactly as the documented power
+table predicts — which is itself a useful confirmation that the stated power
+limits are real rather than optimistic.
+
+Separately, `sbc.rs::sbc_detects_an_injected_bias` is a permanent, always-on
+negative control: it ranks the true value against posterior draws shifted by
+0.7 posterior sd and requires SBC to reject (measured `chi2 = 65.88`,
+`p = 1.0e-11`).
+
+---
+
+## 7. Runtime
+
+Debug (`cargo test --all`, measured on this branch):
+
+| target | tests | time |
+|---|---|---|
+| `rustmc_core` unit tests | 27 | 0.03 s |
+| `gradient_check` | 8 | < 0.01 s |
+| `prior_recovery` | 15 | 1.1 s |
+| `sbc` (fast tests only) | 3 | 9.7 s |
+| `numerical_stability` | 12 | 26.0 s |
+| `analytic_posterior` | 6 | 41.6 s |
+| `likelihood_recovery` | 5 | 44.0 s |
+| `recovery_suite` (pre-existing) | 12 | 132.0 s |
+| **total** | **88** | **~254 s** |
+
+Before this branch: 39 tests, ~132 s. After: 88 tests, ~254 s — so the suite
+roughly doubled in both count and wall time, and 49 of the 51 new tests
+complete in under 45 s each.
+
+The six opt-in SBC tests add ~40 s in release and are excluded by default:
+
+```
+cargo test -p rustmc_core --test sbc --release -- --ignored --nocapture
+```
+
+Python: `pytest tests/` is **18 passed, 5 xfailed in 4.8 s** against a
+`maturin develop --release` build.
+
+---
+
+## 8. What is still not covered
+
+* **Hierarchical models through the Python DSL** — blocked by DEFECT 1. The
+  Rust-level hierarchical tests (analytic posterior, SBC, shrinkage) cover the
+  engine; the binding path has an xfail placeholder waiting on the fix.
+* **Hierarchical vector parameters** — `normal_prior` with a `ParamRef`
+  hyperparameter combined with `@` is explicitly rejected by the bindings, so
+  there is nothing to test.
+* **`batch_sample`** — no statistical validation. It shares `build_prior_into_graph`
+  and the sampler with `sample()`, but the per-model result assembly is
+  separate code.
+* **`compiled_model.rs`** — serialization round-trips are not statistically
+  validated (does a reloaded artifact sample the same posterior?).
+* **StudentT and Uniform likelihoods** — the DSL has StudentT/Uniform *priors*
+  but no corresponding observation families, so `VALIDATION.md`'s
+  "heavy-tailed regression" item is not yet testable.
+* **SBC precision** — the current replicate counts detect ~0.22 sd location
+  bias and ~1.22x scale bias. Detecting a 5% scale error needs ~10,000
+  replicates, which is a nightly job rather than a CI job.
+* **Multi-likelihood models** — models with several observation heads are
+  exercised incidentally but have no dedicated calibration test.
+* **`ess_tail` and HDI** — asserted to be finite but not validated against
+  reference implementations.
+
+---
+
+## 9. DSL support: spec versus reality
+
+`VALIDATION.md` and the task brief assume a prior-family x likelihood-family x
+scalar/vector/matrix/hierarchical cross-product. What the bindings actually
+support today:
+
+**Priors** (`ModelBuilder`): `normal`, `half_normal`, `exponential`,
+`log_normal`, `student_t`, `uniform`, `bernoulli`, `poisson`, `gamma`, `beta`,
+`vector_normal`.
+
+**Hyperparameters as `ParamRef`**: only `normal_prior(mu, sigma)`,
+`half_normal_prior(sigma)`, `exponential_prior(rate)` and
+`log_normal_prior(mu, sigma)`. `student_t`, `uniform`, `gamma` and `beta` take
+`f64` only — no hierarchical variants.
+
+**Likelihoods**: `normal`, `bernoulli_logit`, `poisson_log`, `exponential`,
+`log_normal`, `negative_binomial`. There is **no** StudentT, Uniform, Gamma,
+Beta or Binomial likelihood, so those prior families can only ever appear as
+priors.
+
+**`sigma` as a `ParamRef`**: supported for `normal_likelihood`,
+`log_normal_likelihood`, and `negative_binomial_likelihood` (as `alpha`).
+
+**Vector parameters**: explicit via `vector_normal_prior`, or auto-promoted
+from any continuous scalar prior used with `@`. Auto-promotion requires
+constant hyperparameters — a hierarchical vector parameter is rejected with an
+explicit error.
+
+**Expression algebra**: `ParamRef * "key"`, `ParamRef @ "key"`,
+`VectorParamRef @ "key"`, `+` between expressions / params / floats. There is
+no subtraction, no scalar multiplication of a parameter by a number, no
+interaction terms, and no elementwise product of two parameters.
+
+**Not supported at all**: multivariate normal priors, covariance/correlation
+parameters, LKJ, simplex or ordered constraints, censoring/truncation, mixtures,
+missing data, offsets/exposures (a Poisson offset must be folded into the data),
+non-identity links beyond the fixed per-family link, and time-series structures
+(an AR(1) has to be written as a lagged regression by hand).
+
+The single largest gap between spec and reality is that **hierarchical models
+are advertised and documented but do not run** (DEFECT 1).

--- a/rust_core/tests/analytic_posterior.rs
+++ b/rust_core/tests/analytic_posterior.rs
@@ -1,0 +1,296 @@
+//! Analytical reference tests: models whose posterior is available in closed
+//! form, compared against the sampler's output.
+//!
+//! These are the strongest correctness evidence in the suite. Unlike parameter
+//! recovery (which only checks that the posterior is *near the truth*), these
+//! check that the posterior is *the right distribution*: both its mean and its
+//! spread are asserted against exact values.
+//!
+//! See `common/mod.rs` for the tolerance derivation.
+
+mod common;
+
+use common::{
+    assert_converged, assert_mean_within_mcse, assert_post_warmup_divergences,
+    assert_sd_within_mcse, invert, linear_gaussian_posterior, mat_vec, nuts, Rng,
+};
+use rustmc_core::distributions::Normal;
+use rustmc_core::graph::Graph;
+
+const CHAINS: usize = 4;
+const DRAWS: usize = 600;
+const WARMUP: usize = 600;
+
+/// Conjugate Normal-Normal with known observation sd.
+///
+/// Target failure mode: a systematic shift or scale error in the Normal
+/// log-density or in its gradient. The posterior mean and sd are exact, so a
+/// bug that (say) dropped a factor of 2 in the quadratic term would move the
+/// posterior sd by sqrt(2) and fail immediately.
+#[test]
+fn conjugate_normal_normal_matches_analytic_posterior() {
+    let mut rng = Rng::new(0xC0FFEE);
+    let mu_true = 1.25;
+    let sigma = 0.8; // known
+    let m0 = 0.0;
+    let s0 = 2.0;
+    let n = 40;
+    let y: Vec<f64> = (0..n).map(|_| rng.normal_with(mu_true, sigma)).collect();
+
+    // Exact posterior.
+    let prec = 1.0 / (s0 * s0) + n as f64 / (sigma * sigma);
+    let post_mean = (m0 / (s0 * s0) + y.iter().sum::<f64>() / (sigma * sigma)) / prec;
+    let post_sd = (1.0 / prec).sqrt();
+
+    let mut graph = Graph::new();
+    let mu = Normal::prior(&mut graph, "mu", m0, s0);
+    let mu_vec = graph.scalar_broadcast(mu);
+    let sigma_node = graph.add_constant(sigma);
+    let obs = graph.add_obs_data(y);
+    graph.normal_obs_logp(mu_vec, sigma_node, obs);
+
+    let result = nuts(graph, 20_001, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.02);
+    assert_post_warmup_divergences(&result, 0);
+    assert_mean_within_mcse(&report, "mu", post_mean, 500.0, 0.0);
+    assert_sd_within_mcse(&report, "mu", post_sd, 500.0, 0.0);
+}
+
+/// Conjugate Normal-Normal where the *prior* dominates (n = 3, wide sigma).
+///
+/// Target failure mode: the prior term being silently dropped or double
+/// counted. With little data the posterior is almost the prior, so a missing
+/// prior contribution shows up as a large sd error rather than a small one.
+#[test]
+fn conjugate_normal_normal_prior_dominated_matches_analytic_posterior() {
+    let y = vec![2.0, -1.0, 0.5];
+    let sigma = 5.0;
+    let m0 = 1.0;
+    let s0 = 0.7;
+    let n = y.len();
+
+    let prec = 1.0 / (s0 * s0) + n as f64 / (sigma * sigma);
+    let post_mean = (m0 / (s0 * s0) + y.iter().sum::<f64>() / (sigma * sigma)) / prec;
+    let post_sd = (1.0 / prec).sqrt();
+
+    let mut graph = Graph::new();
+    let mu = Normal::prior(&mut graph, "mu", m0, s0);
+    let mu_vec = graph.scalar_broadcast(mu);
+    let sigma_node = graph.add_constant(sigma);
+    let obs = graph.add_obs_data(y);
+    graph.normal_obs_logp(mu_vec, sigma_node, obs);
+
+    let result = nuts(graph, 20_002, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.02);
+    assert_post_warmup_divergences(&result, 0);
+    assert_mean_within_mcse(&report, "mu", post_mean, 500.0, 0.0);
+    assert_sd_within_mcse(&report, "mu", post_sd, 500.0, 0.0);
+}
+
+/// Linear Gaussian regression with known noise sd, via the `FusedLinearMu` op.
+///
+/// Target failure mode: an indexing or scaling error in `FusedLinearMu`'s
+/// forward pass or its adjoint. The full posterior mean vector and marginal
+/// sds are exact.
+#[test]
+fn linear_gaussian_regression_fused_matches_analytic_posterior() {
+    let mut rng = Rng::new(0xBEEF01);
+    let n = 60;
+    let sigma = 0.7;
+    let beta_true = [0.9, -1.4, 0.35];
+    let prior_mean = [0.0, 0.0, 0.0];
+    let prior_sd = [3.0, 3.0, 3.0];
+
+    let x1: Vec<f64> = (0..n).map(|_| rng.normal()).collect();
+    let x2: Vec<f64> = (0..n).map(|_| rng.normal()).collect();
+    let rows: Vec<Vec<f64>> = (0..n).map(|i| vec![1.0, x1[i], x2[i]]).collect();
+    let y: Vec<f64> = rows
+        .iter()
+        .map(|r| {
+            r.iter().zip(beta_true).map(|(a, b)| a * b).sum::<f64>() + rng.normal_with(0.0, sigma)
+        })
+        .collect();
+
+    let exact = linear_gaussian_posterior(&rows, &y, sigma, &prior_mean, &prior_sd);
+
+    let mut graph = Graph::new();
+    let a = Normal::prior(&mut graph, "b0", prior_mean[0], prior_sd[0]);
+    let b = Normal::prior(&mut graph, "b1", prior_mean[1], prior_sd[1]);
+    let c = Normal::prior(&mut graph, "b2", prior_mean[2], prior_sd[2]);
+    let d0 = graph.store_data_vec(vec![1.0; n]);
+    let d1 = graph.store_data_vec(x1);
+    let d2 = graph.store_data_vec(x2);
+    let mu = graph.fused_linear_mu(vec![a, b, c], vec![d0, d1, d2], None);
+    let sigma_node = graph.add_constant(sigma);
+    let obs = graph.add_obs_data(y);
+    graph.normal_obs_logp(mu, sigma_node, obs);
+
+    let result = nuts(graph, 20_003, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.02);
+    assert_post_warmup_divergences(&result, 0);
+    for (k, name) in ["b0", "b1", "b2"].iter().enumerate() {
+        assert_mean_within_mcse(&report, name, exact.mean[k], 400.0, 0.0);
+        assert_sd_within_mcse(&report, name, exact.sd(k), 400.0, 0.0);
+    }
+}
+
+/// The same exact posterior, reached through the faer-backed `MatVecMul` op
+/// and the vectorized `VectorNormalLogP` prior.
+///
+/// Target failure mode: the matrix path disagreeing with the scalar path.
+/// Because both this test and the previous one assert against the *same kind*
+/// of closed form, a discrepancy localizes the bug to the matrix code.
+#[test]
+fn matvec_regression_matches_analytic_posterior() {
+    let mut rng = Rng::new(0xBEEF02);
+    let n = 60;
+    let p = 4;
+    let sigma = 0.6;
+    let prior_sd_scalar = 2.0;
+    let beta_true = [0.6, -1.1, 0.25, 0.8];
+
+    // Row-major n x p design matrix, first column an intercept.
+    let mut rows: Vec<Vec<f64>> = Vec::with_capacity(n);
+    for _ in 0..n {
+        let mut row = vec![1.0];
+        for _ in 1..p {
+            row.push(rng.normal());
+        }
+        rows.push(row);
+    }
+    let y: Vec<f64> = rows
+        .iter()
+        .map(|r| {
+            r.iter().zip(beta_true).map(|(a, b)| a * b).sum::<f64>() + rng.normal_with(0.0, sigma)
+        })
+        .collect();
+
+    let prior_mean = vec![0.0; p];
+    let prior_sd = vec![prior_sd_scalar; p];
+    let exact = linear_gaussian_posterior(&rows, &y, sigma, &prior_mean, &prior_sd);
+
+    let mut graph = Graph::new();
+    let beta_start = graph.add_vector_params("beta", p);
+    graph.vector_normal_logp(beta_start, p, 0.0, prior_sd_scalar);
+    let flat: Vec<f64> = rows.iter().flatten().copied().collect();
+    let matrix = graph.store_matrix(flat, n, p);
+    let mu = graph.mat_vec_mul(matrix, beta_start, p, None);
+    let sigma_node = graph.add_constant(sigma);
+    let obs = graph.add_obs_data(y);
+    graph.normal_obs_logp(mu, sigma_node, obs);
+
+    let result = nuts(graph, 20_004, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.03);
+    assert_post_warmup_divergences(&result, 0);
+    for k in 0..p {
+        let name = format!("beta[{k}]");
+        let name = if report.params.iter().any(|q| q.name == name) {
+            name
+        } else {
+            format!("beta_{k}")
+        };
+        assert_mean_within_mcse(&report, &name, exact.mean[k], 400.0, 0.0);
+        assert_sd_within_mcse(&report, &name, exact.sd(k), 400.0, 0.0);
+    }
+}
+
+/// Two-level linear-Gaussian hierarchy with *known* variance components, so
+/// the joint posterior over (mu, theta_1..theta_J) is exactly Gaussian.
+///
+/// Target failure mode: the hierarchical `prior_with_nodes` path mis-wiring
+/// the parent mean, or the partial-pooling shrinkage coming out at the wrong
+/// strength. Shrinkage strength is entirely determined by tau vs sigma_j, so
+/// an error there moves both the posterior means and their sds.
+#[test]
+fn hierarchical_linear_gaussian_matches_analytic_posterior() {
+    let j = 6usize;
+    let s0 = 5.0; // prior sd on mu
+    let tau = 1.2; // known group sd
+    let sigma = [1.0, 1.4, 0.8, 2.0, 1.1, 0.9]; // known within-group sds
+    let y = [1.9, -0.4, 3.1, 0.2, 1.1, 2.4];
+
+    // Joint precision over [mu, theta_0..theta_{J-1}].
+    let dim = j + 1;
+    let mut lambda = vec![vec![0.0; dim]; dim];
+    let mut h = vec![0.0; dim];
+    lambda[0][0] = 1.0 / (s0 * s0) + j as f64 / (tau * tau);
+    for g in 0..j {
+        lambda[0][g + 1] = -1.0 / (tau * tau);
+        lambda[g + 1][0] = -1.0 / (tau * tau);
+        lambda[g + 1][g + 1] = 1.0 / (tau * tau) + 1.0 / (sigma[g] * sigma[g]);
+        h[g + 1] = y[g] / (sigma[g] * sigma[g]);
+    }
+    let cov = invert(&lambda);
+    let mean = mat_vec(&cov, &h);
+
+    let mut graph = Graph::new();
+    let mu = Normal::prior(&mut graph, "mu", 0.0, s0);
+    let tau_node = graph.add_constant(tau);
+    for g in 0..j {
+        let theta = Normal::prior_with_nodes(&mut graph, &format!("theta_{g}"), mu, tau_node);
+        let yi = graph.add_constant(y[g]);
+        let si = graph.add_constant(sigma[g]);
+        graph.normal_logp(yi, theta, si);
+    }
+
+    let result = nuts(graph, 20_005, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.03);
+    assert_post_warmup_divergences(&result, 0);
+    assert_mean_within_mcse(&report, "mu", mean[0], 400.0, 0.0);
+    assert_sd_within_mcse(&report, "mu", cov[0][0].sqrt(), 400.0, 0.0);
+    for g in 0..j {
+        let name = format!("theta_{g}");
+        assert_mean_within_mcse(&report, &name, mean[g + 1], 400.0, 0.0);
+        assert_sd_within_mcse(&report, &name, cov[g + 1][g + 1].sqrt(), 400.0, 0.0);
+    }
+}
+
+/// Near-collinear predictors (empirical correlation ~0.999) with a proper
+/// prior, so the posterior is still exactly Gaussian but extremely elongated.
+///
+/// Target failure mode: mass-matrix adaptation failing on a badly conditioned
+/// target, producing a posterior that is too narrow along the stiff direction.
+/// The tolerance widens automatically because ESS collapses; the assertion
+/// still has teeth because the two marginal sds differ by orders of magnitude
+/// from the well-conditioned case.
+#[test]
+fn near_collinear_regression_matches_analytic_posterior() {
+    let mut rng = Rng::new(0xBEEF03);
+    let n = 100;
+    let sigma = 0.5;
+    let prior_sd = [2.0, 2.0];
+
+    let x1: Vec<f64> = (0..n).map(|_| rng.normal()).collect();
+    let x2: Vec<f64> = x1.iter().map(|&v| v + 0.03 * rng.normal()).collect();
+    let rows: Vec<Vec<f64>> = (0..n).map(|i| vec![x1[i], x2[i]]).collect();
+    let y: Vec<f64> = rows
+        .iter()
+        .map(|r| 1.0 * r[0] - 0.5 * r[1] + rng.normal_with(0.0, sigma))
+        .collect();
+
+    let exact = linear_gaussian_posterior(&rows, &y, sigma, &[0.0, 0.0], &prior_sd);
+
+    let mut graph = Graph::new();
+    let b1 = Normal::prior(&mut graph, "b1", 0.0, prior_sd[0]);
+    let b2 = Normal::prior(&mut graph, "b2", 0.0, prior_sd[1]);
+    let d1 = graph.store_data_vec(x1);
+    let d2 = graph.store_data_vec(x2);
+    let mu = graph.fused_linear_mu(vec![b1, b2], vec![d1, d2], None);
+    let sigma_node = graph.add_constant(sigma);
+    let obs = graph.add_obs_data(y);
+    graph.normal_obs_logp(mu, sigma_node, obs);
+
+    let result = nuts(graph, 20_006, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.05);
+    assert_post_warmup_divergences(&result, 5);
+    for (k, name) in ["b1", "b2"].iter().enumerate() {
+        assert_mean_within_mcse(&report, name, exact.mean[k], 200.0, 0.0);
+        assert_sd_within_mcse(&report, name, exact.sd(k), 200.0, 0.0);
+    }
+}

--- a/rust_core/tests/common/mod.rs
+++ b/rust_core/tests/common/mod.rs
@@ -1,0 +1,474 @@
+//! Shared helpers for the statistical validation suite.
+//!
+//! # Tolerance philosophy
+//!
+//! Every assertion in this suite compares a Monte Carlo estimate against a
+//! value that is either analytically known or known by construction. The
+//! tolerance is therefore derived from the Monte Carlo standard error (MCSE)
+//! of the estimator rather than hand-tuned until the test happens to pass.
+//!
+//! * **Posterior mean.** For a posterior with standard deviation `s` and bulk
+//!   effective sample size `S`, the MCSE of the sample mean is `s / sqrt(S)`.
+//!   `DiagnosticsReport` reports this directly as `mcse_mean`. We assert
+//!   `|mean_hat - mean_true| <= K_MEAN * mcse_mean`. With `K_MEAN = 4` a single
+//!   assertion has a ~6e-5 two-sided false-positive rate under a normal CLT
+//!   approximation; across the ~120 mean assertions in this suite the
+//!   family-wise flake probability is well under 1%.
+//!
+//! * **Posterior standard deviation.** The MCSE of a standard-deviation
+//!   estimate from `S` effectively independent draws of a roughly Gaussian
+//!   quantity is `s / sqrt(2 S)`, i.e. a relative error of `1 / sqrt(2 S)`.
+//!   We use `K_SD = 5` because the sd estimator's sampling distribution is
+//!   more skewed than the mean's and because `ess_bulk` is tuned for the mean.
+//!   The *detectable* effect size is therefore `K_SD / sqrt(2 S)` relative:
+//!   at `S = 2000` that is ~7.9%, so a scale error of 10% or more (and any
+//!   sqrt(2)- or 2x-style scale bug) is caught, while a 1% error is not.
+//!   Where a tighter bound is wanted, the test raises the draw count instead
+//!   of lowering `K_SD`.
+//!
+//! * **Floors.** Some assertions add a small absolute floor so that a
+//!   pathologically small reported MCSE (which itself is an estimate) cannot
+//!   make a test infinitely strict. Floors are always stated in the caller.
+//!
+//! * **Determinism.** Every test seeds both the data-generating RNG and the
+//!   sampler. Reruns are bit-identical, so a failure is a real failure and
+//!   not a reseed away from passing.
+
+#![allow(dead_code)]
+
+use rustmc_core::diagnostics::{DiagnosticsReport, ParamDiagnostics};
+use rustmc_core::graph::Graph;
+use rustmc_core::sampler::{sample as run_sample, SampleResult, SamplerConfig, SamplerType};
+
+/// Multiplier on `mcse_mean` for posterior-mean assertions.
+pub const K_MEAN: f64 = 4.0;
+/// Multiplier on the relative sd MCSE `1/sqrt(2 S)` for posterior-sd assertions.
+pub const K_SD: f64 = 5.0;
+
+/// Run NUTS with a fixed configuration. `num_threads = 1` keeps chain results
+/// reproducible independently of machine core count.
+pub fn nuts(graph: Graph, seed: u64, chains: usize, draws: usize, warmup: usize) -> SampleResult {
+    run_sample(
+        graph,
+        SamplerConfig {
+            sampler: SamplerType::Nuts,
+            num_chains: chains,
+            num_draws: draws,
+            num_warmup: warmup,
+            step_size: 0.0,
+            num_leapfrog_steps: 15,
+            max_tree_depth: 10,
+            seed,
+            num_threads: 1,
+            show_progress: false,
+        },
+    )
+    .expect("sampling failed")
+}
+
+pub fn diag<'a>(report: &'a DiagnosticsReport, name: &str) -> &'a ParamDiagnostics {
+    report
+        .params
+        .iter()
+        .find(|p| p.name == name)
+        .unwrap_or_else(|| {
+            panic!(
+                "missing diagnostic for {name}; available: {:?}",
+                report.params.iter().map(|p| &p.name).collect::<Vec<_>>()
+            )
+        })
+}
+
+/// Assert the sampled posterior mean of `name` matches `truth` to within
+/// `K_MEAN` reported Monte Carlo standard errors (plus an absolute `floor`).
+///
+/// Also requires `ess_bulk >= min_ess`: without adequate ESS the reported MCSE
+/// is itself unreliable and the assertion would be vacuous.
+pub fn assert_mean_within_mcse(
+    report: &DiagnosticsReport,
+    name: &str,
+    truth: f64,
+    min_ess: f64,
+    floor: f64,
+) {
+    let p = diag(report, name);
+    assert!(
+        p.ess_bulk.is_finite() && p.ess_bulk >= min_ess,
+        "{name}: ess_bulk {} < required {min_ess}; MCSE-based tolerance would be meaningless",
+        p.ess_bulk
+    );
+    let tol = K_MEAN * p.mcse_mean + floor;
+    assert!(
+        (p.mean - truth).abs() <= tol,
+        "{name}: posterior mean {:.6} differs from analytic {:.6} by {:.6}, \
+         tolerance {:.6} = {K_MEAN} * mcse({:.6}) + floor({floor}) [ess_bulk {:.0}]",
+        p.mean,
+        truth,
+        (p.mean - truth).abs(),
+        tol,
+        p.mcse_mean,
+        p.ess_bulk
+    );
+}
+
+/// Assert the sampled posterior sd of `name` matches `truth` to within
+/// `K_SD / sqrt(2 * ess_bulk)` in relative terms (plus an absolute `floor`).
+///
+/// Assumes an approximately Gaussian target; use
+/// [`assert_sd_within_mcse_kurtosis`] for skewed or heavy-tailed targets.
+pub fn assert_sd_within_mcse(
+    report: &DiagnosticsReport,
+    name: &str,
+    truth: f64,
+    min_ess: f64,
+    floor: f64,
+) {
+    assert_sd_within_mcse_kurtosis(report, name, truth, 3.0, min_ess, floor)
+}
+
+/// As [`assert_sd_within_mcse`], but with the target's standardized fourth
+/// moment `kurtosis = mu4 / sigma^4` supplied explicitly.
+///
+/// The delta-method standard error of a sample standard deviation from `S`
+/// effectively independent draws is `sigma * sqrt((kurtosis - 1) / (4 S))`.
+/// For a Gaussian (`kurtosis = 3`) this reduces to `sigma / sqrt(2 S)`. Using
+/// the true kurtosis keeps heavy-tailed targets (LogNormal, Exponential,
+/// StudentT) from producing spurious failures without loosening the bound for
+/// well-behaved ones.
+pub fn assert_sd_within_mcse_kurtosis(
+    report: &DiagnosticsReport,
+    name: &str,
+    truth: f64,
+    kurtosis: f64,
+    min_ess: f64,
+    floor: f64,
+) {
+    let p = diag(report, name);
+    assert!(
+        p.ess_bulk.is_finite() && p.ess_bulk >= min_ess,
+        "{name}: ess_bulk {} < required {min_ess}",
+        p.ess_bulk
+    );
+    let rel = K_SD * ((kurtosis - 1.0) / (4.0 * p.ess_bulk)).sqrt();
+    let tol = rel * truth.abs() + floor;
+    assert!(
+        (p.std - truth).abs() <= tol,
+        "{name}: posterior sd {:.6} differs from analytic {:.6} by {:.6} \
+         ({:.2}% relative), tolerance {:.6} ({:.2}% relative, K_SD={K_SD}, ess_bulk {:.0})",
+        p.std,
+        truth,
+        (p.std - truth).abs(),
+        100.0 * (p.std - truth).abs() / truth.abs(),
+        tol,
+        100.0 * rel,
+        p.ess_bulk
+    );
+}
+
+/// Split the divergence count into (warmup, post-warmup).
+///
+/// NOTE: `SampleResult::total_divergences()` — and therefore
+/// `DiagnosticsReport::divergences` and the Python `FitResult.divergences()` —
+/// counts divergences over *warmup as well as sampling* iterations. Stan and
+/// PyMC report post-warmup divergences only. Divergences during step-size
+/// adaptation are expected and benign; divergences after warmup indicate
+/// posterior bias. Statistical tests here gate on the post-warmup count.
+pub fn divergence_split(result: &SampleResult) -> (usize, usize) {
+    let mut warm = 0;
+    let mut post = 0;
+    for chain in &result.transitions {
+        for t in chain {
+            if t.divergent {
+                if t.is_warmup {
+                    warm += 1;
+                } else {
+                    post += 1;
+                }
+            }
+        }
+    }
+    (warm, post)
+}
+
+/// Assert that no more than `max` divergences occurred *after* warmup.
+pub fn assert_post_warmup_divergences(result: &SampleResult, max: usize) {
+    let (warm, post) = divergence_split(result);
+    assert!(
+        post <= max,
+        "{post} post-warmup divergences > allowed {max} (plus {warm} during warmup)"
+    );
+}
+
+/// Assert the post-warmup divergence *rate* stays under `max_rate`.
+///
+/// Used for targets whose unconstrained geometry is genuinely stiff (anything
+/// on a log scale has a doubly-exponential right tail), where a small residual
+/// rate is expected from the step size rather than from a correctness defect.
+/// The accompanying moment assertions are what establish the absence of bias;
+/// this gate only catches a rate blowing up.
+pub fn assert_post_warmup_divergence_rate(result: &SampleResult, max_rate: f64) {
+    let (warm, post) = divergence_split(result);
+    let draws: usize = result.samples.iter().map(|c| c.len()).sum();
+    let rate = post as f64 / draws.max(1) as f64;
+    assert!(
+        rate <= max_rate,
+        "post-warmup divergence rate {:.4}% ({post}/{draws}) > allowed {:.4}% \
+         (plus {warm} during warmup)",
+        100.0 * rate,
+        100.0 * max_rate
+    );
+}
+
+/// Convergence / health gate applied to every statistical test.
+pub fn assert_converged(report: &DiagnosticsReport, max_rhat: f64) {
+    for p in &report.params {
+        assert!(
+            p.r_hat.is_finite() && p.r_hat < max_rhat,
+            "{}: r_hat {} exceeded {max_rhat}",
+            p.name,
+            p.r_hat
+        );
+    }
+}
+
+// ── Small dense linear algebra (avoids adding a dependency) ─────────────────
+
+/// Invert a symmetric positive-definite matrix via Gauss-Jordan with partial
+/// pivoting. Panics if the matrix is singular to working precision.
+pub fn invert(a: &[Vec<f64>]) -> Vec<Vec<f64>> {
+    let n = a.len();
+    let mut m: Vec<Vec<f64>> = a
+        .iter()
+        .enumerate()
+        .map(|(i, row)| {
+            let mut r = row.clone();
+            r.extend((0..n).map(|j| if i == j { 1.0 } else { 0.0 }));
+            r
+        })
+        .collect();
+
+    for col in 0..n {
+        let (pivot_row, _) = (col..n)
+            .map(|r| (r, m[r][col].abs()))
+            .fold((col, -1.0), |acc, x| if x.1 > acc.1 { x } else { acc });
+        assert!(
+            m[pivot_row][col].abs() > 1e-14,
+            "matrix is singular at column {col}"
+        );
+        m.swap(col, pivot_row);
+        let pivot = m[col][col];
+        for v in m[col].iter_mut() {
+            *v /= pivot;
+        }
+        for r in 0..n {
+            if r == col {
+                continue;
+            }
+            let factor = m[r][col];
+            if factor == 0.0 {
+                continue;
+            }
+            for c in 0..2 * n {
+                m[r][c] -= factor * m[col][c];
+            }
+        }
+    }
+
+    m.into_iter().map(|row| row[n..].to_vec()).collect()
+}
+
+pub fn mat_vec(a: &[Vec<f64>], b: &[f64]) -> Vec<f64> {
+    a.iter()
+        .map(|row| row.iter().zip(b).map(|(x, y)| x * y).sum())
+        .collect()
+}
+
+/// Posterior of a linear-Gaussian model expressed through its information form:
+/// prior precision `lambda0`, prior information vector `h0`, plus the
+/// likelihood contribution `X' Sigma_y^{-1} X` and `X' Sigma_y^{-1} y`.
+///
+/// Returns `(mean, covariance)`.
+pub struct GaussianPosterior {
+    pub mean: Vec<f64>,
+    pub cov: Vec<Vec<f64>>,
+}
+
+impl GaussianPosterior {
+    pub fn sd(&self, i: usize) -> f64 {
+        self.cov[i][i].sqrt()
+    }
+}
+
+/// Build the exact posterior of `y ~ N(X beta, sigma^2 I)` with independent
+/// Normal priors `beta_k ~ N(prior_mean[k], prior_sd[k])`.
+///
+/// `x` is `n` rows of `p` columns.
+pub fn linear_gaussian_posterior(
+    x: &[Vec<f64>],
+    y: &[f64],
+    sigma: f64,
+    prior_mean: &[f64],
+    prior_sd: &[f64],
+) -> GaussianPosterior {
+    let p = prior_mean.len();
+    let inv_var = 1.0 / (sigma * sigma);
+    let mut lambda = vec![vec![0.0; p]; p];
+    let mut h = vec![0.0; p];
+
+    for (k, item) in lambda.iter_mut().enumerate().take(p) {
+        item[k] += 1.0 / (prior_sd[k] * prior_sd[k]);
+        h[k] += prior_mean[k] / (prior_sd[k] * prior_sd[k]);
+    }
+    for (row, yi) in x.iter().zip(y) {
+        for j in 0..p {
+            h[j] += inv_var * row[j] * yi;
+            for k in 0..p {
+                lambda[j][k] += inv_var * row[j] * row[k];
+            }
+        }
+    }
+
+    let cov = invert(&lambda);
+    let mean = mat_vec(&cov, &h);
+    GaussianPosterior { mean, cov }
+}
+
+// ── Deterministic RNG utilities ────────────────────────────────────────────
+
+/// Split-mix style deterministic uniform stream. Used where we want reproducible
+/// synthetic data without depending on a particular `rand` version's stream.
+pub struct Rng(u64);
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Rng(seed.wrapping_mul(2685821657736338717).wrapping_add(1))
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform on (0, 1).
+    pub fn uniform(&mut self) -> f64 {
+        let v = (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64;
+        v.clamp(1e-15, 1.0 - 1e-15)
+    }
+
+    /// Standard normal via Box-Muller.
+    pub fn normal(&mut self) -> f64 {
+        let u1 = self.uniform();
+        let u2 = self.uniform();
+        (-2.0 * u1.ln()).sqrt() * (std::f64::consts::TAU * u2).cos()
+    }
+
+    pub fn normal_with(&mut self, mu: f64, sigma: f64) -> f64 {
+        mu + sigma * self.normal()
+    }
+}
+
+// ── Rank / uniformity statistics for SBC ───────────────────────────────────
+
+/// Chi-square statistic for `counts` against a uniform expectation, plus the
+/// number of degrees of freedom.
+pub fn chi_square_uniform(counts: &[usize]) -> (f64, usize) {
+    let total: usize = counts.iter().sum();
+    let expected = total as f64 / counts.len() as f64;
+    let stat = counts
+        .iter()
+        .map(|&c| {
+            let d = c as f64 - expected;
+            d * d / expected
+        })
+        .sum();
+    (stat, counts.len() - 1)
+}
+
+/// Upper-tail probability of a chi-square distribution with `df` degrees of
+/// freedom, via the regularized upper incomplete gamma function Q(df/2, x/2).
+pub fn chi_square_sf(x: f64, df: usize) -> f64 {
+    if x <= 0.0 {
+        return 1.0;
+    }
+    gamma_q(df as f64 / 2.0, x / 2.0)
+}
+
+/// Regularized upper incomplete gamma Q(a, x) = 1 - P(a, x).
+fn gamma_q(a: f64, x: f64) -> f64 {
+    if x < a + 1.0 {
+        1.0 - gamma_p_series(a, x)
+    } else {
+        gamma_q_cf(a, x)
+    }
+}
+
+fn gamma_p_series(a: f64, x: f64) -> f64 {
+    let mut ap = a;
+    let mut sum = 1.0 / a;
+    let mut del = sum;
+    for _ in 0..500 {
+        ap += 1.0;
+        del *= x / ap;
+        sum += del;
+        if del.abs() < sum.abs() * 1e-14 {
+            break;
+        }
+    }
+    sum * (-x + a * x.ln() - ln_gamma(a)).exp()
+}
+
+fn gamma_q_cf(a: f64, x: f64) -> f64 {
+    let tiny = 1e-300;
+    let mut b = x + 1.0 - a;
+    let mut c = 1.0 / tiny;
+    let mut d = 1.0 / b;
+    let mut h = d;
+    for i in 1..500 {
+        let an = -(i as f64) * (i as f64 - a);
+        b += 2.0;
+        d = an * d + b;
+        if d.abs() < tiny {
+            d = tiny;
+        }
+        c = b + an / c;
+        if c.abs() < tiny {
+            c = tiny;
+        }
+        d = 1.0 / d;
+        let del = d * c;
+        h *= del;
+        if (del - 1.0).abs() < 1e-14 {
+            break;
+        }
+    }
+    (-x + a * x.ln() - ln_gamma(a)).exp() * h
+}
+
+/// Lanczos log-gamma.
+pub fn ln_gamma(x: f64) -> f64 {
+    const G: [f64; 9] = [
+        0.999_999_999_999_809_9,
+        676.520_368_121_885_1,
+        -1_259.139_216_722_402_8,
+        771.323_428_777_653_1,
+        -176.615_029_162_140_6,
+        12.507_343_278_686_905,
+        -0.138_571_095_265_720_12,
+        9.984_369_578_019_572e-6,
+        1.505_632_735_149_311_6e-7,
+    ];
+    if x < 0.5 {
+        (std::f64::consts::PI / (std::f64::consts::PI * x).sin()).ln() - ln_gamma(1.0 - x)
+    } else {
+        let x = x - 1.0;
+        let mut a = G[0];
+        let t = x + 7.5;
+        for (i, &g) in G.iter().enumerate().skip(1) {
+            a += g / (x + i as f64);
+        }
+        0.5 * (std::f64::consts::TAU).ln() + (x + 0.5) * t.ln() - t + a.ln()
+    }
+}

--- a/rust_core/tests/gradient_check.rs
+++ b/rust_core/tests/gradient_check.rs
@@ -1,0 +1,446 @@
+//! Finite-difference validation of the reverse-mode gradient.
+//!
+//! Every statistical claim in this repository rests on `grad_logp` returning
+//! the exact gradient of `eval_logp`. If it does not, NUTS still runs, still
+//! converges, and still produces a plausible-looking posterior — it is simply
+//! the posterior of a *different* model. That failure mode is invisible to
+//! parameter-recovery tests when the error is small, so it is checked directly
+//! here.
+//!
+//! These tests are deterministic and fast (no sampling), so they run on every
+//! `cargo test`.
+//!
+//! # Tolerance
+//!
+//! Central differences have truncation error O(h^2 * |f'''|) and roundoff
+//! O(eps * |f| / h). With `h = 1e-5` and f64 (eps ~ 2.2e-16) the roundoff floor
+//! is ~1e-11 * |f| and truncation ~1e-10 * |f'''|. We therefore require
+//! agreement to a relative tolerance of 1e-5 with an absolute floor of 1e-6,
+//! which is loose enough to never flake and ~5 orders of magnitude tighter
+//! than any plausible algebra error (a dropped factor of 2, a sign flip, a
+//! missing Jacobian term).
+
+mod common;
+
+use rustmc_core::autodiff::{eval_logp, grad_logp};
+use rustmc_core::distributions::{
+    BetaDist, Exponential, Gamma, HalfNormal, LogNormal, Normal, StudentT, Uniform,
+};
+use rustmc_core::graph::Graph;
+
+const H: f64 = 1e-5;
+const REL_TOL: f64 = 1e-5;
+const ABS_TOL: f64 = 1e-6;
+
+/// Compare `grad_logp` against central finite differences of `eval_logp`.
+fn check_gradient(label: &str, graph: &Graph, point: &[f64]) {
+    let (logp, analytic) = grad_logp(graph, point);
+    assert!(
+        logp.is_finite(),
+        "{label}: logp is not finite at {point:?} (got {logp})"
+    );
+    assert_eq!(
+        analytic.len(),
+        point.len(),
+        "{label}: gradient length {} != parameter count {}",
+        analytic.len(),
+        point.len()
+    );
+
+    for i in 0..point.len() {
+        let mut up = point.to_vec();
+        let mut down = point.to_vec();
+        let h = H * point[i].abs().max(1.0);
+        up[i] += h;
+        down[i] -= h;
+        let numeric = (eval_logp(graph, &up) - eval_logp(graph, &down)) / (2.0 * h);
+        // Cancellation floor of the difference quotient: the two logp values
+        // are each known to ~eps*|logp|, so the quotient carries an
+        // irreducible error of ~eps*|logp|/h. At extreme parameter values
+        // |logp| can reach 1e8, which dominates every other error term.
+        let fd_noise = 8.0 * f64::EPSILON * logp.abs() / h;
+        let tol = REL_TOL * numeric.abs().max(analytic[i].abs()) + ABS_TOL + fd_noise;
+        assert!(
+            (analytic[i] - numeric).abs() <= tol,
+            "{label}: d logp / d p[{i}] analytic {:.12e} vs finite-difference {:.12e} \
+             (|diff| {:.3e} > tol {:.3e}); full gradient {:?}",
+            analytic[i],
+            numeric,
+            (analytic[i] - numeric).abs(),
+            tol,
+            analytic
+        );
+    }
+}
+
+fn design(n: usize, seed: u64) -> (Vec<f64>, Vec<f64>) {
+    let mut rng = common::Rng::new(seed);
+    let x: Vec<f64> = (0..n).map(|_| rng.normal()).collect();
+    let y: Vec<f64> = (0..n).map(|_| rng.normal()).collect();
+    (x, y)
+}
+
+// ── Scalar prior families: transform + Jacobian correctness ────────────────
+
+#[test]
+fn scalar_prior_gradients_match_finite_differences() {
+    // Each entry: (label, builder, evaluation points in *unconstrained* space)
+    let points = [-1.7_f64, -0.4, 0.0, 0.6, 1.9];
+
+    let mut g = Graph::new();
+    Normal::prior(&mut g, "x", 0.3, 1.4);
+    for &p in &points {
+        check_gradient("Normal prior", &g, &[p]);
+    }
+
+    let mut g = Graph::new();
+    HalfNormal::prior(&mut g, "x", 1.1);
+    for &p in &points {
+        check_gradient("HalfNormal prior (exp transform)", &g, &[p]);
+    }
+
+    let mut g = Graph::new();
+    LogNormal::prior(&mut g, "x", -0.2, 0.9);
+    for &p in &points {
+        check_gradient("LogNormal prior", &g, &[p]);
+    }
+
+    let mut g = Graph::new();
+    Exponential::prior(&mut g, "x", 2.5);
+    for &p in &points {
+        check_gradient("Exponential prior", &g, &[p]);
+    }
+
+    let mut g = Graph::new();
+    Gamma::prior(&mut g, "x", 2.3, 1.7);
+    for &p in &points {
+        check_gradient("Gamma prior", &g, &[p]);
+    }
+
+    let mut g = Graph::new();
+    BetaDist::prior(&mut g, "x", 2.0, 3.5);
+    for &p in &points {
+        check_gradient("Beta prior (sigmoid transform)", &g, &[p]);
+    }
+
+    let mut g = Graph::new();
+    Uniform::prior(&mut g, "x", -2.0, 3.0);
+    for &p in &points {
+        check_gradient("Uniform prior (bounded sigmoid transform)", &g, &[p]);
+    }
+
+    let mut g = Graph::new();
+    StudentT::prior(&mut g, "x", 4.0, 0.5, 1.3);
+    for &p in &points {
+        check_gradient("StudentT prior", &g, &[p]);
+    }
+}
+
+// ── Vectorized prior families ──────────────────────────────────────────────
+
+#[test]
+fn vector_prior_gradients_match_finite_differences() {
+    let point = [-1.2_f64, 0.3, 0.9, -0.05];
+
+    let mut g = Graph::new();
+    let s = g.add_vector_params("v", 4);
+    g.vector_normal_logp(s, 4, 0.4, 1.6);
+    check_gradient("VectorNormalLogP", &g, &point);
+
+    let mut g = Graph::new();
+    let s = g.add_vector_params_with_transform("v", 4, rustmc_core::graph::ParamTransform::Exp);
+    g.vector_half_normal_logp(s, 4, 1.3);
+    check_gradient("VectorHalfNormalLogP", &g, &point);
+
+    let mut g = Graph::new();
+    let s = g.add_vector_params("v", 4);
+    g.vector_student_t_logp(s, 4, 5.0, -0.3, 1.1);
+    check_gradient("VectorStudentTLogP", &g, &point);
+
+    let mut g = Graph::new();
+    let s = g.add_vector_params_with_transform("v", 4, rustmc_core::graph::ParamTransform::Exp);
+    g.vector_gamma_logp(s, 4, 2.5, 1.4);
+    check_gradient("VectorGammaLogP", &g, &point);
+
+    let mut g = Graph::new();
+    let s = g.add_vector_params_with_transform("v", 4, rustmc_core::graph::ParamTransform::Sigmoid);
+    g.vector_beta_logp(s, 4, 2.2, 3.1);
+    check_gradient("VectorBetaLogP", &g, &point);
+
+    let mut g = Graph::new();
+    let s = g.add_vector_params_with_transform(
+        "v",
+        4,
+        rustmc_core::graph::ParamTransform::BoundedSigmoid {
+            lower: -1.0,
+            upper: 4.0,
+        },
+    );
+    g.vector_uniform_logp(s, 4, -1.0, 4.0);
+    check_gradient("VectorUniformLogP", &g, &point);
+}
+
+// ── Observation families ───────────────────────────────────────────────────
+
+#[test]
+fn observation_family_gradients_match_finite_differences() {
+    let n = 25;
+    let (x, _) = design(n, 7);
+    let point = [0.4_f64, -0.7];
+
+    // Normal
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 2.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 2.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x.clone());
+    let mu = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let s = g.add_constant(0.9);
+    let (_, yy) = design(n, 8);
+    let obs = g.add_obs_data(yy);
+    g.normal_obs_logp(mu, s, obs);
+    check_gradient("Normal observation", &g, &point);
+
+    // BernoulliLogit
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 2.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 2.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x.clone());
+    let eta = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let obs = g.add_obs_data((0..n).map(|i| (i % 2) as f64).collect());
+    g.obs_logp_bernoulli_logit(eta, obs);
+    check_gradient("BernoulliLogit observation", &g, &point);
+
+    // PoissonLog
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 2.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 2.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x.clone());
+    let eta = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let obs = g.add_obs_data((0..n).map(|i| (i % 5) as f64).collect());
+    g.obs_logp_poisson_log(eta, obs);
+    check_gradient("PoissonLog observation", &g, &point);
+
+    // ExponentialLog
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 2.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 2.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x.clone());
+    let eta = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let obs = g.add_obs_data((0..n).map(|i| 0.3 + 0.1 * i as f64).collect());
+    g.obs_logp_exponential_log(eta, obs);
+    check_gradient("ExponentialLog observation", &g, &point);
+
+    // LogNormal
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 2.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 2.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x.clone());
+    let mu = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let s = g.add_constant(0.7);
+    let obs = g.add_obs_data((0..n).map(|i| 0.5 + 0.2 * i as f64).collect());
+    g.obs_logp_lognormal(mu, s, obs);
+    check_gradient("LogNormal observation", &g, &point);
+
+    // NegativeBinomialLog
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 2.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 2.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x.clone());
+    let eta = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let alpha = g.add_constant(2.5);
+    let obs = g.add_obs_data((0..n).map(|i| (i % 7) as f64).collect());
+    g.obs_logp_negative_binomial_log(eta, alpha, obs);
+    check_gradient("NegativeBinomialLog observation", &g, &point);
+}
+
+/// Observation families with a *learned* auxiliary parameter (sigma / alpha),
+/// which exercises the adjoint path through `aux` rather than a constant node.
+#[test]
+fn learned_scale_gradients_match_finite_differences() {
+    let n = 20;
+    let (x, y) = design(n, 11);
+
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 2.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 2.0);
+    let sigma = HalfNormal::prior(&mut g, "sigma", 1.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x);
+    let mu = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let obs = g.add_obs_data(y);
+    g.normal_obs_logp(mu, sigma, obs);
+    for point in [[0.3, -0.5, 0.2], [-1.1, 0.8, -0.9], [0.0, 0.0, 1.4]] {
+        check_gradient("Normal observation with learned sigma", &g, &point);
+    }
+}
+
+// ── Structural ops ─────────────────────────────────────────────────────────
+
+#[test]
+fn matvec_gradients_match_finite_differences() {
+    let n = 30;
+    let p = 5;
+    let mut rng = common::Rng::new(13);
+    let flat: Vec<f64> = (0..n * p).map(|_| rng.normal()).collect();
+    let y: Vec<f64> = (0..n).map(|_| rng.normal()).collect();
+
+    // Without intercept.
+    let mut g = Graph::new();
+    let s = g.add_vector_params("beta", p);
+    g.vector_normal_logp(s, p, 0.0, 1.5);
+    let m = g.store_matrix(flat.clone(), n, p);
+    let mu = g.mat_vec_mul(m, s, p, None);
+    let sig = g.add_constant(0.8);
+    let obs = g.add_obs_data(y.clone());
+    g.normal_obs_logp(mu, sig, obs);
+    check_gradient("MatVecMul", &g, &[0.4, -0.9, 0.15, 1.1, -0.3]);
+
+    // With a learned intercept declared *after* the vector block.
+    let mut g = Graph::new();
+    let s = g.add_vector_params("beta", p);
+    g.vector_normal_logp(s, p, 0.0, 1.5);
+    let icpt = Normal::prior(&mut g, "icpt", 0.0, 3.0);
+    let m = g.store_matrix(flat, n, p);
+    let mu = g.mat_vec_mul(m, s, p, Some(icpt));
+    let sig = g.add_constant(0.8);
+    let obs = g.add_obs_data(y);
+    g.normal_obs_logp(mu, sig, obs);
+    check_gradient(
+        "MatVecMul with intercept",
+        &g,
+        &[0.4, -0.9, 0.15, 1.1, -0.3, 0.6],
+    );
+}
+
+#[test]
+fn elementwise_op_gradients_match_finite_differences() {
+    let n = 12;
+    let (x, y) = design(n, 17);
+
+    // ScalarMulData + ScalarBroadcastAdd + VectorAdd, non-fused path.
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 2.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 2.0);
+    let xd = g.add_data("x", x.clone());
+    let bx = g.scalar_mul_data(b, xd);
+    let x2d = g.add_data("x2", x.iter().map(|v| v * v).collect());
+    let ax2 = g.scalar_mul_data(a, x2d);
+    let both = g.vector_add(bx, ax2);
+    let mu = g.scalar_broadcast_add(a, both);
+    let sig = g.add_constant(1.0);
+    let obs = g.add_obs_data(y.clone());
+    g.normal_obs_logp(mu, sig, obs);
+    check_gradient(
+        "ScalarMulData / VectorAdd / ScalarBroadcastAdd",
+        &g,
+        &[0.7, -0.4],
+    );
+
+    // ScalarBroadcast on its own.
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 2.0);
+    let mu = g.scalar_broadcast(a);
+    let sig = g.add_constant(1.2);
+    let obs = g.add_obs_data(y);
+    g.normal_obs_logp(mu, sig, obs);
+    check_gradient("ScalarBroadcast", &g, &[0.55]);
+
+    // Arithmetic / transcendental chain: exp, log, sigmoid, square, div, sub, neg.
+    let mut g = Graph::new();
+    let u = Normal::prior(&mut g, "u", 0.0, 2.0);
+    let v = Normal::prior(&mut g, "v", 0.0, 2.0);
+    let two = g.add_constant(2.0);
+    let e = g.exp(u);
+    let sq = g.square(v);
+    let sum = g.add(e, sq);
+    let lg = g.log(sum);
+    let sg = g.sigmoid(v);
+    let dv = g.div(lg, two);
+    let sb = g.sub(dv, sg);
+    let ng = g.neg(sb);
+    let ml = g.mul(ng, e);
+    let one = g.add_constant(1.0);
+    let zero = g.add_constant(0.0);
+    g.normal_logp(ml, zero, one);
+    for point in [[0.2, 0.9], [-0.8, -1.3], [1.4, 0.05]] {
+        check_gradient("arithmetic chain", &g, &point);
+    }
+}
+
+#[test]
+fn hierarchical_gradients_match_finite_differences() {
+    // Centered: theta_j ~ N(mu, tau), tau itself a HalfNormal parameter.
+    let mut g = Graph::new();
+    let mu = Normal::prior(&mut g, "mu", 0.0, 5.0);
+    let tau = HalfNormal::prior(&mut g, "tau", 2.0);
+    let y = [1.2_f64, -0.3, 2.4];
+    let sd = [1.0_f64, 1.5, 0.8];
+    for (j, (&yj, &sj)) in y.iter().zip(sd.iter()).enumerate() {
+        let theta = Normal::prior_with_nodes(&mut g, &format!("theta_{j}"), mu, tau);
+        let yn = g.add_constant(yj);
+        let sn = g.add_constant(sj);
+        g.normal_logp(yn, theta, sn);
+    }
+    for point in [
+        [0.5, 0.1, 0.9, -0.2, 1.3],
+        [-1.4, -0.9, 0.0, 0.7, -0.5],
+        [2.0, 1.2, -1.1, 0.4, 0.8],
+    ] {
+        check_gradient("centered hierarchy with learned tau", &g, &point);
+    }
+
+    // Non-centered: theta = mu + tau * z.
+    let mut g = Graph::new();
+    let mu = Normal::prior(&mut g, "mu", 0.0, 5.0);
+    let tau = HalfNormal::prior(&mut g, "tau", 2.0);
+    for (j, (&yj, &sj)) in y.iter().zip(sd.iter()).enumerate() {
+        let z = Normal::prior(&mut g, &format!("z_{j}"), 0.0, 1.0);
+        let tz = g.mul(tau, z);
+        let theta = g.add(mu, tz);
+        let yn = g.add_constant(yj);
+        let sn = g.add_constant(sj);
+        g.normal_logp(yn, theta, sn);
+    }
+    for point in [[0.5, 0.1, 0.9, -0.2, 1.3], [-1.4, -0.9, 0.0, 0.7, -0.5]] {
+        check_gradient("non-centered hierarchy", &g, &point);
+    }
+}
+
+/// The gradient must stay exact at extreme-but-valid parameter values, where
+/// naive implementations of `log(1 + exp(x))` or `log(sigmoid(x))` overflow.
+#[test]
+fn gradients_stay_exact_at_extreme_parameter_values() {
+    let n = 15;
+    let (x, _) = design(n, 23);
+
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 10.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 10.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x);
+    let eta = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let obs = g.add_obs_data((0..n).map(|i| (i % 2) as f64).collect());
+    g.obs_logp_bernoulli_logit(eta, obs);
+    // Linear predictors reaching +-30 push sigmoid to within 1e-13 of 0 or 1.
+    for point in [[25.0, 0.0], [-25.0, 0.0], [0.0, 20.0], [0.0, -20.0]] {
+        check_gradient("BernoulliLogit at extreme eta", &g, &point);
+    }
+
+    // Very small and very large learned sigma.
+    let mut g = Graph::new();
+    let mu = Normal::prior(&mut g, "mu", 0.0, 10.0);
+    let sigma = HalfNormal::prior(&mut g, "sigma", 5.0);
+    let mu_vec = g.scalar_broadcast(mu);
+    let obs = g.add_obs_data(vec![0.1, -0.2, 0.05, 0.0, 0.3]);
+    g.normal_obs_logp(mu_vec, sigma, obs);
+    // raw = log(sigma): -9 => sigma ~ 1.2e-4; +9 => sigma ~ 8100.
+    for point in [[0.05, -9.0], [0.05, 9.0], [0.0, 0.0]] {
+        check_gradient("Normal observation at extreme sigma", &g, &point);
+    }
+}

--- a/rust_core/tests/likelihood_recovery.rs
+++ b/rust_core/tests/likelihood_recovery.rs
@@ -1,0 +1,283 @@
+//! Parameter recovery for the observation families that `recovery_suite.rs`
+//! does not cover, plus a high-dimensional `MatVecMul` recovery run.
+//!
+//! Recovery tests are weaker evidence than the analytic-posterior tests: they
+//! only show the posterior sits near the truth, not that it has the right
+//! shape. They are included because they are the only available check for
+//! families with no conjugate reference (Exponential, NegativeBinomial), and
+//! because they exercise the full sampling stack on realistic data sizes.
+//!
+//! # Tolerance
+//!
+//! For a well-identified GLM coefficient the posterior sd is approximately the
+//! maximum-likelihood standard error. Each assertion therefore uses
+//! `|posterior mean - truth| <= 3 * posterior sd + 4 * mcse_mean`: three
+//! posterior sds is the sampling variability of the estimate given this one
+//! seeded dataset, and the MCSE term covers the Monte Carlo error on top. This
+//! is derived, not tuned; the tests were not re-run with widened tolerances.
+
+mod common;
+
+use common::{assert_converged, assert_post_warmup_divergence_rate, diag, nuts};
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use rand_distr::{Distribution, Exp as ExpDist, Gamma as GammaDist, Normal as NormalDist, Poisson};
+use rustmc_core::diagnostics::DiagnosticsReport;
+use rustmc_core::distributions::{HalfNormal, Normal};
+use rustmc_core::graph::Graph;
+
+const CHAINS: usize = 4;
+const DRAWS: usize = 400;
+const WARMUP: usize = 400;
+const MAX_DIV_RATE: f64 = 0.02;
+
+/// `|mean - truth| <= 3 * posterior_sd + 4 * mcse` — see module docs.
+fn assert_recovered(report: &DiagnosticsReport, name: &str, truth: f64) {
+    let p = diag(report, name);
+    let tol = 3.0 * p.std + 4.0 * p.mcse_mean;
+    assert!(
+        (p.mean - truth).abs() <= tol,
+        "{name}: posterior mean {:.5} vs truth {:.5} (|diff| {:.5}) exceeds \
+         3*sd({:.5}) + 4*mcse({:.5}) = {:.5}",
+        p.mean,
+        truth,
+        (p.mean - truth).abs(),
+        p.std,
+        p.mcse_mean,
+        tol
+    );
+}
+
+/// `y_i ~ Exponential(rate = exp(a + b x_i))`.
+#[test]
+fn exponential_glm_recovers_rate_coefficients() {
+    let mut rng = ChaCha8Rng::seed_from_u64(4001);
+    let a_true = 0.4;
+    let b_true = -0.7;
+    let n = 400;
+    let xd = NormalDist::new(0.0, 1.0).unwrap();
+    let x: Vec<f64> = (0..n).map(|_| xd.sample(&mut rng)).collect();
+    let y: Vec<f64> = x
+        .iter()
+        .map(|&xi| {
+            let rate = (a_true + b_true * xi).exp();
+            ExpDist::new(rate).unwrap().sample(&mut rng)
+        })
+        .collect();
+
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 3.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 3.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x);
+    let eta = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let obs = g.add_obs_data(y);
+    g.obs_logp_exponential_log(eta, obs);
+
+    let result = nuts(g, 40_001, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.03);
+    assert_post_warmup_divergence_rate(&result, MAX_DIV_RATE);
+    assert_recovered(&report, "a", a_true);
+    assert_recovered(&report, "b", b_true);
+}
+
+/// `y_i ~ LogNormal(a + b x_i, sigma)` with `sigma` learned.
+#[test]
+fn lognormal_glm_recovers_location_and_scale() {
+    let mut rng = ChaCha8Rng::seed_from_u64(4002);
+    let a_true = 0.6;
+    let b_true = 0.9;
+    let sigma_true = 0.45;
+    let n = 300;
+    let xd = NormalDist::new(0.0, 1.0).unwrap();
+    let nd = NormalDist::new(0.0, sigma_true).unwrap();
+    let x: Vec<f64> = (0..n).map(|_| xd.sample(&mut rng)).collect();
+    let y: Vec<f64> = x
+        .iter()
+        .map(|&xi| (a_true + b_true * xi + nd.sample(&mut rng)).exp())
+        .collect();
+
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 3.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 3.0);
+    let sigma = HalfNormal::prior(&mut g, "sigma", 1.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x);
+    let mu = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let obs = g.add_obs_data(y);
+    g.obs_logp_lognormal(mu, sigma, obs);
+
+    let result = nuts(g, 40_002, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.03);
+    assert_post_warmup_divergence_rate(&result, MAX_DIV_RATE);
+    assert_recovered(&report, "a", a_true);
+    assert_recovered(&report, "b", b_true);
+    assert_recovered(&report, "sigma", sigma_true);
+}
+
+/// `y_i ~ NegativeBinomial(mean = exp(a + b x_i), dispersion alpha)`.
+///
+/// The dispersion is held fixed at its true value: with `alpha` free and only
+/// a few hundred observations it is only weakly identified, and a recovery
+/// assertion on it would be a coin flip rather than a test.
+#[test]
+fn negative_binomial_glm_recovers_mean_coefficients() {
+    let mut rng = ChaCha8Rng::seed_from_u64(4003);
+    let a_true = 1.1;
+    let b_true = 0.5;
+    let alpha = 3.0;
+    let n = 500;
+    let xd = NormalDist::new(0.0, 1.0).unwrap();
+    let x: Vec<f64> = (0..n).map(|_| xd.sample(&mut rng)).collect();
+    let y: Vec<f64> = x
+        .iter()
+        .map(|&xi| {
+            let mu = (a_true + b_true * xi).exp();
+            let lambda = GammaDist::new(alpha, mu / alpha).unwrap().sample(&mut rng);
+            Poisson::new(lambda.max(1e-12)).unwrap().sample(&mut rng)
+        })
+        .collect();
+
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 3.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 3.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x);
+    let eta = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let alpha_node = g.add_constant(alpha);
+    let obs = g.add_obs_data(y);
+    g.obs_logp_negative_binomial_log(eta, alpha_node, obs);
+
+    let result = nuts(g, 40_003, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.03);
+    assert_post_warmup_divergence_rate(&result, MAX_DIV_RATE);
+    assert_recovered(&report, "a", a_true);
+    assert_recovered(&report, "b", b_true);
+}
+
+/// High-dimensional regression through `MatVecMul`: `p = 25`, `n = 400`,
+/// with `sigma` learned. Checks the whole coefficient vector by RMSE against
+/// the exact posterior-mean RMSE that the priors imply.
+#[test]
+fn high_dimensional_matvec_regression_recovers_coefficients() {
+    let mut rng = ChaCha8Rng::seed_from_u64(4004);
+    let n = 250;
+    let p = 15;
+    let sigma_true = 0.8;
+    let xd = NormalDist::new(0.0, 1.0).unwrap();
+    let bd = NormalDist::new(0.0, 1.0).unwrap();
+    let nd = NormalDist::new(0.0, sigma_true).unwrap();
+
+    let beta_true: Vec<f64> = (0..p).map(|_| bd.sample(&mut rng)).collect();
+    let mut flat = Vec::with_capacity(n * p);
+    let mut y = Vec::with_capacity(n);
+    for _ in 0..n {
+        let row: Vec<f64> = (0..p).map(|_| xd.sample(&mut rng)).collect();
+        let mu: f64 = row.iter().zip(&beta_true).map(|(a, b)| a * b).sum();
+        y.push(mu + nd.sample(&mut rng));
+        flat.extend(row);
+    }
+
+    let mut g = Graph::new();
+    let s = g.add_vector_params("beta", p);
+    g.vector_normal_logp(s, p, 0.0, 1.0);
+    let sigma = HalfNormal::prior(&mut g, "sigma", 2.0);
+    let m = g.store_matrix(flat, n, p);
+    let mu = g.mat_vec_mul(m, s, p, None);
+    let obs = g.add_obs_data(y);
+    g.normal_obs_logp(mu, sigma, obs);
+
+    let result = nuts(g, 40_004, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.05);
+    assert_post_warmup_divergence_rate(&result, MAX_DIV_RATE);
+    assert_recovered(&report, "sigma", sigma_true);
+
+    // With standard-normal predictors and n >> p the posterior sd of each
+    // coefficient is ~ sigma / sqrt(n), so the RMSE of the posterior mean
+    // vector around the truth should be close to that. Allow 3x as a bound.
+    let expected_rmse = sigma_true / (n as f64).sqrt();
+    let mut sum_sq = 0.0;
+    for (k, truth) in beta_true.iter().enumerate() {
+        let d = diag(&report, &format!("beta[{k}]"));
+        sum_sq += (d.mean - truth).powi(2);
+    }
+    let rmse = (sum_sq / p as f64).sqrt();
+    assert!(
+        rmse <= 3.0 * expected_rmse,
+        "beta RMSE {rmse:.5} exceeds 3 * sigma/sqrt(n) = {:.5}",
+        3.0 * expected_rmse
+    );
+}
+
+/// Hierarchical partial pooling with a learned group scale, non-centered.
+///
+/// Asserts recovery of the hyperparameters and that shrinkage moves the group
+/// estimates toward the grand mean relative to the raw group means — the
+/// defining behaviour of partial pooling, and something a model that silently
+/// degenerated to no-pooling or complete-pooling would fail.
+#[test]
+fn hierarchical_partial_pooling_recovers_and_shrinks() {
+    let mut rng = ChaCha8Rng::seed_from_u64(4005);
+    let groups = 8;
+    let per_group = 6;
+    let mu_true = 2.0;
+    let tau_true = 1.0;
+    let sigma_true = 1.5;
+    let gd = NormalDist::new(mu_true, tau_true).unwrap();
+    let nd = NormalDist::new(0.0, sigma_true).unwrap();
+
+    let theta_true: Vec<f64> = (0..groups).map(|_| gd.sample(&mut rng)).collect();
+    let raw_means: Vec<f64> = theta_true
+        .iter()
+        .map(|&t| (0..per_group).map(|_| t + nd.sample(&mut rng)).sum::<f64>() / per_group as f64)
+        .collect();
+
+    // Group means are sufficient statistics: y_bar_g ~ N(theta_g, sigma/sqrt(m)).
+    let se = sigma_true / (per_group as f64).sqrt();
+
+    let mut g = Graph::new();
+    let mu = Normal::prior(&mut g, "mu", 0.0, 10.0);
+    let tau = HalfNormal::prior(&mut g, "tau", 5.0);
+    for (gi, &ybar) in raw_means.iter().enumerate() {
+        let z = Normal::prior(&mut g, &format!("z_{gi}"), 0.0, 1.0);
+        let tz = g.mul(tau, z);
+        let theta = g.add(mu, tz);
+        let yn = g.add_constant(ybar);
+        let sn = g.add_constant(se);
+        g.normal_logp(yn, theta, sn);
+    }
+
+    let result = nuts(g, 40_005, CHAINS, 800, 800);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.05);
+    assert_post_warmup_divergence_rate(&result, 0.03);
+    assert_recovered(&report, "mu", mu_true);
+    assert_recovered(&report, "tau", tau_true);
+
+    // Reconstruct theta_g = mu + tau * z_g at the posterior mean and check
+    // shrinkage: every group estimate must lie between its raw mean and the
+    // grand posterior mean (inclusive), which is what pooling guarantees.
+    let mu_hat = diag(&report, "mu").mean;
+    let tau_hat = diag(&report, "tau").mean;
+    let mut shrunk = 0;
+    for (gi, &ybar) in raw_means.iter().enumerate() {
+        let z_hat = diag(&report, &format!("z_{gi}")).mean;
+        let theta_hat = mu_hat + tau_hat * z_hat;
+        assert!(
+            (theta_hat - mu_hat).abs() <= (ybar - mu_hat).abs() + 1e-6,
+            "group {gi}: pooled estimate {theta_hat:.4} is farther from the grand mean \
+             {mu_hat:.4} than the raw group mean {ybar:.4} — no shrinkage occurred"
+        );
+        if (theta_hat - mu_hat).abs() < 0.99 * (ybar - mu_hat).abs() {
+            shrunk += 1;
+        }
+    }
+    assert!(
+        shrunk >= groups - 1,
+        "only {shrunk}/{groups} groups were measurably shrunk toward the grand mean"
+    );
+}

--- a/rust_core/tests/numerical_stability.rs
+++ b/rust_core/tests/numerical_stability.rs
@@ -1,0 +1,388 @@
+//! Numerical stability, extreme-but-valid inputs, determinism, and failure
+//! modes.
+//!
+//! Everything here is either exact (no Monte Carlo tolerance needed) or
+//! asserted against a closed form. Where a statistical tolerance is needed the
+//! justification is stated inline.
+
+mod common;
+
+use common::{
+    assert_converged, assert_mean_within_mcse, assert_post_warmup_divergence_rate,
+    assert_sd_within_mcse, diag, linear_gaussian_posterior, nuts, Rng,
+};
+use rustmc_core::autodiff::{eval_logp, grad_logp, Evaluator};
+use rustmc_core::distributions::{HalfNormal, Normal};
+use rustmc_core::graph::Graph;
+use rustmc_core::sampler::{sample as run_sample, SamplerConfig, SamplerType};
+
+// ── Determinism ────────────────────────────────────────────────────────────
+
+/// The same graph, config and seed must produce bit-identical draws.
+///
+/// Without this, every other test in the suite is unfalsifiable: a failure
+/// could always be blamed on the RNG. `num_threads = 1` is deliberate; the
+/// cross-thread case is asserted separately below.
+#[test]
+fn sampling_is_bit_reproducible_for_a_fixed_seed() {
+    let build = || {
+        let mut rng = Rng::new(5150);
+        let n = 40;
+        let x: Vec<f64> = (0..n).map(|_| rng.normal()).collect();
+        let y: Vec<f64> = x.iter().map(|&xi| 1.0 + 0.5 * xi + rng.normal()).collect();
+        let mut g = Graph::new();
+        let a = Normal::prior(&mut g, "a", 0.0, 3.0);
+        let b = Normal::prior(&mut g, "b", 0.0, 3.0);
+        let s = HalfNormal::prior(&mut g, "sigma", 1.0);
+        let d0 = g.store_data_vec(vec![1.0; n]);
+        let d1 = g.store_data_vec(x);
+        let mu = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+        let obs = g.add_obs_data(y);
+        g.normal_obs_logp(mu, s, obs);
+        g
+    };
+
+    let first = nuts(build(), 777, 2, 120, 120);
+    let second = nuts(build(), 777, 2, 120, 120);
+    assert_eq!(
+        first.samples, second.samples,
+        "draws differ across identical runs"
+    );
+    assert_eq!(first.step_sizes, second.step_sizes, "step sizes differ");
+    assert_eq!(
+        first.divergences, second.divergences,
+        "divergence counts differ"
+    );
+}
+
+/// Chain results must not depend on the size of the Rayon pool: each chain is
+/// seeded from `seed + chain_index`, so thread scheduling must be irrelevant.
+#[test]
+fn chain_results_are_independent_of_thread_count() {
+    let build = || {
+        let mut g = Graph::new();
+        let mu = Normal::prior(&mut g, "mu", 0.0, 2.0);
+        let mu_vec = g.scalar_broadcast(mu);
+        let s = g.add_constant(1.0);
+        let obs = g.add_obs_data(vec![0.4, -0.2, 1.1, 0.7, -0.9]);
+        g.normal_obs_logp(mu_vec, s, obs);
+        g
+    };
+    let run = |threads: usize| {
+        run_sample(
+            build(),
+            SamplerConfig {
+                sampler: SamplerType::Nuts,
+                num_chains: 4,
+                num_draws: 100,
+                num_warmup: 100,
+                step_size: 0.0,
+                num_leapfrog_steps: 15,
+                max_tree_depth: 10,
+                seed: 4242,
+                num_threads: threads,
+                show_progress: false,
+            },
+        )
+        .expect("sampling failed")
+    };
+    assert_eq!(
+        run(1).samples,
+        run(4).samples,
+        "draws depend on the thread pool size"
+    );
+}
+
+// ── Extreme but valid inputs ───────────────────────────────────────────────
+
+/// Observation noise six orders of magnitude apart on either side of 1.
+///
+/// The posterior is exactly Gaussian in both cases, so both the location and
+/// the scale of the answer are checked, not merely that nothing crashed.
+#[test]
+fn extreme_observation_scales_still_give_the_analytic_posterior() {
+    for &sigma in &[1e-4_f64, 1e4] {
+        let mut rng = Rng::new(31337);
+        let n = 30;
+        let mu_true = 2.0;
+        let s0 = 10.0 * sigma.max(1.0);
+        let y: Vec<f64> = (0..n).map(|_| rng.normal_with(mu_true, sigma)).collect();
+
+        let prec = 1.0 / (s0 * s0) + n as f64 / (sigma * sigma);
+        let post_mean = (y.iter().sum::<f64>() / (sigma * sigma)) / prec;
+        let post_sd = (1.0 / prec).sqrt();
+
+        let mut g = Graph::new();
+        let mu = Normal::prior(&mut g, "mu", 0.0, s0);
+        let mu_vec = g.scalar_broadcast(mu);
+        let sn = g.add_constant(sigma);
+        let obs = g.add_obs_data(y);
+        g.normal_obs_logp(mu_vec, sn, obs);
+
+        let result = nuts(g, 50_001, 4, 600, 600);
+        let report = result.diagnostics();
+        assert_converged(&report, 1.03);
+        assert_post_warmup_divergence_rate(&result, 0.01);
+        assert_mean_within_mcse(&report, "mu", post_mean, 300.0, 0.0);
+        assert_sd_within_mcse(&report, "mu", post_sd, 300.0, 0.0);
+    }
+}
+
+/// A single observation. Everything downstream of `n_obs` must handle `n = 1`
+/// (SIMD-style loops, variance accumulators, matrix row counts).
+#[test]
+fn a_single_observation_still_gives_the_analytic_posterior() {
+    let sigma = 1.3_f64;
+    let s0 = 2.0_f64;
+    let y = 0.75_f64;
+    let prec = 1.0 / (s0 * s0) + 1.0 / (sigma * sigma);
+    let post_mean = (y / (sigma * sigma)) / prec;
+    let post_sd = (1.0 / prec).sqrt();
+
+    let mut g = Graph::new();
+    let mu = Normal::prior(&mut g, "mu", 0.0, s0);
+    let mu_vec = g.scalar_broadcast(mu);
+    let sn = g.add_constant(sigma);
+    let obs = g.add_obs_data(vec![y]);
+    g.normal_obs_logp(mu_vec, sn, obs);
+
+    let result = nuts(g, 50_002, 4, 800, 500);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.02);
+    assert_post_warmup_divergences_zero(&result);
+    assert_mean_within_mcse(&report, "mu", post_mean, 400.0, 0.0);
+    assert_sd_within_mcse(&report, "mu", post_sd, 400.0, 0.0);
+}
+
+fn assert_post_warmup_divergences_zero(result: &rustmc_core::sampler::SampleResult) {
+    common::assert_post_warmup_divergences(result, 0);
+}
+
+/// A large observation vector through the fused path. Catches accumulation
+/// error and any `n`-dependent indexing bug that only bites past a chunk size.
+#[test]
+fn large_observation_vector_gives_the_analytic_posterior() {
+    let mut rng = Rng::new(90210);
+    let n = 6_000;
+    let sigma = 1.0;
+    let beta_true = [0.5, -0.25];
+    let prior_sd = [5.0, 5.0];
+
+    let x: Vec<f64> = (0..n).map(|_| rng.normal()).collect();
+    let rows: Vec<Vec<f64>> = (0..n).map(|i| vec![1.0, x[i]]).collect();
+    let y: Vec<f64> = rows
+        .iter()
+        .map(|r| beta_true[0] * r[0] + beta_true[1] * r[1] + rng.normal_with(0.0, sigma))
+        .collect();
+    let exact = linear_gaussian_posterior(&rows, &y, sigma, &[0.0, 0.0], &prior_sd);
+
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, prior_sd[0]);
+    let b = Normal::prior(&mut g, "b", 0.0, prior_sd[1]);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x);
+    let mu = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let sn = g.add_constant(sigma);
+    let obs = g.add_obs_data(y);
+    g.normal_obs_logp(mu, sn, obs);
+
+    let result = nuts(g, 50_003, 2, 250, 250);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.05);
+    for (k, name) in ["a", "b"].iter().enumerate() {
+        assert_mean_within_mcse(&report, name, exact.mean[k], 100.0, 0.0);
+        assert_sd_within_mcse(&report, name, exact.sd(k), 100.0, 0.0);
+    }
+}
+
+/// Perfectly collinear predictors: the likelihood is flat along one direction,
+/// so the posterior is exactly the prior in that direction. A sampler that
+/// blew up (NaNs, infinite step sizes, unbounded drift) would fail here.
+#[test]
+fn perfectly_collinear_predictors_fall_back_to_the_prior_direction() {
+    let mut rng = Rng::new(1618);
+    let n = 60;
+    let sigma = 0.5;
+    let prior_sd = 1.0;
+    let x: Vec<f64> = (0..n).map(|_| rng.normal()).collect();
+    // x2 is an exact copy of x1, so only (b1 + b2) is identified.
+    let rows: Vec<Vec<f64>> = (0..n).map(|i| vec![x[i], x[i]]).collect();
+    let y: Vec<f64> = rows
+        .iter()
+        .map(|r| 0.6 * r[0] + rng.normal_with(0.0, sigma))
+        .collect();
+    let exact = linear_gaussian_posterior(&rows, &y, sigma, &[0.0, 0.0], &[prior_sd, prior_sd]);
+
+    let mut g = Graph::new();
+    let b1 = Normal::prior(&mut g, "b1", 0.0, prior_sd);
+    let b2 = Normal::prior(&mut g, "b2", 0.0, prior_sd);
+    let d1 = g.store_data_vec(x.clone());
+    let d2 = g.store_data_vec(x);
+    let mu = g.fused_linear_mu(vec![b1, b2], vec![d1, d2], None);
+    let sn = g.add_constant(sigma);
+    let obs = g.add_obs_data(y);
+    g.normal_obs_logp(mu, sn, obs);
+
+    let result = nuts(g, 50_004, 4, 1000, 1000);
+    let report = result.diagnostics();
+    for p in &report.params {
+        assert!(
+            p.mean.is_finite() && p.std.is_finite(),
+            "{}: non-finite summary",
+            p.name
+        );
+    }
+    assert_converged(&report, 1.10);
+    // ESS along the unidentified direction is low by construction, so 100 is
+    // the gate; the posterior is still exactly Gaussian and both marginals
+    // are asserted against it.
+    for (k, name) in ["b1", "b2"].iter().enumerate() {
+        assert_mean_within_mcse(&report, name, exact.mean[k], 100.0, 0.0);
+        assert_sd_within_mcse(&report, name, exact.sd(k), 100.0, 0.0);
+    }
+}
+
+/// Data values large enough that a naive `sum(x^2)` would lose precision.
+#[test]
+fn large_magnitude_predictors_do_not_destroy_the_gradient() {
+    let n = 50;
+    let mut rng = Rng::new(2024);
+    let x: Vec<f64> = (0..n).map(|_| 1e6 * rng.normal()).collect();
+    let y: Vec<f64> = x.iter().map(|&xi| 1e-6 * xi + rng.normal()).collect();
+
+    let mut g = Graph::new();
+    let b = Normal::prior(&mut g, "b", 0.0, 1.0);
+    let d1 = g.store_data_vec(x);
+    let mu = g.fused_linear_mu(vec![b], vec![d1], None);
+    let sn = g.add_constant(1.0);
+    let obs = g.add_obs_data(y);
+    g.normal_obs_logp(mu, sn, obs);
+
+    // Analytic check of the gradient at a point, independent of the sampler.
+    for &p in &[-1e-6, 0.0, 1e-6, 5e-6] {
+        let (logp, grad) = grad_logp(&g, &[p]);
+        assert!(logp.is_finite(), "logp not finite at b = {p}");
+        let h = 1e-11;
+        let numeric = (eval_logp(&g, &[p + h]) - eval_logp(&g, &[p - h])) / (2.0 * h);
+        let tol = 1e-4 * numeric.abs().max(grad[0].abs()) + 1e-3;
+        assert!(
+            (grad[0] - numeric).abs() <= tol,
+            "gradient {} vs finite difference {} at b = {p}",
+            grad[0],
+            numeric
+        );
+    }
+}
+
+// ── Failure modes ──────────────────────────────────────────────────────────
+
+#[test]
+fn mismatched_data_lengths_are_rejected_before_sampling() {
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 1.0);
+    let d0 = g.store_data_vec(vec![1.0; 10]);
+    let mu = g.fused_linear_mu(vec![a], vec![d0], None);
+    let sn = g.add_constant(1.0);
+    let obs = g.add_obs_data(vec![0.0; 7]); // wrong length
+    g.normal_obs_logp(mu, sn, obs);
+
+    let err = g
+        .validate_shapes()
+        .expect_err("mismatched lengths must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("length") && msg.contains("expected"),
+        "shape error message is not actionable: {msg}"
+    );
+
+    let mut g2 = Graph::new();
+    let a = Normal::prior(&mut g2, "a", 0.0, 1.0);
+    let d0 = g2.store_data_vec(vec![1.0; 10]);
+    let mu = g2.fused_linear_mu(vec![a], vec![d0], None);
+    let sn = g2.add_constant(1.0);
+    let obs = g2.add_obs_data(vec![0.0; 7]);
+    g2.normal_obs_logp(mu, sn, obs);
+    let result = run_sample(
+        g2,
+        SamplerConfig {
+            show_progress: false,
+            num_draws: 5,
+            num_warmup: 5,
+            num_chains: 1,
+            ..Default::default()
+        },
+    );
+    assert!(
+        result.is_err(),
+        "sample() accepted a graph with inconsistent vector lengths"
+    );
+}
+
+#[test]
+fn matrix_payload_shape_mismatch_is_rejected() {
+    let mut g = Graph::new();
+    let s = g.add_vector_params("beta", 3);
+    g.vector_normal_logp(s, 3, 0.0, 1.0);
+    // Claim 10x3 but supply only 20 values.
+    let m = g.store_matrix(vec![0.0; 20], 10, 3);
+    let mu = g.mat_vec_mul(m, s, 3, None);
+    let sn = g.add_constant(1.0);
+    let obs = g.add_obs_data(vec![0.0; 10]);
+    g.normal_obs_logp(mu, sn, obs);
+
+    let err = g
+        .validate_shapes()
+        .expect_err("bad matrix payload must be rejected");
+    assert!(
+        err.to_string().contains("shape"),
+        "matrix shape error is not actionable: {err}"
+    );
+}
+
+#[test]
+fn matrix_row_count_must_match_the_observation_vector() {
+    let mut g = Graph::new();
+    let s = g.add_vector_params("beta", 2);
+    g.vector_normal_logp(s, 2, 0.0, 1.0);
+    let m = g.store_matrix(vec![0.0; 12], 6, 2);
+    let mu = g.mat_vec_mul(m, s, 2, None);
+    let sn = g.add_constant(1.0);
+    let obs = g.add_obs_data(vec![0.0; 9]);
+    g.normal_obs_logp(mu, sn, obs);
+
+    assert!(
+        g.validate_shapes().is_err(),
+        "matrix row count / observation length mismatch was not caught"
+    );
+}
+
+#[test]
+fn evaluator_construction_reports_shape_errors_rather_than_panicking() {
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 1.0);
+    let d0 = g.store_data_vec(vec![1.0; 5]);
+    let mu = g.fused_linear_mu(vec![a], vec![d0], None);
+    let sn = g.add_constant(1.0);
+    let obs = g.add_obs_data(vec![0.0; 4]);
+    g.normal_obs_logp(mu, sn, obs);
+
+    assert!(
+        Evaluator::try_new(&g).is_err(),
+        "Evaluator::try_new accepted an inconsistent graph"
+    );
+}
+
+/// A model with no observations at all is legal (it is a prior sample) and
+/// must not be mistaken for a shape error.
+#[test]
+fn prior_only_graph_is_valid_and_samples() {
+    let mut g = Graph::new();
+    Normal::prior(&mut g, "x", 1.0, 2.0);
+    assert_eq!(
+        g.validate_shapes().expect("prior-only graph must validate"),
+        0
+    );
+    let result = nuts(g, 50_005, 2, 200, 200);
+    let report = result.diagnostics();
+    assert!(diag(&report, "x").mean.is_finite());
+}

--- a/rust_core/tests/prior_recovery.rs
+++ b/rust_core/tests/prior_recovery.rs
@@ -1,0 +1,389 @@
+//! Prior-only sampling: does the sampler reproduce the distribution it was
+//! told to sample from?
+//!
+//! A model with priors but no likelihood has a posterior that *is* the prior.
+//! Its moments are known in closed form for every family the DSL supports, so
+//! this is the cleanest possible end-to-end check of:
+//!
+//!   * the log-density algebra for each family,
+//!   * the constraining transform (exp / sigmoid / bounded sigmoid), and
+//!   * the Jacobian correction that goes with it.
+//!
+//! A missing or wrong Jacobian is the classic silent-bias bug: the sampler
+//! still converges, but to a tilted version of the intended distribution.
+//! `gradient_check.rs` cannot catch it (the gradient of a *wrong* density is
+//! still self-consistent); this file can.
+//!
+//! It is also the prior-predictive validation required by `VALIDATION.md`
+//! workstream 2, expressed at the parameter level where the reference values
+//! are exact rather than simulated.
+
+mod common;
+
+use common::{
+    assert_converged, assert_mean_within_mcse, assert_post_warmup_divergence_rate,
+    assert_sd_within_mcse_kurtosis, diag, nuts,
+};
+use rustmc_core::distributions::{
+    BetaDist, Exponential, Gamma, HalfNormal, LogNormal, Normal, StudentT, Uniform,
+};
+use rustmc_core::graph::{Graph, ParamTransform};
+
+const CHAINS: usize = 4;
+const DRAWS: usize = 1500;
+const WARMUP: usize = 500;
+const MIN_ESS: f64 = 800.0;
+/// Log-scale parameters (HalfNormal, Gamma, Exponential, LogNormal) have a
+/// doubly-exponential right tail in unconstrained space, which produces a small
+/// residual divergence rate at any practical step size. Measured rate across 24
+/// independent seeds for the HalfNormal case is 0.29%; 1% is a generous but
+/// still meaningful ceiling. Bias, not divergence count, is what the moment
+/// assertions below actually test.
+const MAX_DIV_RATE: f64 = 0.01;
+
+/// Moments of a univariate family: mean, sd, and standardized fourth moment.
+struct Moments {
+    mean: f64,
+    sd: f64,
+    kurtosis: f64,
+}
+
+fn normal_moments(mu: f64, sigma: f64) -> Moments {
+    Moments {
+        mean: mu,
+        sd: sigma,
+        kurtosis: 3.0,
+    }
+}
+
+fn half_normal_moments(sigma: f64) -> Moments {
+    let two_over_pi = 2.0 / std::f64::consts::PI;
+    Moments {
+        mean: sigma * two_over_pi.sqrt(),
+        sd: sigma * (1.0 - two_over_pi).sqrt(),
+        // Excess kurtosis of the half-normal is 8(pi - 3)/(pi - 2)^2.
+        kurtosis: 3.0 + 8.0 * (std::f64::consts::PI - 3.0) / (std::f64::consts::PI - 2.0).powi(2),
+    }
+}
+
+fn log_normal_moments(mu: f64, sigma: f64) -> Moments {
+    let s2 = sigma * sigma;
+    let mean = (mu + 0.5 * s2).exp();
+    let var = ((s2).exp() - 1.0) * (2.0 * mu + s2).exp();
+    Moments {
+        mean,
+        sd: var.sqrt(),
+        kurtosis: (4.0 * s2).exp() + 2.0 * (3.0 * s2).exp() + 3.0 * (2.0 * s2).exp() - 3.0,
+    }
+}
+
+fn exponential_moments(rate: f64) -> Moments {
+    Moments {
+        mean: 1.0 / rate,
+        sd: 1.0 / rate,
+        kurtosis: 9.0,
+    }
+}
+
+fn gamma_moments(alpha: f64, beta: f64) -> Moments {
+    Moments {
+        mean: alpha / beta,
+        sd: alpha.sqrt() / beta,
+        kurtosis: 3.0 + 6.0 / alpha,
+    }
+}
+
+fn beta_moments(a: f64, b: f64) -> Moments {
+    let s = a + b;
+    let var = a * b / (s * s * (s + 1.0));
+    let excess =
+        6.0 * ((a - b).powi(2) * (s + 1.0) - a * b * (s + 2.0)) / (a * b * (s + 2.0) * (s + 3.0));
+    Moments {
+        mean: a / s,
+        sd: var.sqrt(),
+        kurtosis: 3.0 + excess,
+    }
+}
+
+fn uniform_moments(lower: f64, upper: f64) -> Moments {
+    Moments {
+        mean: 0.5 * (lower + upper),
+        sd: (upper - lower) / 12.0_f64.sqrt(),
+        kurtosis: 1.8,
+    }
+}
+
+/// StudentT scaled by `sigma`; requires `nu > 4` for a finite fourth moment.
+fn student_t_moments(nu: f64, mu: f64, sigma: f64) -> Moments {
+    Moments {
+        mean: mu,
+        sd: sigma * (nu / (nu - 2.0)).sqrt(),
+        kurtosis: 3.0 + 6.0 / (nu - 4.0),
+    }
+}
+
+fn check_prior(label: &str, graph: Graph, seed: u64, name: &str, m: &Moments) {
+    let result = nuts(graph, seed, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.02);
+    assert_post_warmup_divergence_rate(&result, MAX_DIV_RATE);
+    assert_mean_within_mcse(&report, name, m.mean, MIN_ESS, 0.0);
+    assert_sd_within_mcse_kurtosis(&report, name, m.sd, m.kurtosis, MIN_ESS, 0.0);
+    let p = diag(&report, name);
+    println!(
+        "{label:<28} mean {:>9.5} (exact {:>9.5})  sd {:>9.5} (exact {:>9.5})  ess {:>7.0}",
+        p.mean, m.mean, p.std, m.sd, p.ess_bulk
+    );
+}
+
+#[test]
+fn normal_prior_reproduces_its_own_distribution() {
+    let mut g = Graph::new();
+    Normal::prior(&mut g, "x", 0.3, 1.4);
+    check_prior(
+        "Normal(0.3, 1.4)",
+        g,
+        30_001,
+        "x",
+        &normal_moments(0.3, 1.4),
+    );
+}
+
+/// Exp transform: a missing `+raw` Jacobian would bias this toward zero.
+#[test]
+fn half_normal_prior_reproduces_its_own_distribution() {
+    let mut g = Graph::new();
+    HalfNormal::prior(&mut g, "x", 1.1);
+    check_prior("HalfNormal(1.1)", g, 30_002, "x", &half_normal_moments(1.1));
+}
+
+#[test]
+fn log_normal_prior_reproduces_its_own_distribution() {
+    let mut g = Graph::new();
+    LogNormal::prior(&mut g, "x", -0.2, 0.5);
+    check_prior(
+        "LogNormal(-0.2, 0.5)",
+        g,
+        30_003,
+        "x",
+        &log_normal_moments(-0.2, 0.5),
+    );
+}
+
+#[test]
+fn exponential_prior_reproduces_its_own_distribution() {
+    let mut g = Graph::new();
+    Exponential::prior(&mut g, "x", 2.5);
+    check_prior(
+        "Exponential(rate=2.5)",
+        g,
+        30_004,
+        "x",
+        &exponential_moments(2.5),
+    );
+}
+
+#[test]
+fn gamma_prior_reproduces_its_own_distribution() {
+    let mut g = Graph::new();
+    Gamma::prior(&mut g, "x", 2.3, 1.7);
+    check_prior(
+        "Gamma(2.3, rate=1.7)",
+        g,
+        30_005,
+        "x",
+        &gamma_moments(2.3, 1.7),
+    );
+}
+
+/// Sigmoid transform: the Jacobian is `log x + log(1 - x)`.
+#[test]
+fn beta_prior_reproduces_its_own_distribution() {
+    let mut g = Graph::new();
+    BetaDist::prior(&mut g, "x", 2.0, 3.5);
+    check_prior("Beta(2.0, 3.5)", g, 30_006, "x", &beta_moments(2.0, 3.5));
+}
+
+/// Bounded-sigmoid transform. The Uniform log-density is constant inside the
+/// support, so the *entire* shape of this posterior comes from the Jacobian:
+/// if the Jacobian were dropped the draws would pile up at the boundaries.
+#[test]
+fn uniform_prior_reproduces_its_own_distribution() {
+    let mut g = Graph::new();
+    Uniform::prior(&mut g, "x", -2.0, 3.0);
+    check_prior(
+        "Uniform(-2, 3)",
+        g,
+        30_007,
+        "x",
+        &uniform_moments(-2.0, 3.0),
+    );
+}
+
+#[test]
+fn student_t_prior_reproduces_its_own_distribution() {
+    let mut g = Graph::new();
+    StudentT::prior(&mut g, "x", 8.0, 0.5, 1.3);
+    check_prior(
+        "StudentT(nu=8, 0.5, 1.3)",
+        g,
+        30_008,
+        "x",
+        &student_t_moments(8.0, 0.5, 1.3),
+    );
+}
+
+// ── Vectorized prior ops ───────────────────────────────────────────────────
+//
+// The `Vector*LogP` ops are a separate implementation from the scalar
+// distributions (they operate directly on the parameter slice and accumulate
+// gradients without going through the graph). Their marginals must match the
+// same closed forms.
+
+fn check_vector_prior(label: &str, graph: Graph, seed: u64, n: usize, m: &Moments) {
+    let result = nuts(graph, seed, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.02);
+    assert_post_warmup_divergence_rate(&result, MAX_DIV_RATE);
+    for k in 0..n {
+        let bracket = format!("v[{k}]");
+        let name = if report.params.iter().any(|q| q.name == bracket) {
+            bracket
+        } else {
+            format!("v_{k}")
+        };
+        assert_mean_within_mcse(&report, &name, m.mean, MIN_ESS, 0.0);
+        assert_sd_within_mcse_kurtosis(&report, &name, m.sd, m.kurtosis, MIN_ESS, 0.0);
+    }
+    println!("{label:<28} all {n} marginals matched closed-form moments");
+}
+
+#[test]
+fn vector_normal_prior_reproduces_its_own_distribution() {
+    let n = 3;
+    let mut g = Graph::new();
+    let s = g.add_vector_params("v", n);
+    g.vector_normal_logp(s, n, 0.4, 1.6);
+    check_vector_prior(
+        "VectorNormal(0.4, 1.6)",
+        g,
+        31_001,
+        n,
+        &normal_moments(0.4, 1.6),
+    );
+}
+
+#[test]
+fn vector_half_normal_prior_reproduces_its_own_distribution() {
+    let n = 3;
+    let mut g = Graph::new();
+    let s = g.add_vector_params_with_transform("v", n, ParamTransform::Exp);
+    g.vector_half_normal_logp(s, n, 1.3);
+    check_vector_prior(
+        "VectorHalfNormal(1.3)",
+        g,
+        31_002,
+        n,
+        &half_normal_moments(1.3),
+    );
+}
+
+#[test]
+fn vector_gamma_prior_reproduces_its_own_distribution() {
+    let n = 3;
+    let mut g = Graph::new();
+    let s = g.add_vector_params_with_transform("v", n, ParamTransform::Exp);
+    g.vector_gamma_logp(s, n, 2.5, 1.4);
+    check_vector_prior(
+        "VectorGamma(2.5, 1.4)",
+        g,
+        31_003,
+        n,
+        &gamma_moments(2.5, 1.4),
+    );
+}
+
+#[test]
+fn vector_beta_prior_reproduces_its_own_distribution() {
+    let n = 3;
+    let mut g = Graph::new();
+    let s = g.add_vector_params_with_transform("v", n, ParamTransform::Sigmoid);
+    g.vector_beta_logp(s, n, 2.2, 3.1);
+    check_vector_prior(
+        "VectorBeta(2.2, 3.1)",
+        g,
+        31_004,
+        n,
+        &beta_moments(2.2, 3.1),
+    );
+}
+
+#[test]
+fn vector_uniform_prior_reproduces_its_own_distribution() {
+    let n = 3;
+    let mut g = Graph::new();
+    let s = g.add_vector_params_with_transform(
+        "v",
+        n,
+        ParamTransform::BoundedSigmoid {
+            lower: -1.0,
+            upper: 4.0,
+        },
+    );
+    g.vector_uniform_logp(s, n, -1.0, 4.0);
+    check_vector_prior(
+        "VectorUniform(-1, 4)",
+        g,
+        31_005,
+        n,
+        &uniform_moments(-1.0, 4.0),
+    );
+}
+
+#[test]
+fn vector_student_t_prior_reproduces_its_own_distribution() {
+    let n = 3;
+    let mut g = Graph::new();
+    let s = g.add_vector_params("v", n);
+    g.vector_student_t_logp(s, n, 8.0, -0.3, 1.1);
+    check_vector_prior(
+        "VectorStudentT(8, -0.3, 1.1)",
+        g,
+        31_006,
+        n,
+        &student_t_moments(8.0, -0.3, 1.1),
+    );
+}
+
+/// A hierarchical prior with no data: `theta ~ N(mu, tau)` with `mu` and `tau`
+/// themselves given priors. Marginalizing analytically, `theta` has mean 0 and
+/// variance `Var(mu) + E[tau^2]`, and its distribution is a scale mixture, so
+/// only the mean and variance are asserted (with the kurtosis of the mixture
+/// computed exactly from the component moments).
+#[test]
+fn hierarchical_prior_marginal_matches_closed_form() {
+    let mu_sd = 1.5;
+    let tau_sd = 0.9; // tau ~ HalfNormal(tau_sd)
+
+    let mut g = Graph::new();
+    let mu = Normal::prior(&mut g, "mu", 0.0, mu_sd);
+    let tau = HalfNormal::prior(&mut g, "tau", tau_sd);
+    // Non-centered so the geometry is benign; the marginal is unchanged.
+    let z = Normal::prior(&mut g, "z", 0.0, 1.0);
+    let tz = g.mul(tau, z);
+    let _theta = g.add(mu, tz);
+
+    let result = nuts(g, 31_007, CHAINS, DRAWS, WARMUP);
+    let report = result.diagnostics();
+    assert_converged(&report, 1.02);
+    assert_post_warmup_divergence_rate(&result, MAX_DIV_RATE);
+
+    // Component marginals are exact.
+    assert_mean_within_mcse(&report, "mu", 0.0, MIN_ESS, 0.0);
+    assert_sd_within_mcse_kurtosis(&report, "mu", mu_sd, 3.0, MIN_ESS, 0.0);
+    assert_mean_within_mcse(&report, "z", 0.0, MIN_ESS, 0.0);
+    assert_sd_within_mcse_kurtosis(&report, "z", 1.0, 3.0, MIN_ESS, 0.0);
+    let tau_m = half_normal_moments(tau_sd);
+    assert_mean_within_mcse(&report, "tau", tau_m.mean, MIN_ESS, 0.0);
+    assert_sd_within_mcse_kurtosis(&report, "tau", tau_m.sd, tau_m.kurtosis, MIN_ESS, 0.0);
+}

--- a/rust_core/tests/sbc.rs
+++ b/rust_core/tests/sbc.rs
@@ -1,0 +1,531 @@
+//! Simulation-Based Calibration (Talts, Betancourt, Simpson, Vehtari & Gelman,
+//! 2018, arXiv:1804.06788).
+//!
+//! # What this proves
+//!
+//! For any correct Bayesian sampler, if you draw `theta~ ~ p(theta)`, simulate
+//! `y ~ p(y | theta~)`, and then draw `L` independent samples from
+//! `p(theta | y)`, the rank of `theta~` among those `L` draws is uniform on
+//! `{0, ..., L}`. This holds for *every* model and *every* parameter, and it
+//! fails whenever the sampled distribution differs from the intended posterior
+//! in any way — a shifted mean, a compressed variance, a wrong Jacobian, a
+//! non-reversible transition kernel. It is the single most sensitive test in
+//! this suite and the one most likely to expose a subtle bias.
+//!
+//! # Configuration and why
+//!
+//! * `L = 63` posterior draws per replicate, kept after thinning by `THIN = 8`
+//!   from a chain of `63 * 8 = 504` post-warmup draws. Thinning is what makes
+//!   the "L independent draws" premise approximately true; without it,
+//!   autocorrelation inflates the middle of the rank histogram and produces
+//!   false alarms. `L + 1 = 64` possible ranks bin exactly into 8 bins of 8.
+//!
+//! * Ranks are binned into `BINS = 8` cells and tested with a chi-square
+//!   goodness-of-fit statistic against uniformity (`df = 7`). We fail below
+//!   `P_THRESHOLD = 1e-3`. With ~14 chi-square tests across this file the
+//!   family-wise false-alarm probability is ~1.4%; each individual test is
+//!   therefore effectively never flaky, while a systematic bias — which grows
+//!   the statistic non-centrally in the number of replicates — is caught.
+//!
+//! * The fast test uses `FAST_REPS = 128` replicates; the opt-in test uses
+//!   `FULL_REPS = 512`.
+//!
+//! # Power (what these tests can and cannot detect)
+//!
+//! The non-centrality of the chi-square statistic is
+//! `N * sum_k (p_k - 1/8)^2 / (1/8)`, where `p_k` is the rank-bin probability
+//! under the perturbed posterior. Rejection at `p < 1e-3` needs `chi2 > 24.3`.
+//! Solving for the perturbation size gives the detection thresholds:
+//!
+//! | perturbation                        | detected at 128 reps | at 512 reps |
+//! |-------------------------------------|----------------------|-------------|
+//! | posterior mean shifted by `d` sd    | `d >= 0.45`          | `d >= 0.22` |
+//! | posterior sd inflated by factor `c` | `c >= 1.5`           | `c >= 1.22` |
+//!
+//! So these tests rule out gross bias, not a 5% scale error. That limit is a
+//! property of SBC replicate counts, not of the assertion, and raising
+//! `FULL_REPS` is the only way to tighten it. `sbc_detects_an_injected_bias`
+//! is a live negative control that fails if the machinery ever goes inert.
+//!
+//! # Running the full suite
+//!
+//! ```text
+//! cargo test -p rustmc_core --test sbc --release -- --ignored --nocapture
+//! ```
+//!
+//! It prints every rank histogram, chi-square statistic and p-value, so a
+//! failure is diagnosable rather than just red.
+//!
+//! # Posterior credible-interval calibration
+//!
+//! `run_sbc` also asserts that the empirical coverage of central posterior
+//! credible intervals matches their nominal level. This is `VALIDATION.md`
+//! workstream 2 ("predictive intervals contain observed values at the expected
+//! rate") applied at the parameter level, where the nominal rate is exact
+//! rather than simulated. It is computed from the same ranks at no extra cost.
+
+mod common;
+
+use common::{chi_square_sf, chi_square_uniform, nuts, Rng};
+use rustmc_core::distributions::{HalfNormal, Normal};
+use rustmc_core::graph::Graph;
+
+const L: usize = 63;
+const THIN: usize = 8;
+const WARMUP: usize = 400;
+const BINS: usize = 8;
+const P_THRESHOLD: f64 = 1e-3;
+const FAST_REPS: usize = 128;
+const FULL_REPS: usize = 512;
+
+/// One SBC replicate: a graph, the true parameter values in *constrained*
+/// (reported) space, and the parameter names to rank.
+struct Replicate {
+    graph: Graph,
+    truth: Vec<f64>,
+    names: Vec<String>,
+}
+
+/// Per-parameter SBC outcome.
+struct SbcOutcome {
+    name: String,
+    chi2: f64,
+    df: usize,
+    p_value: f64,
+    hist: Vec<usize>,
+    /// (nominal, empirical, binomial standard error) for each interval tested.
+    coverage: Vec<(f64, f64, f64)>,
+}
+
+/// Central credible intervals checked as a by-product of the ranks: the
+/// fraction of replicates whose rank lands in the central `b - a + 1` of the
+/// `L + 1` possible ranks is exactly the empirical coverage of the
+/// corresponding central posterior interval.
+const COVERAGE_WINDOWS: [(usize, usize); 2] = [(8, 55), (3, 60)];
+
+/// Run SBC for a model and return one outcome per ranked parameter.
+fn sbc_report<F>(label: &str, reps: usize, mut build: F) -> Vec<SbcOutcome>
+where
+    F: FnMut(&mut Rng) -> Replicate,
+{
+    let mut rng = Rng::new(0x5BC_0000 + label.len() as u64);
+    let mut histograms: Vec<Vec<usize>> = Vec::new();
+    let mut all_ranks: Vec<Vec<usize>> = Vec::new();
+    let mut names: Vec<String> = Vec::new();
+
+    for rep in 0..reps {
+        let Replicate {
+            graph,
+            truth,
+            names: pnames,
+        } = build(&mut rng);
+        if histograms.is_empty() {
+            histograms = vec![vec![0usize; BINS]; pnames.len()];
+            all_ranks = vec![Vec::with_capacity(reps); pnames.len()];
+            names = pnames.clone();
+        }
+
+        // One chain; ranks must come from a single exchangeable set of draws.
+        let result = nuts(graph, 900_000 + rep as u64 * 7919, 1, L * THIN, WARMUP);
+        let chain = &result.samples[0];
+        let param_names = &result.param_names;
+
+        for (pi, pname) in pnames.iter().enumerate() {
+            let idx = param_names
+                .iter()
+                .position(|n| n == pname)
+                .unwrap_or_else(|| panic!("{label}: no parameter named {pname}"));
+            let draws: Vec<f64> = (0..L).map(|k| chain[k * THIN][idx]).collect();
+            let rank = draws.iter().filter(|&&v| v < truth[pi]).count();
+            let bin = rank * BINS / (L + 1);
+            histograms[pi][bin.min(BINS - 1)] += 1;
+            all_ranks[pi].push(rank);
+        }
+    }
+
+    let mut out = Vec::new();
+    for (pi, name) in names.iter().enumerate() {
+        let (chi2, df) = chi_square_uniform(&histograms[pi]);
+        let p_value = chi_square_sf(chi2, df);
+        let coverage = COVERAGE_WINDOWS
+            .iter()
+            .map(|&(a, b)| {
+                let q = (b - a + 1) as f64 / (L + 1) as f64;
+                let hits = all_ranks[pi].iter().filter(|&&r| r >= a && r <= b).count();
+                let emp = hits as f64 / reps as f64;
+                let se = (q * (1.0 - q) / reps as f64).sqrt();
+                (q, emp, se)
+            })
+            .collect();
+        println!(
+            "SBC {label:<34} {name:<10} reps={reps:<4} chi2={chi2:7.2} df={df} p={p_value:.4}  \
+hist={:?}  coverage={:?}",
+            histograms[pi],
+            COVERAGE_WINDOWS
+                .iter()
+                .map(|&(a, b)| {
+                    let q = (b - a + 1) as f64 / (L + 1) as f64;
+                    let hits = all_ranks[pi].iter().filter(|&&r| r >= a && r <= b).count();
+                    (
+                        (100.0 * q).round() / 100.0,
+                        (1000.0 * hits as f64 / reps as f64).round() / 1000.0,
+                    )
+                })
+                .collect::<Vec<_>>()
+        );
+        out.push(SbcOutcome {
+            name: name.clone(),
+            chi2,
+            df,
+            p_value,
+            hist: histograms[pi].clone(),
+            coverage,
+        });
+    }
+    out
+}
+
+/// Run SBC and assert every rank histogram is uniform and every credible
+/// interval attains its nominal coverage.
+///
+/// Coverage tolerance: 3.5 binomial standard errors, a ~0.05% per-assertion
+/// false-alarm rate.
+fn run_sbc<F>(label: &str, reps: usize, build: F)
+where
+    F: FnMut(&mut Rng) -> Replicate,
+{
+    let outcomes = sbc_report(label, reps, build);
+    let mut failures = Vec::new();
+    for o in &outcomes {
+        for &(q, emp, se) in &o.coverage {
+            if (emp - q).abs() > 3.5 * se {
+                failures.push(format!(
+                    "{}: central {:.1}% credible interval covered {:.1}% over {reps} \
+                     replicates (|diff| {:.4} > 3.5 * binomial se {:.4})",
+                    o.name,
+                    100.0 * q,
+                    100.0 * emp,
+                    (emp - q).abs(),
+                    3.5 * se
+                ));
+            }
+        }
+        if o.p_value < P_THRESHOLD {
+            failures.push(format!(
+                "{}: rank histogram not uniform, chi2={:.2} df={} p={:.2e} hist={:?}",
+                o.name, o.chi2, o.df, o.p_value, o.hist
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "{label}: SBC calibration failed:\n  {}",
+        failures.join("\n  ")
+    );
+}
+
+// ── Models ─────────────────────────────────────────────────────────────────
+
+/// Location only: `mu ~ N(0, 1)`, `y_i ~ N(mu, 1)`.
+/// Targets the core Normal density and the `ScalarBroadcast` + observation path.
+fn location_model(rng: &mut Rng) -> Replicate {
+    let n = 8;
+    let mu_true = rng.normal();
+    let y: Vec<f64> = (0..n).map(|_| rng.normal_with(mu_true, 1.0)).collect();
+
+    let mut g = Graph::new();
+    let mu = Normal::prior(&mut g, "mu", 0.0, 1.0);
+    let mu_vec = g.scalar_broadcast(mu);
+    let s = g.add_constant(1.0);
+    let obs = g.add_obs_data(y);
+    g.normal_obs_logp(mu_vec, s, obs);
+
+    Replicate {
+        graph: g,
+        truth: vec![mu_true],
+        names: vec!["mu".into()],
+    }
+}
+
+/// Scale only: `sigma ~ HalfNormal(1)`, `y_i ~ N(0, sigma)`.
+///
+/// This is the highest-value SBC model in the file: it is the only one whose
+/// correctness depends on the exp transform's Jacobian being right, and a
+/// wrong Jacobian produces a *perfectly converged* chain with a systematically
+/// shifted rank histogram.
+fn scale_model(rng: &mut Rng) -> Replicate {
+    let n = 8;
+    // HalfNormal(1) draw.
+    let sigma_true = rng.normal().abs().max(1e-6);
+    let y: Vec<f64> = (0..n).map(|_| rng.normal_with(0.0, sigma_true)).collect();
+
+    let mut g = Graph::new();
+    let sigma = HalfNormal::prior(&mut g, "sigma", 1.0);
+    let zero = g.add_constant(0.0);
+    let mu_vec = g.scalar_broadcast(zero);
+    let obs = g.add_obs_data(y);
+    g.normal_obs_logp(mu_vec, sigma, obs);
+
+    Replicate {
+        graph: g,
+        truth: vec![sigma_true],
+        names: vec!["sigma".into()],
+    }
+}
+
+/// Regression with a learned scale: `a, b ~ N(0, 1)`, `sigma ~ HalfNormal(1)`,
+/// `y_i ~ N(a + b x_i, sigma)`. Targets `FusedLinearMu` and the joint geometry
+/// of location and scale parameters.
+fn regression_model(rng: &mut Rng) -> Replicate {
+    let n = 12;
+    let a_true = rng.normal();
+    let b_true = rng.normal();
+    let sigma_true = rng.normal().abs().max(1e-6);
+    let x: Vec<f64> = (0..n).map(|_| rng.normal()).collect();
+    let y: Vec<f64> = x
+        .iter()
+        .map(|&xi| rng.normal_with(a_true + b_true * xi, sigma_true))
+        .collect();
+
+    let mut g = Graph::new();
+    let a = Normal::prior(&mut g, "a", 0.0, 1.0);
+    let b = Normal::prior(&mut g, "b", 0.0, 1.0);
+    let sigma = HalfNormal::prior(&mut g, "sigma", 1.0);
+    let d0 = g.store_data_vec(vec![1.0; n]);
+    let d1 = g.store_data_vec(x);
+    let mu = g.fused_linear_mu(vec![a, b], vec![d0, d1], None);
+    let obs = g.add_obs_data(y);
+    g.normal_obs_logp(mu, sigma, obs);
+
+    Replicate {
+        graph: g,
+        truth: vec![a_true, b_true, sigma_true],
+        names: vec!["a".into(), "b".into(), "sigma".into()],
+    }
+}
+
+/// Non-centered two-level hierarchy: `mu ~ N(0, 1)`, `tau ~ HalfNormal(1)`,
+/// `theta_j = mu + tau z_j` with `z_j ~ N(0, 1)`, `y_j ~ N(theta_j, 1)`.
+/// Targets the hierarchical wiring the Python DSL auto-non-centers onto.
+fn hierarchical_model(rng: &mut Rng) -> Replicate {
+    let j = 5;
+    let mu_true = rng.normal();
+    let tau_true = rng.normal().abs().max(1e-6);
+    let z_true: Vec<f64> = (0..j).map(|_| rng.normal()).collect();
+
+    let mut g = Graph::new();
+    let mu = Normal::prior(&mut g, "mu", 0.0, 1.0);
+    let tau = HalfNormal::prior(&mut g, "tau", 1.0);
+    for (jj, &z_t) in z_true.iter().enumerate() {
+        let y_j = rng.normal_with(mu_true + tau_true * z_t, 1.0);
+        let z = Normal::prior(&mut g, &format!("z_{jj}"), 0.0, 1.0);
+        let tz = g.mul(tau, z);
+        let theta = g.add(mu, tz);
+        let yn = g.add_constant(y_j);
+        let sn = g.add_constant(1.0);
+        g.normal_logp(yn, theta, sn);
+    }
+
+    Replicate {
+        graph: g,
+        truth: vec![mu_true, tau_true, z_true[0]],
+        names: vec!["mu".into(), "tau".into(), "z_0".into()],
+    }
+}
+
+/// **Centered** two-level hierarchy: `theta_j ~ N(mu, tau)` directly, with
+/// `tau ~ HalfNormal(1)`. This is the classic funnel geometry and it produces
+/// divergent transitions at any practical step size.
+///
+/// It is here deliberately. `nuts::run_chain` rejects the *entire* transition
+/// whenever any subtree diverges (`if !tree_stats.diverging { current = ... }`)
+/// rather than keeping the proposal drawn from the valid part of the
+/// trajectory, which is what Stan does. That modification is not obviously
+/// reversible, so it is a plausible source of bias — and this is the model
+/// where such a bias would show up. See `docs`/the validation report.
+fn centered_hierarchical_model(rng: &mut Rng) -> Replicate {
+    let j = 5;
+    let mu_true = rng.normal();
+    let tau_true = rng.normal().abs().max(1e-6);
+    let theta_true: Vec<f64> = (0..j).map(|_| rng.normal_with(mu_true, tau_true)).collect();
+
+    let mut g = Graph::new();
+    let mu = Normal::prior(&mut g, "mu", 0.0, 1.0);
+    let tau = HalfNormal::prior(&mut g, "tau", 1.0);
+    for (jj, &t_t) in theta_true.iter().enumerate() {
+        let y_j = rng.normal_with(t_t, 1.0);
+        let theta = Normal::prior_with_nodes(&mut g, &format!("theta_{jj}"), mu, tau);
+        let yn = g.add_constant(y_j);
+        let sn = g.add_constant(1.0);
+        g.normal_logp(yn, theta, sn);
+    }
+
+    Replicate {
+        graph: g,
+        truth: vec![mu_true, tau_true, theta_true[0]],
+        names: vec!["mu".into(), "tau".into(), "theta_0".into()],
+    }
+}
+
+/// Matrix-vector regression: `beta ~ N(0, 1)^p`, `y ~ N(X beta, 1)`.
+/// Targets the faer `MatVecMul` gradient and the `VectorNormalLogP` prior.
+fn matvec_model(rng: &mut Rng) -> Replicate {
+    let n = 15;
+    let p = 3;
+    let beta_true: Vec<f64> = (0..p).map(|_| rng.normal()).collect();
+    let mut flat = Vec::with_capacity(n * p);
+    let mut y = Vec::with_capacity(n);
+    for _ in 0..n {
+        let row: Vec<f64> = (0..p).map(|_| rng.normal()).collect();
+        let mu: f64 = row.iter().zip(&beta_true).map(|(a, b)| a * b).sum();
+        y.push(rng.normal_with(mu, 1.0));
+        flat.extend(row);
+    }
+
+    let mut g = Graph::new();
+    let s = g.add_vector_params("beta", p);
+    g.vector_normal_logp(s, p, 0.0, 1.0);
+    let m = g.store_matrix(flat, n, p);
+    let mu = g.mat_vec_mul(m, s, p, None);
+    let sig = g.add_constant(1.0);
+    let obs = g.add_obs_data(y);
+    g.normal_obs_logp(mu, sig, obs);
+
+    Replicate {
+        graph: g,
+        truth: vec![beta_true[0], beta_true[1]],
+        names: vec!["beta[0]".into(), "beta[1]".into()],
+    }
+}
+
+// ── Fast (always-on) tests ─────────────────────────────────────────────────
+
+#[test]
+fn sbc_location_model_is_calibrated() {
+    run_sbc("location N(0,1) / N(mu,1)", FAST_REPS, location_model);
+}
+
+#[test]
+fn sbc_scale_model_is_calibrated() {
+    run_sbc("scale HalfNormal(1) / N(0,sigma)", FAST_REPS, scale_model);
+}
+
+// ── Opt-in (slower, higher power) tests ────────────────────────────────────
+
+#[test]
+#[ignore = "full SBC run; opt in with --ignored"]
+fn sbc_location_model_is_calibrated_full() {
+    run_sbc("location (full)", FULL_REPS, location_model);
+}
+
+#[test]
+#[ignore = "full SBC run; opt in with --ignored"]
+fn sbc_scale_model_is_calibrated_full() {
+    run_sbc("scale (full)", FULL_REPS, scale_model);
+}
+
+#[test]
+#[ignore = "full SBC run; opt in with --ignored"]
+fn sbc_regression_model_is_calibrated_full() {
+    run_sbc(
+        "regression a+bx, learned sigma",
+        FULL_REPS,
+        regression_model,
+    );
+}
+
+#[test]
+#[ignore = "full SBC run; opt in with --ignored"]
+fn sbc_hierarchical_model_is_calibrated_full() {
+    run_sbc("hierarchical non-centered", FULL_REPS, hierarchical_model);
+}
+
+#[test]
+#[ignore = "full SBC run; opt in with --ignored"]
+fn sbc_matvec_model_is_calibrated_full() {
+    run_sbc("matvec X @ beta", FULL_REPS, matvec_model);
+}
+
+/// Characterisation test for a **reproduced miscalibration**.
+///
+/// The centered parameterisation of the two-level hierarchy is the classic
+/// Neal funnel: NUTS cannot reach the neck at small `tau`, so `tau`'s
+/// posterior is systematically truncated from below and its credible
+/// intervals under-cover. This is measured, not assumed:
+///
+/// ```text
+/// tau: central 75% credible interval covered 65.6% over 512 replicates
+///      (4.9 binomial standard errors low)
+/// ```
+///
+/// The non-centered version of the same model (`sbc_hierarchical_model_*`) is
+/// calibrated, which is what localises this to the parameterisation rather
+/// than to the engine. It matters because
+/// `examples/hierarchical_templates.py` builds the *centered* form and the
+/// Python DSL's auto-non-centering is unreachable (see the pinned defect in
+/// `tests/test_statistical_engine_bugs.py`).
+///
+/// This test asserts the miscalibration is still present. If it starts
+/// passing — because the geometry handling improved — that is good news and
+/// the test (and the docs it points at) should be updated.
+#[test]
+#[ignore = "full SBC run; opt in with --ignored"]
+fn sbc_centered_hierarchical_model_is_known_miscalibrated() {
+    let outcomes = sbc_report(
+        "hierarchical CENTERED (funnel)",
+        FULL_REPS,
+        centered_hierarchical_model,
+    );
+    let tau = outcomes
+        .iter()
+        .find(|o| o.name == "tau")
+        .expect("tau outcome");
+    let (q, emp, se) = tau.coverage[0];
+    assert!(
+        emp < q - 3.0 * se,
+        "the centered funnel's tau credible interval is no longer under-covering \
+         (nominal {:.1}%, empirical {:.1}%, se {:.4}); update this test and the \
+         hierarchical docs/examples",
+        100.0 * q,
+        100.0 * emp,
+        se
+    );
+}
+
+/// Negative control: rank the true value against posterior draws that have
+/// been deliberately shifted by 0.7 posterior sd. SBC must reject this.
+///
+/// Guards against the SBC machinery itself being inert — a wrong rank formula,
+/// an off-by-one in the binning, a chi-square implementation that never fires.
+/// At 128 replicates a 0.7 sd shift gives an expected chi-square of ~64
+/// (p ~ 2e-11), so this control has a large margin and is not itself flaky.
+#[test]
+fn sbc_detects_an_injected_bias() {
+    let reps = FAST_REPS;
+    let mut rng = Rng::new(0xDEADBEEF);
+    let mut hist = vec![0usize; BINS];
+
+    for rep in 0..reps {
+        let Replicate { graph, truth, .. } = location_model(&mut rng);
+        let result = nuts(graph, 900_000 + rep as u64 * 7919, 1, L * THIN, WARMUP);
+        let chain = &result.samples[0];
+        let draws: Vec<f64> = (0..L).map(|k| chain[k * THIN][0]).collect();
+        let mean = draws.iter().sum::<f64>() / L as f64;
+        let sd = (draws.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / (L as f64 - 1.0)).sqrt();
+        // Inject a 0.7-sd location bias into the posterior draws.
+        let perturbed: Vec<f64> = draws.iter().map(|v| v + 0.7 * sd).collect();
+        let rank = perturbed.iter().filter(|&&v| v < truth[0]).count();
+        hist[(rank * BINS / (L + 1)).min(BINS - 1)] += 1;
+    }
+
+    let (stat, df) = chi_square_uniform(&hist);
+    let p = chi_square_sf(stat, df);
+    println!(
+        "SBC negative control (+0.7 sd shift): chi2={stat:.2} df={df} p={p:.3e} hist={hist:?}"
+    );
+    assert!(
+        p < P_THRESHOLD,
+        "SBC failed to detect a 0.7-sd posterior location bias \
+         (chi2={stat:.2}, p={p:.3e}, hist={hist:?}); the calibration test has no power"
+    );
+}

--- a/tests/test_statistical_conjugate.py
+++ b/tests/test_statistical_conjugate.py
@@ -1,0 +1,273 @@
+"""Analytic-posterior tests driven through the public Python DSL.
+
+The Rust suite (``rust_core/tests/analytic_posterior.rs``) proves the *engine*
+targets the right posterior. This file proves the *bindings* build the model
+the user described: a mis-wired prior, a dropped intercept, or a transposed
+design matrix would leave the Rust tests green and these red.
+
+Tolerances
+----------
+Every assertion compares against a closed-form value and is sized from the
+reported Monte Carlo standard error:
+
+* posterior mean: ``|mean_hat - exact| <= 4 * mcse_mean``.  Under a normal CLT
+  approximation a single such assertion fires spuriously with probability
+  ~6e-5.
+* posterior sd: ``|sd_hat - exact| <= 5 * exact / sqrt(2 * ess_bulk)``, from
+  the delta-method standard error of a sample sd for a Gaussian target.
+
+Nothing here was widened after the fact; the constants 4 and 5 are fixed in
+``K_MEAN``/``K_SD`` and reused everywhere.
+"""
+
+import numpy as np
+import pytest
+
+rustmc = pytest.importorskip("rustmc")
+
+K_MEAN = 4.0
+K_SD = 5.0
+
+CHAINS = 4
+DRAWS = 1500
+WARMUP = 1000
+
+
+def _diag(fit, name):
+    for d in fit.diagnostics():
+        if d["name"] == name:
+            return d
+    raise AssertionError(f"no diagnostic named {name!r}; have {[d['name'] for d in fit.diagnostics()]}")
+
+
+def assert_mean(fit, name, exact, min_ess=400.0):
+    d = _diag(fit, name)
+    assert d["ess_bulk"] >= min_ess, (
+        f"{name}: ess_bulk {d['ess_bulk']:.0f} < {min_ess}; an MCSE-based "
+        "tolerance would be meaningless"
+    )
+    tol = K_MEAN * d["mcse_mean"]
+    assert abs(d["mean"] - exact) <= tol, (
+        f"{name}: posterior mean {d['mean']:.6f} vs exact {exact:.6f} "
+        f"(|diff| {abs(d['mean'] - exact):.6f} > {K_MEAN} * mcse {d['mcse_mean']:.6f} "
+        f"= {tol:.6f}, ess_bulk {d['ess_bulk']:.0f})"
+    )
+
+
+def assert_sd(fit, name, exact, min_ess=400.0):
+    d = _diag(fit, name)
+    assert d["ess_bulk"] >= min_ess
+    rel = K_SD / np.sqrt(2.0 * d["ess_bulk"])
+    tol = rel * abs(exact)
+    assert abs(d["std"] - exact) <= tol, (
+        f"{name}: posterior sd {d['std']:.6f} vs exact {exact:.6f} "
+        f"({100 * abs(d['std'] - exact) / exact:.2f}% relative) exceeds "
+        f"{100 * rel:.2f}% tolerance (ess_bulk {d['ess_bulk']:.0f})"
+    )
+
+
+def assert_rhat(fit, limit=1.05):
+    for d in fit.diagnostics():
+        assert np.isfinite(d["r_hat"]) and d["r_hat"] < limit, (
+            f"{d['name']}: r_hat {d['r_hat']}"
+        )
+
+
+def linear_gaussian_posterior(X, y, sigma, prior_mean, prior_sd):
+    """Exact posterior of ``y ~ N(X beta, sigma^2 I)`` with independent
+    ``beta_k ~ N(prior_mean[k], prior_sd[k])``.  Returns (mean, cov)."""
+    X = np.asarray(X, dtype=float)
+    prior_prec = np.diag(1.0 / np.asarray(prior_sd, dtype=float) ** 2)
+    lam = prior_prec + X.T @ X / sigma**2
+    h = prior_prec @ np.asarray(prior_mean, dtype=float) + X.T @ np.asarray(y) / sigma**2
+    cov = np.linalg.inv(lam)
+    return cov @ h, cov
+
+
+def _fit(spec, seed, chains=CHAINS, draws=DRAWS, warmup=WARMUP):
+    return rustmc.sample(
+        spec,
+        chains=chains,
+        draws=draws,
+        warmup=warmup,
+        seed=seed,
+        threads=1,
+        show_progress=False,
+    )
+
+
+# ── Conjugate Normal-Normal ───────────────────────────────────────────────
+
+
+def test_conjugate_normal_normal_matches_analytic_posterior():
+    rng = np.random.default_rng(11)
+    n, sigma, m0, s0 = 50, 0.9, 0.0, 2.5
+    y = rng.normal(1.4, sigma, size=n)
+
+    prec = 1.0 / s0**2 + n / sigma**2
+    exact_mean = (m0 / s0**2 + y.sum() / sigma**2) / prec
+    exact_sd = np.sqrt(1.0 / prec)
+
+    b = rustmc.ModelBuilder({"y": y})
+    mu = b.normal_prior("mu", m0, s0)
+    b.normal_likelihood("y_obs", mu, sigma, "y")
+    fit = _fit(b.build(), 101)
+
+    assert_rhat(fit)
+    assert_mean(fit, "mu", exact_mean)
+    assert_sd(fit, "mu", exact_sd)
+
+
+# ── Linear regression through ``param * "x"`` ─────────────────────────────
+
+
+def test_linear_regression_matches_analytic_posterior():
+    rng = np.random.default_rng(12)
+    n, sigma = 80, 0.7
+    x = rng.normal(size=n)
+    y = 0.8 - 1.3 * x + rng.normal(0, sigma, size=n)
+
+    X = np.column_stack([np.ones(n), x])
+    exact_mean, exact_cov = linear_gaussian_posterior(X, y, sigma, [0.0, 0.0], [3.0, 3.0])
+
+    b = rustmc.ModelBuilder({"x": x, "y": y})
+    a = b.normal_prior("a", 0.0, 3.0)
+    bb = b.normal_prior("b", 0.0, 3.0)
+    b.normal_likelihood("y_obs", a + bb * "x", sigma, "y")
+    fit = _fit(b.build(), 102)
+
+    assert_rhat(fit)
+    for k, name in enumerate(["a", "b"]):
+        assert_mean(fit, name, exact_mean[k])
+        assert_sd(fit, name, np.sqrt(exact_cov[k, k]))
+
+
+# ── Matrix-vector regression through the ``@`` operator ───────────────────
+
+
+def test_matvec_regression_matches_analytic_posterior():
+    rng = np.random.default_rng(13)
+    n, p, sigma, prior_sd = 100, 4, 0.6, 2.0
+    X = rng.normal(size=(n, p))
+    X[:, 0] = 1.0
+    beta_true = np.array([0.5, -1.0, 0.3, 0.7])
+    y = X @ beta_true + rng.normal(0, sigma, size=n)
+
+    exact_mean, exact_cov = linear_gaussian_posterior(
+        X, y, sigma, np.zeros(p), np.full(p, prior_sd)
+    )
+
+    b = rustmc.ModelBuilder({"X": X, "y": y})
+    beta = b.vector_normal_prior("beta", p, 0.0, prior_sd)
+    b.normal_likelihood("y_obs", beta @ "X", sigma, "y")
+    fit = _fit(b.build(), 103)
+
+    assert_rhat(fit)
+    for k in range(p):
+        assert_mean(fit, f"beta[{k}]", exact_mean[k])
+        assert_sd(fit, f"beta[{k}]", np.sqrt(exact_cov[k, k]))
+
+
+def test_matvec_auto_promotion_matches_explicit_vector_prior():
+    """``normal_prior`` + ``@`` must build the same model as
+    ``vector_normal_prior`` + ``@``.  Both are checked against the same exact
+    posterior, so a discrepancy localises to the auto-promotion path."""
+    rng = np.random.default_rng(14)
+    n, p, sigma, prior_sd = 90, 3, 0.5, 1.5
+    X = rng.normal(size=(n, p))
+    y = X @ np.array([0.4, -0.8, 0.2]) + rng.normal(0, sigma, size=n)
+    exact_mean, exact_cov = linear_gaussian_posterior(
+        X, y, sigma, np.zeros(p), np.full(p, prior_sd)
+    )
+
+    b = rustmc.ModelBuilder({"X": X, "y": y})
+    beta = b.normal_prior("beta", 0.0, prior_sd)  # scalar prior, auto-promoted
+    b.normal_likelihood("y_obs", beta @ "X", sigma, "y")
+    fit = _fit(b.build(), 104)
+
+    assert_rhat(fit)
+    for k in range(p):
+        assert_mean(fit, f"beta[{k}]", exact_mean[k])
+        assert_sd(fit, f"beta[{k}]", np.sqrt(exact_cov[k, k]))
+
+
+# ── Hierarchical model with a ParamRef hyperparameter ─────────────────────
+
+
+@pytest.mark.xfail(
+    reason=(
+        "DEFECT 1 (see tests/test_statistical_engine_bugs.py): a prior with a "
+        "ParamRef hyperparameter is auto-non-centered into '<name>__raw' and "
+        "its derived value node is never registered under the user-facing "
+        "name, so referencing it in a likelihood raises "
+        "ValueError('Unknown param: ...'). No hierarchical model can be fitted "
+        "through the Python DSL today. This test is the analytic reference the "
+        "fix should be validated against."
+    ),
+    raises=ValueError,
+    strict=False,
+)
+def test_hierarchical_known_variances_matches_analytic_posterior():
+    """Two-level linear-Gaussian model with *fixed* variance components, so
+    the joint posterior over (mu, theta_1..theta_J) is exactly Gaussian.
+
+    ``normal_prior(name, mu=ParamRef, sigma=const)`` triggers the automatic
+    non-centering path in the bindings; the resulting posterior must be the
+    same distribution regardless of parameterisation.
+    """
+    J = 5
+    s0, tau = 4.0, 1.1
+    sigma = np.array([1.0, 1.3, 0.9, 1.6, 1.1])
+    y = np.array([1.5, -0.6, 2.2, 0.4, 1.0])
+
+    # Joint precision over [mu, theta_0..theta_{J-1}].
+    dim = J + 1
+    lam = np.zeros((dim, dim))
+    h = np.zeros(dim)
+    lam[0, 0] = 1.0 / s0**2 + J / tau**2
+    for g in range(J):
+        lam[0, g + 1] = lam[g + 1, 0] = -1.0 / tau**2
+        lam[g + 1, g + 1] = 1.0 / tau**2 + 1.0 / sigma[g] ** 2
+        h[g + 1] = y[g] / sigma[g] ** 2
+    cov = np.linalg.inv(lam)
+    mean = cov @ h
+
+    # The DSL exposes one scalar `sigma` per likelihood, but the groups have
+    # different observation sds. Dividing both the response and the one-hot
+    # indicator column by sigma_g rescales every row to unit sd, which leaves
+    # the posterior unchanged.
+    scaled = {"y": y / sigma}
+    for g in range(J):
+        col = np.zeros(J)
+        col[g] = 1.0 / sigma[g]
+        scaled[f"g{g}"] = col
+
+    b = rustmc.ModelBuilder(scaled)
+    mu = b.normal_prior("mu", 0.0, s0)
+    thetas = [b.normal_prior(f"theta_{g}", mu, tau) for g in range(J)]
+    expr = thetas[0] * "g0"
+    for g in range(1, J):
+        expr = expr + thetas[g] * f"g{g}"
+    b.normal_likelihood("y_obs", expr, 1.0, "y")
+    fit = _fit(b.build(), 105)
+
+    assert_rhat(fit)
+    assert_mean(fit, "mu", mean[0])
+    assert_sd(fit, "mu", np.sqrt(cov[0, 0]))
+    for g in range(J):
+        assert_mean(fit, f"theta_{g}", mean[g + 1])
+        assert_sd(fit, f"theta_{g}", np.sqrt(cov[g + 1, g + 1]))
+
+
+def test_sampling_is_reproducible_for_a_fixed_seed():
+    rng = np.random.default_rng(15)
+    y = rng.normal(size=40)
+    b = rustmc.ModelBuilder({"y": y})
+    mu = b.normal_prior("mu", 0.0, 2.0)
+    b.normal_likelihood("y_obs", mu, 1.0, "y")
+    spec = b.build()
+    first = _fit(spec, 999, chains=2, draws=100, warmup=100)
+    second = _fit(spec, 999, chains=2, draws=100, warmup=100)
+    np.testing.assert_array_equal(
+        first.get_samples()["mu"], second.get_samples()["mu"]
+    )

--- a/tests/test_statistical_engine_bugs.py
+++ b/tests/test_statistical_engine_bugs.py
@@ -1,0 +1,201 @@
+"""Pinned defects found while building the statistical validation suite.
+
+Each test here documents a *reproducible* engine defect. They are marked
+``xfail`` so the suite stays green, and each one names the fix that should make
+it pass. When a defect is fixed, delete the marker (or the whole test if it is
+subsumed by a positive test elsewhere).
+
+None of these are fixed in this branch: this worktree owns tests only.
+See ``VALIDATION_RESULTS.md`` for the full write-up.
+"""
+
+import numpy as np
+import pytest
+
+rustmc = pytest.importorskip("rustmc")
+
+
+@pytest.mark.xfail(
+    reason=(
+        "DEFECT 1: a parameter whose prior takes a ParamRef hyperparameter "
+        "(any hierarchical model) cannot be referenced in a likelihood. "
+        "build_prior_into_graph's auto-non-centering path registers the raw "
+        "parameter as '<name>__raw' and stores the derived value node only in "
+        "value_node_map, but build_mu_expr resolves names via "
+        "Graph::node_by_name, which never sees it. Every hierarchical model "
+        "expressible in the DSL fails with ValueError('Unknown param: ...'), "
+        "including examples/hierarchical_example.py."
+    ),
+    raises=ValueError,
+    strict=False,
+)
+def test_hierarchical_parameter_can_be_used_in_a_likelihood():
+    rng = np.random.default_rng(0)
+    data = {f"y_{j}": rng.normal(size=10) for j in range(3)}
+    b = rustmc.ModelBuilder(data)
+    mu_global = b.normal_prior("mu_global", 0.0, 10.0)
+    sigma_group = b.half_normal_prior("sigma_group", 5.0)
+    for j in range(3):
+        group = b.normal_prior(f"mu_{j}", mu_global, sigma_group)
+        b.normal_likelihood(f"obs_{j}", group, 2.0, f"y_{j}")
+
+    fit = rustmc.sample(
+        b.build(), chains=2, draws=200, warmup=200, seed=1, show_progress=False
+    )
+    means = fit.mean()
+    assert "mu_global" in means and np.isfinite(means["mu_global"])
+
+
+@pytest.mark.xfail(
+    reason=(
+        "DEFECT 2: sample_prior_predictive panics (a Rust PanicException, not "
+        "a Python error) when a scalar prior is auto-promoted to a vector "
+        "parameter by the '@' operator. sample_prior_raw pushes one raw value "
+        "for PriorSpec::Normal / HalfNormal / StudentT / Uniform / Gamma / "
+        "Beta regardless of auto_vector_params, so the raw vector is n-1 "
+        "values short and derive_display_draw indexes out of bounds. Only the "
+        "Exponential and LogNormal branches handle the vector case; explicit "
+        "vector_normal_prior works because PriorSpec::VectorNormal loops over n."
+    ),
+    strict=False,
+)
+def test_prior_predictive_supports_auto_promoted_vector_parameters():
+    rng = np.random.default_rng(0)
+    n, p = 20, 3
+    X = rng.normal(size=(n, p))
+    y = rng.normal(size=n)
+    b = rustmc.ModelBuilder({"X": X, "y": y})
+    beta = b.normal_prior("beta", 0.0, 1.0)  # auto-promoted to length p by @
+    b.normal_likelihood("y_obs", beta @ "X", 1.0, "y")
+
+    out = rustmc.sample_prior_predictive(b.build(), n_samples=25, seed=1)
+    assert np.asarray(out["y_obs"]).shape == (25, n)
+
+
+def test_prior_predictive_works_with_an_explicit_vector_prior():
+    """Positive control for DEFECT 2: the explicit vector prior path is fine,
+    which is what localises the bug to the auto-promotion branch."""
+    rng = np.random.default_rng(0)
+    n, p = 20, 3
+    X = rng.normal(size=(n, p))
+    y = rng.normal(size=n)
+    b = rustmc.ModelBuilder({"X": X, "y": y})
+    beta = b.vector_normal_prior("beta", p, 0.0, 1.0)
+    b.normal_likelihood("y_obs", beta @ "X", 1.0, "y")
+
+    out = rustmc.sample_prior_predictive(b.build(), n_samples=25, seed=1)
+    assert np.asarray(out["y_obs"]).shape == (25, n)
+
+
+@pytest.mark.xfail(
+    reason=(
+        "DEFECT 3: FitResult.divergences() reports divergences accumulated "
+        "over warmup *and* sampling. Stan and PyMC report post-warmup "
+        "divergences only. On a well-behaved 1-parameter Gaussian target this "
+        "reports ~20 'divergences' where the true post-warmup count is 0, so "
+        "the number cannot be used as the health signal the docs describe. The "
+        "per-draw flags needed to split it are already stored in "
+        "SampleResult::transitions."
+    ),
+    strict=False,
+)
+def test_divergence_count_excludes_warmup():
+    rng = np.random.default_rng(3)
+    y = rng.normal(1.25, 0.8, size=40)
+    b = rustmc.ModelBuilder({"y": y})
+    mu = b.normal_prior("mu", 0.0, 2.0)
+    b.normal_likelihood("y_obs", mu, 0.8, "y")
+    fit = rustmc.sample(
+        b.build(), chains=4, draws=750, warmup=750, seed=20001,
+        threads=1, show_progress=False,
+    )
+    # The Rust-side post-warmup count for this exact model and seed is 0
+    # (see rust_core/tests/analytic_posterior.rs).
+    assert sum(fit.divergences()) == 0
+
+
+@pytest.mark.xfail(
+    reason=(
+        "DEFECT 4: to_arviz() omits sample_stats['diverging'], warning that "
+        "'exact per-draw divergence flags are not stored'. They are: "
+        "SampleResult::transitions carries `divergent` and `is_warmup` for "
+        "every transition. As a result az.plot_pair(divergences=True) and "
+        "every ArviZ divergence diagnostic are unavailable."
+    ),
+    strict=False,
+)
+def test_arviz_export_includes_per_draw_divergence_flags():
+    az = pytest.importorskip("arviz")
+    rng = np.random.default_rng(4)
+    y = rng.normal(size=30)
+    b = rustmc.ModelBuilder({"y": y})
+    mu = b.normal_prior("mu", 0.0, 2.0)
+    b.normal_likelihood("y_obs", mu, 1.0, "y")
+    fit = rustmc.sample(
+        b.build(), chains=2, draws=200, warmup=200, seed=5, show_progress=False
+    )
+    idata = fit.to_arviz()
+    assert "diverging" in idata.sample_stats
+    assert idata.sample_stats["diverging"].shape == (2, 200)
+    _ = az
+
+
+def test_unknown_data_key_fails_with_an_actionable_error():
+    """Positive failure-mode test: bad keys must raise a clear Python error,
+    not panic and not silently produce a wrong model."""
+    y = np.zeros(5)
+    b = rustmc.ModelBuilder({"y": y})
+    a = b.normal_prior("a", 0.0, 1.0)
+    with pytest.raises(ValueError) as exc:
+        b.normal_likelihood("y_obs", a * "not_a_key", 1.0, "y")
+    assert "not_a_key" in str(exc.value)
+
+
+def test_mismatched_observation_length_fails_with_an_actionable_error():
+    b = rustmc.ModelBuilder({"x": np.zeros(10), "y": np.zeros(7)})
+    a = b.normal_prior("a", 0.0, 1.0)
+    b.normal_likelihood("y_obs", a * "x", 1.0, "y")
+    with pytest.raises(ValueError) as exc:
+        rustmc.sample(
+            b.build(), chains=1, draws=10, warmup=10, seed=1, show_progress=False
+        )
+    msg = str(exc.value).lower()
+    assert "length" in msg or "expected" in msg
+
+
+def test_binary_likelihood_rejects_non_binary_observations():
+    """Support validation happens at sample() time, not at builder time — the
+    builder accepts the model and only `build_likelihood_into_graph` checks.
+    That is a usability wart, not a correctness one, so it is asserted as-is."""
+    b = rustmc.ModelBuilder({"y": np.array([0.0, 1.0, 2.0])})
+    eta = b.normal_prior("eta", 0.0, 1.0)
+    b.bernoulli_logit_likelihood("y_obs", eta, "y")  # accepted here
+    with pytest.raises(ValueError) as exc:
+        rustmc.sample(
+            b.build(), chains=1, draws=10, warmup=10, seed=1, show_progress=False
+        )
+    assert "y_obs" in str(exc.value)
+
+
+def test_count_likelihood_rejects_negative_observations():
+    b = rustmc.ModelBuilder({"y": np.array([0.0, 1.0, -3.0])})
+    eta = b.normal_prior("eta", 0.0, 1.0)
+    b.poisson_log_likelihood("y_obs", eta, "y")
+    with pytest.raises(ValueError) as exc:
+        rustmc.sample(
+            b.build(), chains=1, draws=10, warmup=10, seed=1, show_progress=False
+        )
+    assert "y_obs" in str(exc.value)
+
+
+def test_discrete_prior_cannot_be_auto_promoted_by_matmul():
+    rng = np.random.default_rng(6)
+    X = rng.normal(size=(10, 2))
+    b = rustmc.ModelBuilder({"X": X, "y": rng.normal(size=10)})
+    p = b.bernoulli_prior("p", 0.5)
+    b.normal_likelihood("y_obs", p @ "X", 1.0, "y")
+    with pytest.raises(ValueError) as exc:
+        rustmc.sample(
+            b.build(), chains=1, draws=10, warmup=10, seed=1, show_progress=False
+        )
+    assert "Bernoulli" in str(exc.value)

--- a/tests/test_statistical_predictive.py
+++ b/tests/test_statistical_predictive.py
@@ -1,0 +1,261 @@
+"""Prior-predictive and posterior-predictive calibration through the Python API.
+
+``VALIDATION.md`` workstreams 1 (coverage) and 2 (calibration).
+
+Tolerances
+----------
+* Prior-predictive moment checks compare against exact closed forms.  The
+  Monte Carlo standard error of each estimate is computed from the *known*
+  variance of the estimator (accounting for the fact that observations sharing
+  a parameter draw are correlated), and the assertion allows 4 of them.
+* Posterior-predictive coverage is averaged over independent replicates whose
+  true parameters are drawn from the prior.  Under that design the nominal
+  coverage is exact, so the tolerance is 4 empirical standard errors of the
+  replicate-level coverage — measured from the run itself, not assumed.
+"""
+
+import numpy as np
+import pytest
+
+rustmc = pytest.importorskip("rustmc")
+
+K = 4.0
+
+
+def _fit(spec, seed, chains=2, draws=600, warmup=600):
+    return rustmc.sample(
+        spec,
+        chains=chains,
+        draws=draws,
+        warmup=warmup,
+        seed=seed,
+        threads=1,
+        show_progress=False,
+    )
+
+
+# ── Prior predictive ──────────────────────────────────────────────────────
+
+
+def test_prior_predictive_parameter_draws_match_closed_form_moments():
+    """``sample_prior_raw`` is a second, independent implementation of every
+    prior family (it draws directly rather than sampling the log density).
+    Its marginals must match the same closed forms the sampler reproduces.
+    """
+    n_samples = 40_000
+    y = np.zeros(5)
+
+    cases = [
+        # (builder call, exact mean, exact sd)
+        (lambda b: b.normal_prior("p", 1.5, 2.0), 1.5, 2.0),
+        (
+            lambda b: b.half_normal_prior("p", 1.3),
+            1.3 * np.sqrt(2 / np.pi),
+            1.3 * np.sqrt(1 - 2 / np.pi),
+        ),
+        (lambda b: b.exponential_prior("p", 2.0), 0.5, 0.5),
+        (
+            lambda b: b.log_normal_prior("p", -0.3, 0.5),
+            np.exp(-0.3 + 0.125),
+            np.sqrt((np.exp(0.25) - 1) * np.exp(-0.6 + 0.25)),
+        ),
+        (lambda b: b.gamma_prior("p", 3.0, 1.5), 3.0 / 1.5, np.sqrt(3.0) / 1.5),
+        (
+            lambda b: b.beta_prior("p", 2.0, 5.0),
+            2 / 7,
+            np.sqrt(2 * 5 / (49 * 8)),
+        ),
+        (lambda b: b.uniform_prior("p", -1.0, 3.0), 1.0, 4 / np.sqrt(12)),
+        (
+            lambda b: b.student_t_prior("p", 8.0, 0.4, 1.2),
+            0.4,
+            1.2 * np.sqrt(8 / 6),
+        ),
+    ]
+
+    for make, exact_mean, exact_sd in cases:
+        b = rustmc.ModelBuilder({"y": y})
+        p = make(b)
+        b.normal_likelihood("y_obs", p, 1.0, "y")
+        out = rustmc.sample_prior_predictive(b.build(), n_samples=n_samples, seed=7)
+        draws = np.asarray(out["p"])
+        assert draws.shape == (n_samples,)
+
+        se_mean = exact_sd / np.sqrt(n_samples)
+        assert abs(draws.mean() - exact_mean) <= K * se_mean, (
+            f"prior draws for {make}: mean {draws.mean():.5f} vs exact "
+            f"{exact_mean:.5f}, tolerance {K} * {se_mean:.5f}"
+        )
+        # sd of a sample sd: sigma * sqrt((kurtosis - 1) / (4 n)); we do not
+        # know the kurtosis for every family here, so bound it generously at
+        # 12 (heavier than any family in this list except LogNormal(0.5),
+        # whose kurtosis is 8.9).
+        se_sd = exact_sd * np.sqrt((12.0 - 1.0) / (4.0 * n_samples))
+        assert abs(draws.std(ddof=1) - exact_sd) <= K * se_sd, (
+            f"prior draws for {make}: sd {draws.std(ddof=1):.5f} vs exact "
+            f"{exact_sd:.5f}, tolerance {K} * {se_sd:.5f}"
+        )
+
+
+def test_prior_predictive_observations_match_the_marginal_distribution():
+    """For ``mu ~ N(m0, s0)`` and ``y_i ~ N(mu, sigma)`` the prior predictive
+    of ``y`` is exactly ``N(m0, sqrt(s0^2 + sigma^2))``."""
+    m0, s0, sigma = 0.5, 1.5, 0.8
+    n_obs, n_samples = 6, 20_000
+    b = rustmc.ModelBuilder({"y": np.zeros(n_obs)})
+    mu = b.normal_prior("mu", m0, s0)
+    b.normal_likelihood("y_obs", mu, sigma, "y")
+    out = rustmc.sample_prior_predictive(b.build(), n_samples=n_samples, seed=17)
+
+    yy = np.asarray(out["y_obs"])
+    assert yy.shape == (n_samples, n_obs)
+
+    exact_sd = np.sqrt(s0**2 + sigma**2)
+    # Observations within a draw share mu, so Var(overall mean) is
+    # s0^2 / n_samples + sigma^2 / (n_samples * n_obs), not exact_sd^2 / N.
+    se_mean = np.sqrt(s0**2 / n_samples + sigma**2 / (n_samples * n_obs))
+    assert abs(yy.mean() - m0) <= K * se_mean
+
+    # The per-column sd uses one observation per draw, so the draws are
+    # independent and the Gaussian sd standard error applies.
+    col_sd = yy[:, 0].std(ddof=1)
+    se_sd = exact_sd / np.sqrt(2 * n_samples)
+    assert abs(col_sd - exact_sd) <= K * se_sd, (
+        f"prior predictive sd {col_sd:.5f} vs exact {exact_sd:.5f}"
+    )
+
+
+def test_prior_predictive_respects_the_likelihood_support():
+    """Count and binary likelihoods must produce draws inside their support."""
+    n_obs, n_samples = 5, 2_000
+
+    b = rustmc.ModelBuilder({"y": np.zeros(n_obs)})
+    eta = b.normal_prior("eta", 0.0, 1.0)
+    b.bernoulli_logit_likelihood("y_obs", eta, "y")
+    out = rustmc.sample_prior_predictive(b.build(), n_samples=n_samples, seed=3)
+    vals = np.unique(np.asarray(out["y_obs"]))
+    assert set(vals.tolist()) <= {0.0, 1.0}
+
+    b = rustmc.ModelBuilder({"y": np.zeros(n_obs)})
+    eta = b.normal_prior("eta", 0.0, 0.5)
+    b.poisson_log_likelihood("y_obs", eta, "y")
+    out = rustmc.sample_prior_predictive(b.build(), n_samples=n_samples, seed=3)
+    yy = np.asarray(out["y_obs"])
+    assert (yy >= 0).all() and np.allclose(yy, np.round(yy))
+
+    b = rustmc.ModelBuilder({"y": np.ones(n_obs)})
+    eta = b.normal_prior("eta", 0.0, 0.5)
+    b.exponential_likelihood("y_obs", eta, "y")
+    out = rustmc.sample_prior_predictive(b.build(), n_samples=n_samples, seed=3)
+    assert (np.asarray(out["y_obs"]) > 0).all()
+
+
+# ── Posterior predictive ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("nominal", [0.5, 0.9])
+def test_posterior_predictive_interval_coverage_matches_nominal(nominal):
+    """Replicated coverage check.
+
+    Each replicate draws the true coefficients from the model's own prior and
+    simulates data, so the nominal coverage of a central posterior-predictive
+    interval is *exactly* ``nominal``.  We average the per-replicate coverage
+    and compare against ``nominal`` using the empirical standard error of the
+    replicate coverages, so the tolerance is measured rather than assumed.
+    """
+    reps = 16
+    n, sigma, prior_sd = 60, 0.8, 1.5
+    lo_q, hi_q = (1 - nominal) / 2, 1 - (1 - nominal) / 2
+
+    coverages = []
+    for r in range(reps):
+        rng = np.random.default_rng(1000 + r)
+        a_true, b_true = rng.normal(0, prior_sd, size=2)
+        x = rng.normal(size=n)
+        y = a_true + b_true * x + rng.normal(0, sigma, size=n)
+
+        builder = rustmc.ModelBuilder({"x": x, "y": y})
+        a = builder.normal_prior("a", 0.0, prior_sd)
+        bb = builder.normal_prior("b", 0.0, prior_sd)
+        builder.normal_likelihood("y_obs", a + bb * "x", sigma, "y")
+        fit = _fit(builder.build(), 2000 + r, chains=2, draws=500, warmup=500)
+
+        ppc = np.asarray(fit.posterior_predictive(seed=r)["y_obs"])
+        assert ppc.shape[1] == n
+        lo = np.quantile(ppc, lo_q, axis=0)
+        hi = np.quantile(ppc, hi_q, axis=0)
+        coverages.append(float(np.mean((y >= lo) & (y <= hi))))
+
+    coverages = np.array(coverages)
+    emp = coverages.mean()
+    se = coverages.std(ddof=1) / np.sqrt(reps)
+    assert abs(emp - nominal) <= K * se, (
+        f"posterior-predictive {nominal:.0%} interval covered {emp:.1%} of "
+        f"observations across {reps} replicates; |diff| {abs(emp - nominal):.4f} "
+        f"> {K} * empirical se ({se:.4f}); per-replicate coverages {coverages}"
+    )
+
+
+def test_posterior_predictive_mean_and_spread_match_the_analytic_predictive():
+    """For a known-sigma Gaussian linear model the posterior predictive of the
+    i-th observation is exactly ``N(x_i' m, sigma^2 + x_i' C x_i)`` where
+    ``(m, C)`` is the exact Gaussian posterior."""
+    rng = np.random.default_rng(55)
+    n, sigma, prior_sd = 70, 0.7, 2.0
+    x = rng.normal(size=n)
+    y = 0.4 + 0.9 * x + rng.normal(0, sigma, size=n)
+    X = np.column_stack([np.ones(n), x])
+
+    prior_prec = np.eye(2) / prior_sd**2
+    lam = prior_prec + X.T @ X / sigma**2
+    cov = np.linalg.inv(lam)
+    mean = cov @ (X.T @ y / sigma**2)
+
+    b = rustmc.ModelBuilder({"x": x, "y": y})
+    a = b.normal_prior("a", 0.0, prior_sd)
+    bb = b.normal_prior("b", 0.0, prior_sd)
+    b.normal_likelihood("y_obs", a + bb * "x", sigma, "y")
+    fit = _fit(b.build(), 303, chains=4, draws=1500, warmup=1000)
+
+    ppc = np.asarray(fit.posterior_predictive(seed=1)["y_obs"])
+    n_draws = ppc.shape[0]
+
+    exact_mean = X @ mean
+    exact_sd = np.sqrt(sigma**2 + np.einsum("ij,jk,ik->i", X, cov, X))
+
+    emp_mean = ppc.mean(axis=0)
+    emp_sd = ppc.std(axis=0, ddof=1)
+
+    # Draws are autocorrelated; take an effective sample size of n_draws / 10
+    # (conservative for a 2-parameter Gaussian target where the reported
+    # ess_bulk is typically > n_draws / 2).
+    ess = n_draws / 10.0
+    se_mean = exact_sd / np.sqrt(ess)
+    se_sd = exact_sd / np.sqrt(2 * ess)
+
+    assert np.all(np.abs(emp_mean - exact_mean) <= K * se_mean), (
+        "posterior predictive means deviate from the analytic predictive by "
+        f"up to {np.max(np.abs(emp_mean - exact_mean) / se_mean):.2f} standard errors"
+    )
+    assert np.all(np.abs(emp_sd - exact_sd) <= K * se_sd), (
+        "posterior predictive sds deviate from the analytic predictive by "
+        f"up to {np.max(np.abs(emp_sd - exact_sd) / se_sd):.2f} standard errors"
+    )
+
+
+def test_posterior_predictive_is_reproducible_and_respects_n_samples():
+    rng = np.random.default_rng(66)
+    n = 30
+    y = rng.normal(size=n)
+    b = rustmc.ModelBuilder({"y": y})
+    mu = b.normal_prior("mu", 0.0, 2.0)
+    b.normal_likelihood("y_obs", mu, 1.0, "y")
+    fit = _fit(b.build(), 404, chains=2, draws=200, warmup=200)
+
+    first = np.asarray(fit.posterior_predictive(n_samples=50, seed=9)["y_obs"])
+    second = np.asarray(fit.posterior_predictive(n_samples=50, seed=9)["y_obs"])
+    np.testing.assert_array_equal(first, second)
+    assert first.shape == (50, n)
+
+    other = np.asarray(fit.posterior_predictive(n_samples=50, seed=10)["y_obs"])
+    assert not np.array_equal(first, other), "the ppc seed has no effect"


### PR DESCRIPTION
Builds the evidence that rustmc samples from the intended posterior, rather than asserting it. Tests only — no engine source is touched.

## What's added

**Rust** (`rust_core/tests/`, 46 new tests + 6 opt-in)

| file | what it establishes |
|---|---|
| `gradient_check.rs` | `grad_logp` equals the finite-difference gradient of `eval_logp` for every op, prior, likelihood, transform, and at extreme parameter values |
| `prior_recovery.rs` | prior-only sampling reproduces each family's closed-form mean and sd — the test that catches a wrong or missing Jacobian |
| `analytic_posterior.rs` | posterior mean **and** sd vs exact conjugate, linear-Gaussian, matvec and hierarchical references |
| `sbc.rs` | simulation-based calibration, credible-interval coverage, a permanent negative control |
| `likelihood_recovery.rs` | Exponential / LogNormal / NegativeBinomial GLMs, high-dimensional `MatVecMul`, hierarchical shrinkage |
| `numerical_stability.rs` | determinism, thread-independence, sigma from 1e-4 to 1e4, n=1, n=6000, collinearity, shape errors |
| `common/mod.rs` | shared MCSE-derived assertions + the tolerance rationale |

**Python** (`tests/test_statistical_*.py`, 18 passing + 5 pinned xfails): the same analytic references through the public DSL, prior/posterior-predictive calibration, and reproducers for every defect found.

**Docs**: `VALIDATION_RESULTS.md` (results, methodology, defects, gaps, DSL support vs spec) and `VALIDATION.md` updated.

## Tolerances

Nothing was widened to pass. Posterior means use `4 x mcse_mean`; posterior sds use the delta-method standard error `5 x sigma sqrt((kurtosis-1)/(4 ess))` with each family's true kurtosis; finite differences carry an explicit `eps |logp| / h` cancellation term; SBC uses chi-square at `p < 1e-3` with a documented power table.

**Negative control:** injecting a 15% scale error into `Normal::prior` makes three tests fail with precise diagnostics (e.g. `posterior sd 1.599 differs from analytic 1.400 by 14.22% relative, tolerance 4.57%`). Reverted afterwards. `sbc_detects_an_injected_bias` is a permanent always-on control (`chi2 = 65.9, p = 1e-11`).

## Results

Autodiff, all constraining transforms, all analytic posteriors, all predictive checks and SBC across 5 models x 512 replicates: **clean**. Zero post-warmup divergences on every analytic test.

## Defects found (pinned, not fixed)

1. **Hierarchical models do not run through the Python DSL.** Any prior with a `ParamRef` hyperparameter is auto-non-centered to `<name>__raw`; its derived value node is never visible to `Graph::node_by_name`, so using it in a likelihood raises `ValueError: Unknown param`. `examples/hierarchical_example.py` and `examples/hierarchical_templates.py` are broken. (Task 1's area.)
2. **`sample_prior_predictive` panics** on `@`-auto-promoted vector parameters — `sample_prior_raw` pushes one raw value instead of `n` for Normal/HalfNormal/StudentT/Uniform/Gamma/Beta.
3. **Reported divergences include warmup** — 21 reported vs 0 real on a conjugate Normal-Normal. The per-draw flags to split it already exist in `SampleResult::transitions`.
4. **`to_arviz()` discards per-draw divergence flags** it claims are not stored.
5. Two NUTS observations: the whole transition is rejected on any divergence (Stan keeps the valid-subtree proposal), and the accept statistic fed to dual averaging is `min(sum w, n_leaves)` rather than `sum min(1, w)`.

## Reproduced miscalibration

SBC at 512 replicates shows the **centered** hierarchical parameterisation is miscalibrated for `tau`: rank histogram `[113, 50, 49, 46, 60, 57, 74, 63]`, `chi2 = 51.75`, `p = 1.5e-8`, and the nominal 75% credible interval covers 65.6%. The non-centered form of the same model is clean, which localises it to the parameterisation. It matters because the shipped template builds the centered form and the DSL's non-centering is unreachable (defect 1). Pinned as a characterisation test that fires if the geometry handling improves.

## Runtime

`cargo test --all`: 88 passed, ~254 s (was 39 / ~132 s). Six higher-power SBC tests are `#[ignore]`d (~40 s in release, opt in with `--ignored`). `pytest tests/`: 18 passed, 5 xfailed, ~5 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)