### PR TITLE
Add Bayesian forecasting regressors, batches, sparse amounts and runoff for 0.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - name: Verify synchronized package/dependency/lock versions
+        run: python3 scripts/verify_version.py
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       # Statistical recovery tests exercise thousands of gradient evaluations;
@@ -105,17 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          EXPECTED="${TAG#v}"
-          for f in rust_core/Cargo.toml python_bindings/Cargo.toml pyproject.toml; do
-            V=$(grep '^version = ' "$f" | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
-            if [ "$V" != "$EXPECTED" ]; then
-              echo "::error::$f has version $V but tag is $TAG (expected $EXPECTED)"
-              exit 1
-            fi
-          done
-          echo "Version $EXPECTED matches tag $TAG"
+      - run: python3 scripts/verify_version.py
 
   build:
     name: Build wheel (${{ matrix.target }})
@@ -129,11 +121,11 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - os: macos-latest
+          - os: macos-15-intel
             target: x86_64-apple-darwin
-          - os: macos-latest
+          - os: macos-14
             target: aarch64-apple-darwin
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -142,12 +134,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.11"
       - uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --manifest-path python_bindings/Cargo.toml -i python3.9
+          args: --release --out dist --manifest-path python_bindings/Cargo.toml -i python3.11
           manylinux: auto
+      # Test this exact platform artifact, then upload the same file.
+      - name: Verify release wheel in a clean native environment
+        run: python scripts/test_release_artifact.py wheel
       - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.target }}
@@ -155,15 +150,21 @@ jobs:
 
   sdist:
     name: Source distribution
-    needs: version-check
+    needs: [version-check, python-source-install, python-wheel-install]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
       - uses: PyO3/maturin-action@v1
         with:
           command: sdist
           args: --out dist --manifest-path python_bindings/Cargo.toml
+      - name: Verify release source archive in a clean environment
+        run: python scripts/test_release_artifact.py sdist
       - uses: actions/upload-artifact@v4
         with:
           name: sdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,8 @@ jobs:
           ${{ github.workspace }}/tests
 
   version-check:
-    name: Version matches tag
+    name: Release versions
     needs: test
-    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +113,8 @@ jobs:
     # A tag must not reach the publish path unless both source installs and
     # clean-wheel installs passed across the advertised Python matrix.
     needs: [version-check, python-source-install, python-wheel-install]
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Exercise the release platforms before merging, as well as on release tags.
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
     strategy:
       fail-fast: false
       matrix:
@@ -151,7 +151,7 @@ jobs:
   sdist:
     name: Source distribution
     needs: [version-check, python-source-install, python-wheel-install]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ versioning while the public API is stabilized.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-09-08
+
+### Added
+
+- Joint Bayesian exogenous regression for local-level, seasonal, and trend forecasts,
+  with proper Gaussian coefficient priors and paired coefficient/state/variance draws.
+- Time-varying observation rows in fixed Gaussian state-space models and explicit
+  future-design validation, including joint and cumulative forecast covariance.
+- Native independent forecasting batches with stable cell seeds, ragged histories,
+  per-cell models/designs, controlled worker counts, and collected cell errors.
+- Sampler-aware parameter diagnostics for forecasting fits, including coefficients
+  and retained terminal states; Gibbs telemetry does not invent divergences or
+  acceptance rates.
+- Fourier calendar designs with explicit phase and Nyquist handling. Stochastic
+  seasonal fits now accept short histories with at least two finite observations.
+- A hurdle model for nonnegative amounts with static uncertain occurrence
+  probability and dynamic lognormal severity under upper-truncated inverse-gamma
+  variance priors, including exact zeros and all-zero histories.
+- Count-only payment runoff with shared Dirichlet lag probabilities, known or
+  inferred ultimate counts, prefix censoring, and an explicit unscheduled tail.
+  It does not model continuous currency allocations or couple separate accrual fits.
+
+### Fixed
+
+- Guarded oversized forecasting/runoff allocations and sparse large-count binomial
+  draws; strengthened version checks across manifests, dependencies, and the lockfile.
+
+### Packaging
+
+- Prepared synchronized Rust and Python 0.11.0 metadata. Release uploads require
+  verification of the built wheel or source archive before artifact publication.
+
 ## [0.10.0] - 2026-08-04
 
 ### Added
@@ -84,7 +116,8 @@ versioning while the public API is stabilized.
 
 - Last public PyPI release before the fitted forecasting and 0.9 correctness work.
 
-[Unreleased]: https://github.com/tbosier/rustmc/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/tbosier/rustmc/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/tbosier/rustmc/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/tbosier/rustmc/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/tbosier/rustmc/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/tbosier/rustmc/releases/tag/v0.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustmc"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ndarray",
  "numpy",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "rustmc_core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "faer",
  "ndarray",

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ the current Gaussian fitted APIs.
 
 Forecasting examples:
 
+- [`examples/payment_triangle_runoff.py`](examples/payment_triangle_runoff.py): integer-event development with known or uncertain ultimates; [model and data contract](docs/runoff.md).
 - [`examples/rebate_accrual_forecast.py`](examples/rebate_accrual_forecast.py)
 - [`examples/bayesian_local_level_forecasting.py`](examples/bayesian_local_level_forecasting.py)
 - [`examples/bayesian_seasonal_forecasting.py`](examples/bayesian_seasonal_forecasting.py)

--- a/README.md
+++ b/README.md
@@ -208,9 +208,21 @@ total_interval = np.quantile(six_period_totals, [0.025, 0.975])
 The observation interval is posterior predictive; the latent-level interval is a
 credible interval for the expected level. Applications include demand, operations,
 sensor data, and financial series such as rebate accruals. Rebate payments are only an
-example: seasonal settlement timing, zeros, contract drivers, and positive support need
-careful priors and may need calendar, covariate, hurdle, or positive-valued models beyond
-the current Gaussian fitted APIs.
+example: choose a model for settlement timing, zeros, contract drivers, and positive
+support, with priors matched to observation units.
+
+The fitted Gaussian models support [joint Bayesian regressors and Fourier calendar
+terms](docs/regression-forecasting.md), including known future design rows. Calendar
+coefficients, structural states, and variance parameters remain aligned in posterior
+forecast paths. [Native independent batches](docs/forecast-batches.md) fit ragged cells
+with stable IDs, explicit worker limits, per-cell diagnostics, and collected errors.
+Annual seasonal models accept histories shorter than two full cycles under proper priors.
+
+For sparse nonnegative amounts, [BayesianHurdleLogNormal](docs/sparse-amounts.md)
+combines a learned zero probability with dynamic positive severity and bounded log
+variances. [DirichletMultinomialRunoff](docs/runoff.md) models payment-event counts by
+cohort and lag, including unknown ultimate counts and an explicit unscheduled tail.
+Runoff count inputs represent events; currency amounts need an amount model.
 
 Forecasting examples:
 
@@ -230,11 +242,11 @@ Forecasting examples:
 | Continuous priors | Normal, Student-t, HalfNormal, Exponential, LogNormal, Gamma, Beta, Uniform |
 | Likelihoods | Normal, Bernoulli-logit, Poisson-log, Exponential, LogNormal, Negative Binomial |
 | Model structure | Joint ragged hierarchical means, scalar hierarchical priors, scalar/vector regression expressions, automatic non-centering for supported generic scalar hierarchies |
-| Diagnostics | Rank-normalized folded split R-hat, rank-normalized bulk/tail ESS, MCSE, empirical 94% HDI, divergences and acceptance summaries |
+| Diagnostics | Rank-normalized folded split R-hat, bulk/tail ESS, MCSE and HDIs on generic and specialized fits; sampler-specific divergence/acceptance metadata |
 | Predictive workflow | Prior predictive, posterior predictive, pointwise log likelihood, ArviZ export |
-| Repeated models | In-memory compile/bind reuse and parallel batch sampling |
-| Fixed state space | Time-homogeneous linear-Gaussian models, Kalman filter, RTS smoother, missing observations, a seasonal constructor, joint and cumulative conditional forecasts |
-| Specialized inference | Bayesian local level, seasonal local level, local linear trend, and directly observed Gaussian AR(p) |
+| Repeated models | In-memory compile/bind reuse, generic batch sampling, and independent forecasting batches with stable cell IDs |
+| Fixed state space | Constant transitions and time-varying observation rows, Kalman filter, RTS smoother, missing observations, joint and cumulative conditional forecasts |
+| Specialized inference | Bayesian level/trend/seasonal regression, Fourier calendar features, Gaussian AR(p), sparse hurdle lognormal, and payment-count runoff |
 
 Bernoulli and Poisson are exposed for prior-predictive use, but discrete latent
 parameters are not suitable for the current gradient-based samplers. Fitted AR(p)

--- a/benchmarks/forecast_batch.py
+++ b/benchmarks/forecast_batch.py
@@ -1,0 +1,60 @@
+"""Reproducible batch throughput/peak-RSS probe; outputs JSON, no speedup claims.
+
+Run each thread count in a separate process so peak RSS is comparable:
+    python benchmarks/forecast_batch.py --threads 1
+    python benchmarks/forecast_batch.py --threads 4
+"""
+import argparse
+import json
+import platform
+import resource
+import subprocess
+import time
+
+import numpy as np
+import rustmc as rmc
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--threads", type=int, default=1)
+    parser.add_argument("--cells", type=int, default=128)
+    args = parser.parse_args()
+    rng = np.random.default_rng(914)
+    observations = []
+    for cell in range(args.cells):
+        count = 48 + cell % 13
+        level = np.cumsum(rng.normal(0, 0.2, count))
+        observations.append(level + rng.normal(0, 0.4, count))
+    ids = [f"cell/{i}" for i in range(args.cells)]
+    prior = rmc.InverseGammaPrior(3.0, 0.3)
+    model = rmc.BayesianLocalLevel(process_variance_prior=prior,
+                                   observation_variance_prior=prior)
+    started = time.perf_counter()
+    batch = model.fit_batch(observations, ids, chains=4, draws=200, warmup=100,
+                            seed=91, threads=args.threads, chunk_size=32)
+    fit_seconds = time.perf_counter() - started
+    started = time.perf_counter()
+    forecast = batch.forecast(12, seed=92, threads=args.threads, chunk_size=32)
+    forecast_seconds = time.perf_counter() - started
+    # Diagnostics are outside throughput timings and use every retained cell.
+    report = batch.diagnostics()
+    parameters = [parameter for cell in report.values() for parameter in cell]
+    print(json.dumps({
+        "revision": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+        "platform": platform.platform(), "python": platform.python_version(),
+        "numpy": np.__version__, "threads": args.threads, "cells": args.cells,
+        "chains": 4, "draws": 200, "warmup": 100, "history_range": [48, 60],
+        "horizon": 12, "chunk_size": 32, "fit_seed": 91, "forecast_seed": 92,
+        "fit_seconds": fit_seconds, "fit_cells_per_second": args.cells / fit_seconds,
+        "forecast_seconds": forecast_seconds,
+        "peak_rss_kib_linux": resource.getrusage(resource.RUSAGE_SELF).ru_maxrss,
+        "max_rhat": max(parameter["r_hat"] for parameter in parameters),
+        "min_bulk_ess": min(parameter["ess_bulk"] for parameter in parameters),
+        "min_tail_ess": min(parameter["ess_tail"] for parameter in parameters),
+        "retained_fit_cells": len(batch), "retained_forecast_cells": len(forecast),
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/results/2026-09-08-forecast-batch-threads1.json
+++ b/benchmarks/results/2026-09-08-forecast-batch-threads1.json
@@ -1,0 +1,33 @@
+{
+  "revision": "0474d4669920c2b52d9ddbd4d1143037d8e7897d",
+  "platform": "Linux-6.18.46-1-lts-x86_64-with-glibc2.44",
+  "python": "3.12.9",
+  "numpy": "2.4.2",
+  "threads": 1,
+  "cells": 128,
+  "chains": 4,
+  "draws": 200,
+  "warmup": 100,
+  "history_range": [
+    48,
+    60
+  ],
+  "horizon": 12,
+  "chunk_size": 32,
+  "fit_seed": 91,
+  "forecast_seed": 92,
+  "fit_seconds": 0.20348923599522095,
+  "fit_cells_per_second": 629.0259009228682,
+  "forecast_seconds": 0.037272756002494134,
+  "peak_rss_kib_linux": 73384,
+  "max_rhat": 1.1149524939320552,
+  "min_bulk_ess": 27.921802278250436,
+  "min_tail_ess": 47.18146388504586,
+  "retained_fit_cells": 128,
+  "retained_forecast_cells": 128,
+  "cpu": "AMD Ryzen 9 5900X 12-Core Processor",
+  "logical_cpus": 24,
+  "rustc": "rustc 1.89.0 (29483883e 2025-08-04)",
+  "command": "/tmp/rustmc-011-batch-py312/bin/python benchmarks/forecast_batch.py --threads 1",
+  "quality_gate_passed": false
+}

--- a/benchmarks/results/2026-09-08-forecast-batch-threads4.json
+++ b/benchmarks/results/2026-09-08-forecast-batch-threads4.json
@@ -1,0 +1,33 @@
+{
+  "revision": "0474d4669920c2b52d9ddbd4d1143037d8e7897d",
+  "platform": "Linux-6.18.46-1-lts-x86_64-with-glibc2.44",
+  "python": "3.12.9",
+  "numpy": "2.4.2",
+  "threads": 4,
+  "cells": 128,
+  "chains": 4,
+  "draws": 200,
+  "warmup": 100,
+  "history_range": [
+    48,
+    60
+  ],
+  "horizon": 12,
+  "chunk_size": 32,
+  "fit_seed": 91,
+  "forecast_seed": 92,
+  "fit_seconds": 0.06076647499867249,
+  "fit_cells_per_second": 2106.4246363277825,
+  "forecast_seconds": 0.011632289009867236,
+  "peak_rss_kib_linux": 72928,
+  "max_rhat": 1.1149524939320552,
+  "min_bulk_ess": 27.921802278250436,
+  "min_tail_ess": 47.18146388504586,
+  "retained_fit_cells": 128,
+  "retained_forecast_cells": 128,
+  "cpu": "AMD Ryzen 9 5900X 12-Core Processor",
+  "logical_cpus": 24,
+  "rustc": "rustc 1.89.0 (29483883e 2025-08-04)",
+  "command": "/tmp/rustmc-011-batch-py312/bin/python benchmarks/forecast_batch.py --threads 4",
+  "quality_gate_passed": false
+}

--- a/benchmarks/results/2026-09-08-forecast-batch.md
+++ b/benchmarks/results/2026-09-08-forecast-batch.md
@@ -1,0 +1,31 @@
+# Independent forecasting batch probe
+
+These are single-run operational probes of revision `0474d4669920c2b52d9ddbd4d1143037d8e7897d`,
+not a stable performance comparison. Both processes fitted the same seeded 128
+ragged local-level series (48–60 observations), four chains, 100 warmup iterations,
+200 retained draws, then 12-step forecasts. The simulated process SD was 0.2 and
+observation SD 0.4; both variances were inferred under IG(3, 0.3) priors. CPU,
+platform, versions, exact commands, seeds and all controls are retained in the raw
+[one-worker](2026-09-08-forecast-batch-threads1.json) and
+[four-worker](2026-09-08-forecast-batch-threads4.json) output. Builds used
+`maturin develop --release --offline`, `CARGO_BUILD_JOBS=2`, and an isolated target
+and Python environment. The private pool's explicit worker count controls Rayon;
+no BLAS operations are involved in this scalar kernel.
+
+| Probe | Fit including warmup | Forecast | Peak process RSS |
+|---|---:|---:|---:|
+| 1 worker | 0.20349 s | 0.03727 s | 73,384 KiB |
+| 4 workers | 0.06077 s | 0.01163 s | 72,928 KiB |
+
+Compilation/import/data generation and diagnostics are outside the measured fit
+and forecast phases. RSS includes both retained fits and forecasts, Python imports,
+and subsequent diagnostic calculation. Sampling and warmup are not timed separately.
+There is no comparison to another inference engine or posterior-recovery claim.
+
+The maximum rank-normalized folded split R-hat was **1.115**, minimum bulk ESS
+**27.9**, and minimum tail ESS **47.2** in both runs. This short sampler schedule
+**fails convergence-quality criteria** and is not suitable for final inference.
+Gibbs has no Hamiltonian divergences or Metropolis acceptance statistic. Retained
+streams were independently tested to be identical under thread, ordering, and
+chunk changes. A repeated, longer schedule with acceptable diagnostics is needed
+before claiming useful inference throughput or a stable speedup.

--- a/docs/forecast-batches.md
+++ b/docs/forecast-batches.md
@@ -79,3 +79,22 @@ metrics (`None` in Python). Infinite R-hat is retained when it detects separated
 chains. A one-chain fit can have split diagnostics, but
 `independent_chain_comparison=False` makes clear that it cannot compare independent
 chains. Finite diagnostics do not prove convergence, identification, or model adequacy.
+
+Regression batches accept `exog=[X_cell, ...]` and
+`coefficient_priors=[GaussianCoefficientPrior(...), ...]`. Both lists align with
+`ids`; `None` entries select an ordinary non-regression cell. Designs may differ in
+history length and coefficient count across cells. Supply the corresponding
+`exog=[X_future_cell, ...]` to `batch.forecast(steps, ...)`. Missing or malformed
+future designs are per-cell errors; a design is also rejected for a cell fitted
+without regression. Static Fourier designs from `fourier_design` use this same
+contract, preserving their time origin in the future rows. Regression diagnostics
+include every coefficient, variance, and terminal structural state coordinate.
+
+Batch calls reject more than 25,000,000 retained scalar values (approximately 200 MB
+of raw float storage, excluding containers), using conservative component counts.
+Each cell also checks a conservative dense FFBS workspace estimate against this
+limit. Oversized individual cells produce collected errors; a combined retained
+budget overflow is a batch-level error. Checked products reject counts/horizons
+that would otherwise overflow allocation sizes. These are allocation guards, not
+an exact peak-RSS guarantee. Use smaller caller-managed batches to retain larger
+workloads, and reduce draws or model dimension for a single oversized cell.

--- a/docs/forecast-batches.md
+++ b/docs/forecast-batches.md
@@ -1,0 +1,81 @@
+# Independent forecasting batches and diagnostics
+
+`BayesianLocalLevel`, `BayesianSeasonalLocalLevel`, `BayesianLocalLinearTrend`,
+and `BayesianAR` expose native independent-cell fitting:
+
+```python
+import numpy as np
+import rustmc as rmc
+
+prior = rmc.InverseGammaPrior(3.0, 0.4)
+model = rmc.BayesianLocalLevel(
+    process_variance_prior=prior, observation_variance_prior=prior,
+)
+batch = model.fit_batch(
+    [np.array([0.2, 0.4, np.nan, 0.7]), np.array([1.0, 0.9, 1.2])],
+    ids=["north", "south"],
+    chains=4, draws=500, warmup=250, seed=42,
+    threads=4, chunk_size=32, errors="collect",
+)
+print(batch.ids, batch.errors)
+print(batch["north"].summary())
+forecast = batch.forecast(12, seed=43, threads=4, errors="collect")
+paths = forecast["north"].observation_samples  # chain × draw × horizon
+```
+
+`ids` are required, unique, exact UTF-8 strings; returned order matches input order.
+`models=[model_for_north, model_for_south]` supplies per-cell priors and structural
+configuration, including different seasonal periods or AR orders. An entry of
+`None` uses the calling model. Histories may be ragged. Missing observations retain
+their time positions for the state-space models; AR continues to require finite
+histories. Sampling controls are shared across the call. AR uses exact independent
+conjugate draws and ignores batch `warmup`/`thin`.
+
+`errors="collect"` returns successful fits alongside a mapping of cell ID to error
+text. Both validation and numerical errors are isolated; failed entries in `.results`
+are `None`, and indexing a failed ID raises its error. `errors="raise"` stops
+scheduling work after an observed failure; already-running workers may finish.
+Duplicate IDs, wrong batch lengths, or invalid execution options always raise.
+`batch.diagnostics()` maps successful IDs to parameter reports and failed IDs to
+`None`. Forecast errors follow the same contract, including previous fit failures.
+
+One private Rayon pool serves the entire call, including nested chain work. `threads`
+and `chunk_size` must be positive; the default worker limit is one. Native execution
+releases the GIL. `chunk_size` bounds cells dispatched simultaneously; it **does not**
+bound retained output memory. Fit objects retain all posterior parameter draws, and
+forecast objects retain all joint paths. For bounded retention, submit slices of a
+larger workload, persist their summaries or draws, then release each batch before
+submitting the next slice. Accessing `.results` or an individual fit/forecast creates
+an owned copy. Avoid keeping both copies for large workloads.
+
+Seeds depend on `(seed, cell_id, domain)` followed by each sampler's existing
+model/domain/chain derivation, never cell position or worker scheduling. The cell
+encoding is version-one FNV-1a over ASCII `rustmc-cell-v1`, the 64-bit little-endian
+seed, the 64-bit little-endian UTF-8 ID byte length, ID bytes, and domain bytes
+(`fit` or `forecast`). `forecast_cell_seed(seed, cell_id, domain="fit")` exposes this
+contract for single-cell reproduction. Keep seeds and IDs unchanged when reordering,
+chunking, subsetting, or resuming. Different chains and cells use distinct streams;
+64-bit hashes have the usual theoretical collision possibility. IDs are not Unicode
+normalized. Exact numerical reproducibility is guaranteed for the same build and
+platform; floating-point libraries can differ across platforms.
+
+Batch forecasts preserve each model's paired posterior parameters and coherent future
+path. Aggregation across cells represents independent series and introduces no shared
+shocks or hierarchical dependence.
+
+All four fitted models and hierarchical Gibbs fits expose `summary()`, `diagnostics()`,
+and a `sampler_stats` dictionary. Parameter reports reuse rank-normalized folded split
+R-hat, bulk/tail ESS, mean MCSE, and 94% empirical HDIs. These HDIs summarize parameter
+draws; forecast intervals retain their existing equal-tailed semantics. Local and trend
+reports cover learned variances and retained terminal states. Seasonal reports include
+**every** terminal seasonal state coordinate; AR reports cover all coefficients and
+innovation variance. Historical latent states are not retained by these models.
+
+Gibbs/FFBS and exact conjugate sampling have no Hamiltonian divergences or Metropolis
+acceptance rate: both statistics are `None`. `numerical_failures=0` describes a successful
+fit; numerical failures terminate the affected cell and appear separately in batch
+errors. Nonfinite, constant, or fewer-than-six-draw traces have unavailable convergence
+metrics (`None` in Python). Infinite R-hat is retained when it detects separated constant
+chains. A one-chain fit can have split diagnostics, but
+`independent_chain_comparison=False` makes clear that it cannot compare independent
+chains. Finite diagnostics do not prove convergence, identification, or model adequacy.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -197,9 +197,10 @@ lower, upper = seasonal_forecast.interval(0.95)
 cumulative_lower, cumulative_upper = seasonal_forecast.cumulative_interval(0.95)
 ```
 
-With 24 monthly observations, a period-12 model sees only two cycles. It can be fit, but
-seasonal and variance inference will be prior-sensitive and requires rolling-origin
-comparison against simple seasonal baselines.
+Seasonal models require at least two finite observations, with no full-cycle minimum.
+Short histories can be fit, but seasonal and variance inference can be prior-sensitive;
+compare rolling-origin forecasts against simple seasonal baselines. For exogenous
+regressors and compact Fourier seasonality, see [regression forecasting](regression-forecasting.md).
 
 For a fitted stochastic level and slope:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,12 +79,19 @@ MCSE, empirical 94% HDI, divergence detection, and per-chain acceptance rates.
 graph structure.
 
 **Linear Gaussian state space:** `LinearGaussianStateSpace` provides fixed-system
-Kalman filtering, smoothing, missing-observation handling, and forecasting.
+Kalman filtering, smoothing, missing-observation handling, and forecasting, with
+optional time-varying observation rows.
 
 **Forecasting application:** fitted local-level, seasonal local-level, and local-linear-trend structural models
 provide FFBS/Gibbs posterior prediction, while `BayesianAutoRegression(order=p)` supports
 directly observed Gaussian AR(p) at any positive lag order. All return coherent paths and
 parameter-integrated pointwise intervals.
+
+The Gaussian forecasting models support [joint Bayesian exogenous regressors and
+Fourier seasonality](regression-forecasting.md), [independent cell batches and
+diagnostics](forecast-batches.md), and seasonal histories shorter than two cycles.
+Specialized [sparse amount](sparse-amounts.md) and [payment-count runoff](runoff.md)
+models handle zeros and censored cohort development with explicit statistical contracts.
 
 ## What Is Still Missing
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -216,7 +216,7 @@ requires two finite observations, with no full-cycle minimum. Short histories ca
 strongly sensitive to initial-state and variance priors. The regression extension and
 `fourier_design` provide a smaller harmonic model for long periods.
 
-All specialized fits expose `summary()`, `diagnostics()`, and `sampler_stats()`.
+All specialized fits expose `summary()`, `diagnostics()`, and `sampler_stats`.
 Hamiltonian divergences and acceptance are unavailable for Gibbs/FFBS and exact
 conjugate sampling. [Independent batches](forecast-batches.md) preserve cell identity
 and return per-cell fits, errors, diagnostics, and forecasts.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -174,8 +174,10 @@ and observation noise. It is not a simultaneous trajectory band.
 
 `NaN` retains a missing time step and infinities are rejected. Fitting requires at
 least two finite observations. This specialized model assumes equally spaced scalar
-Gaussian observations; seasonality, covariates, and irregular timestamps are not part
-of this model. Gibbs output remains finite
+Gaussian observations. Add known covariates with `fit(..., exog=X,
+coefficient_prior=GaussianCoefficientPrior(...))` and supply future `exog` to the
+returned regression fit. See [regression and Fourier forecasting](regression-forecasting.md).
+Irregular timestamps are not modeled automatically. Gibbs output remains finite
 MCMC output, so inspect multiple-chain convergence and effective sample sizes rather
 than treating it as an analytic posterior.
 
@@ -209,8 +211,19 @@ formed inside each posterior draw before quantiles are calculated.
 
 The fitted model is equally spaced, scalar, Gaussian, and single-seasonal. Seasonal
 innovations preserve structural identification but do not force every realized rolling
-cycle to sum exactly to zero. Missing values retain their time positions. With only two
-observed cycles, variance and seasonal inference is necessarily prior-sensitive.
+cycle to sum exactly to zero. Missing values retain their time positions. Fitting
+requires two finite observations, with no full-cycle minimum. Short histories can be
+strongly sensitive to initial-state and variance priors. The regression extension and
+`fourier_design` provide a smaller harmonic model for long periods.
+
+All specialized fits expose `summary()`, `diagnostics()`, and `sampler_stats()`.
+Hamiltonian divergences and acceptance are unavailable for Gibbs/FFBS and exact
+conjugate sampling. [Independent batches](forecast-batches.md) preserve cell identity
+and return per-cell fits, errors, diagnostics, and forecasts.
+
+For [sparse amounts](sparse-amounts.md), use `BayesianHurdleLogNormal`; for
+[payment-event triangles](runoff.md), use `DirichletMultinomialRunoff`. Their data,
+prior, and inference contracts are documented separately from Gaussian forecasting.
 
 ## Bayesian local-linear-trend forecasting
 

--- a/docs/regression-forecasting.md
+++ b/docs/regression-forecasting.md
@@ -1,0 +1,109 @@
+# Regression and calendar seasonality
+
+`BayesianLocalLevel`, `BayesianLocalLinearTrend`, and
+`BayesianSeasonalLocalLevel` accept keyword-only `exog` and `coefficient_prior`
+arguments in `fit`. An exogenous fit returns `BayesianRegressionFit`. Fits without
+exogenous data retain their original result classes and sampling paths.
+
+```python
+import numpy as np
+import rustmc as rmc
+
+model = rmc.BayesianLocalLevel(
+    rmc.InverseGammaPrior(3.0, 0.08),
+    rmc.InverseGammaPrior(3.0, 0.4),
+    initial_mean=0.0, initial_variance=4.0,
+)
+X = np.column_stack([promotion, price_change]).astype(float)
+prior = rmc.GaussianCoefficientPrior(
+    mean=np.zeros(2), covariance=np.diag([1.0, 0.25]),
+)
+fit = model.fit(y, exog=X, coefficient_prior=prior,
+                chains=4, draws=1000, warmup=500, seed=42)
+forecast = fit.forecast(steps=12, exog=X_future, seed=43)
+lower, upper = forecast.interval(0.95)
+cumulative_lower, cumulative_upper = forecast.cumulative_interval(0.95)
+```
+
+Choose coefficient and variance priors for the scales of your observations and
+features. Coefficient covariance must be finite, symmetric, and strictly positive
+definite. The coefficient prior is independent of the variance priors. Coefficients
+remain uncertain and constant through time; the observation design changes.
+The model samples coefficients and structural states together with augmented-state
+FFBS, then updates each variance from those same sampled states and residuals.
+The coefficient block has exactly zero process noise.
+
+Training `exog` must have shape `(len(y), features)` and contain finite numbers,
+including at missing observations. `NaN` in `y` preserves the calendar position;
+infinite observations are rejected. At least two finite observations are required.
+Every forecast requires finite future `exog` with shape `(steps, features)`.
+Columns have positional identity: supply them in the same order used for fitting.
+The API cannot detect a caller swapping equally shaped columns. Constant or
+collinear columns are allowed under proper priors, but their separate effects can
+remain weakly identified, especially alongside a structural level or trend.
+
+`get_samples_2d()` retains variance arrays with shape `(chains, draws)`,
+`coefficients` with shape `(chains, draws, features)`, and `terminal_state` with
+shape `(chains, draws, structural_dimension)`. Every forecast uses its corresponding
+joint coefficient, terminal-state, and variance draw. Forecast sample arrays have
+shape `(chains, draws, steps)`:
+
+- `regression_samples` is the contribution `X_future @ beta`.
+- `level_samples` (also `state_samples`) is the structural level.
+- `slope_samples` or `seasonal_samples` exposes the applicable structural component.
+- `mean_samples` is the complete conditional mean, including regression.
+- `observation_samples` includes future observation noise.
+- `cumulative_observation_samples` sums the same observation path over time.
+
+Intervals are pointwise equal-tailed posterior-predictive intervals. Forecasts are
+conditional on supplied future features; random future feature scenarios are not
+modeled. Static uncertain coefficients do not implement time-varying coefficients.
+Dense augmented FFBS costs approximately `O(T * (structural_dimension + features)^3)`
+per iteration. Designs with many features therefore need measured runtime planning.
+
+## Fourier seasonality and short histories
+
+`fourier_design(count, period, harmonics, start=0)` produces sine/cosine calendar
+columns. Use an explicit small number of harmonics and regularizing coefficient
+priors. This is fixed harmonic seasonality; it differs from stochastic dummy
+seasonality in `BayesianSeasonalLocalLevel`.
+
+```python
+period, harmonics = 12, 2
+X = rmc.fourier_design(len(y), period, harmonics)
+prior = rmc.GaussianCoefficientPrior(np.zeros(X.shape[1]),
+                                     0.5 * np.eye(X.shape[1]))
+fit = model.fit(y, exog=X, coefficient_prior=prior)
+X_future = rmc.fourier_design(12, period, harmonics, start=len(y))
+forecast = fit.forecast(12, exog=X_future)
+```
+
+`start` is the integer calendar index of the first row. Continue the training origin
+into forecasting, including missing observations. Harmonics must be between one and
+`floor(period / 2)`. Column order is `sin(1), cos(1), sin(2), cos(2), ...`; at the
+even-period Nyquist harmonic, only its cosine is included. For example, period 12
+with 6 harmonics has 11 columns. No intercept is added automatically.
+
+The stochastic seasonal model also accepts short histories with at least two finite
+observations; there is no full-cycle or period-dependent finite-count requirement.
+This permits 12- and 18-month annual histories and short weekly histories. It does
+not establish that the data identify seasonality. Assess sensitivity to initial-state,
+coefficient, and variance priors and compare rolling-origin forecasts against a
+simple baseline. Truncated Fourier models reduce state dimension for long periods.
+
+## Fixed-parameter time-varying observation rows
+
+`LinearGaussianStateSpace.with_observation_rows(rows)` returns a model with one
+finite observation vector per training time. Filtering, smoothing, and FFBS use the
+matching row, including across missing observations. Supply future rows explicitly:
+
+```python
+varying = fixed_model.with_observation_rows(Z_train)
+smoothed = varying.smooth(y)
+forecast = varying.forecast(y, steps=12, future_observation_rows=Z_future)
+```
+
+The future row count must equal `steps`; every row width must equal state dimension.
+Joint forecast covariance uses both corresponding horizon rows. Transition and
+process matrices remain constant. These fixed-parameter forecasts still condition on
+the supplied variances, unlike the fitted Bayesian regression forecasts.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,64 @@
+# Releasing rustmc
+
+`rustmc_core` on crates.io and `rustmc` on PyPI share one version. The internal
+`python_bindings` crate is also named `rustmc`, but it has `publish = false`:
+that name on crates.io belongs to an unrelated project.
+
+Before publishing, synchronize the package versions in `rust_core/Cargo.toml`,
+`python_bindings/Cargo.toml`, and `pyproject.toml`; the binding's `rustmc_core` path
+**and version** dependency; and both workspace package entries in `Cargo.lock`.
+Update the changelog and crate README dependency example. Check the release tag:
+
+```bash
+python3 scripts/verify_version.py v0.11.0
+cargo metadata --locked --offline --no-deps --format-version 1
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --release
+cargo package -p rustmc_core --locked
+```
+
+The version verifier also runs without a tag on every CI change. It supports
+Python 3.9+ without `tomllib` or third-party packages. Its narrow parser reads the
+repository's literal version fields; Cargo checks full manifest/lock validity.
+Explicit malformed tags and mismatched dependency/lock versions fail validation.
+
+After the final revision passes CI and publishing is authorized, publish only the
+core Rust crate from that revision:
+
+```bash
+cargo publish -p rustmc_core --locked
+```
+
+Cargo packages and verifies the crate before uploading. Registry releases are
+immutable, so inspect package contents and test the final revision first. See
+[Cargo's publishing guide](https://doc.rust-lang.org/cargo/reference/publishing.html).
+Wait until the new core version is visible in the public registry index before
+announcing the synchronized release.
+
+For PyPI, pushing the matching `vX.Y.Z` tag triggers `.github/workflows/ci.yml`.
+The release path requires Rust tests/package verification, version checks, and
+source/wheel installs across CPython 3.9–3.13. Each release wheel is then built and
+installed on a matching native platform; a clean temporary environment runs the
+API smoke check and full Python tests against that exact wheel before upload.
+The source archive is likewise installed and tested before upload. Network-marked
+packaging tests remain deselected; these jobs perform archive installation directly.
+
+Release builds use CPython 3.11 and retain the `cp39-abi3` compatibility tag. Native
+Linux ARM and Intel/ARM macOS jobs use standard GitHub-hosted runner labels; see
+[GitHub's runner reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners).
+The earlier Linux matrix separately verifies the advertised Python compatibility
+floor. Test commands can also be run locally after building exactly one artifact:
+
+```bash
+python scripts/test_release_artifact.py wheel --dist-dir dist
+python scripts/test_release_artifact.py sdist --dist-dir dist
+```
+
+The existing `publish` job downloads these verified artifacts and uses PyPI trusted
+publishing through `pypa/gh-action-pypi-publish`, with job-scoped `id-token: write`.
+No explicit API token or new GitHub environment is required by this workflow. Keep
+the configured workflow identity intact; see
+[PyPI's trusted publishing guide](https://docs.pypi.org/trusted-publishers/using-a-publisher/).
+A green build is not itself evidence that publishing succeeded: verify both registry
+versions and install the published distribution before reporting the release complete.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -43,6 +43,8 @@ installed on a matching native platform; a clean temporary environment runs the
 API smoke check and full Python tests against that exact wheel before upload.
 The source archive is likewise installed and tested before upload. Network-marked
 packaging tests remain deselected; these jobs perform archive installation directly.
+Pull requests run these same native artifact checks before merge. Publishing remains
+restricted to matching release tags.
 
 Release builds use CPython 3.11 and retain the `cp39-abi3` compatibility tag. Native
 Linux ARM and Intel/ARM macOS jobs use standard GitHub-hosted runner labels; see

--- a/docs/runoff.md
+++ b/docs/runoff.md
@@ -1,0 +1,163 @@
+# Integer-event payment runoff
+
+`rustmc.DirichletMultinomialRunoff` fits incremental payment-event counts by origin
+and development lag. It pools lag probabilities across cohorts, infers unknown
+ultimate counts, and returns complete posterior payment paths. Currency amounts,
+including amounts expressed in cents, are not independent events and must not be
+used as count observations.
+
+```python
+import numpy as np
+import rustmc
+
+# Regular lags 0, 1, 2, followed by an unscheduled tail.
+counts = np.array([
+    [18., 9., 4., 1.],       # closed cohort
+    [16., 8., 3., np.nan],   # all regular lags elapsed; tail remains open
+    [12., 0., np.nan, np.nan],
+    [7., np.nan, np.nan, np.nan],
+    [np.nan, np.nan, np.nan, np.nan],  # a supplied future cohort
+])
+model = rustmc.DirichletMultinomialRunoff(
+    alpha=[5., 3., 1.5, .5], total_shape=4., total_rate=.125,
+)
+fit = model.fit(
+    counts, origins=[0, 1, 2, 3, 4], valuation=3,
+    totals=[32, None, None, None, None],
+    draws=1500, warmup=750, chains=4, seed=7,
+)
+calendar = fit.calendar_samples(3)  # [chain, draw, valuation+1 ... valuation+3]
+tail = fit.tail_samples            # [chain, draw, cohort], no assigned date
+print(np.quantile(calendar.sum(axis=-1), [.025, .5, .975]))
+print(fit.summary())
+```
+
+## Data and time contract
+
+The input matrix is a two-dimensional float64 NumPy array. Finite cells must be
+nonnegative integers no larger than `2**53 - 1`; this bound also applies to each
+cohort total. A literal zero is an observed zero. `NaN` means unobserved.
+Input is incremental, not cumulative; difference cumulative histories before use.
+
+`origins` and `valuation` are integer periods on a common calendar. For example,
+encode months as `12 * year + month - 1`. Lag zero falls in the origin period.
+Every regular cell whose `origin + lag <= valuation` must be observed, including
+zeros. Future regular cells must be `NaN`. Missing historical regular cells are
+not supported; do not backfill them with zeros. Future cohorts may be supplied
+with fully unobserved rows; the model does not create additional cohorts itself.
+
+The last column is a **tail bucket for every lag at or beyond its index**.
+It normally remains `NaN`. A numeric tail explicitly declares that the tail has
+closed and its entire count is observed. It may close only once its first possible
+period has arrived. A closed row with a known total must sum to that total.
+An open tail does not become an observed zero merely because all regular lags
+have elapsed. The model has no distribution over dates within the tail.
+
+`totals` is a list with one integer or `None` per cohort. An integer conditions on
+an externally known ultimate count and must cover all observed events. `None`
+infers its ultimate. Omitting `totals` infers all ultimates. Known totals must be
+actual conditioning information, not point estimates inserted in place of
+uncertain accrual forecasts.
+
+## Statistical model and inference
+
+There is one shared stationary lag-probability vector:
+
+```text
+p ~ Dirichlet(alpha)
+```
+
+For a known ultimate `N_i`, a cohort's complete count vector has distribution
+`Multinomial(N_i, p)`. Integrating out `p` produces Dirichlet-multinomial
+allocations and dependence across cohorts. There is no separately estimated
+cohort-specific probability vector or concentration. `alpha` is a fixed, proper
+prior: its normalized values give prior lag means and its sum controls strength.
+
+If all ultimates are known, prefix censoring permits exact conjugate inference.
+With `q_l = p_l / sum(p[l:])`, prior hazards are independent
+`Beta(alpha_l, sum(alpha[l+1:]))`. At each observed regular lag, a cohort contributes
+its incremental count to the first shape and its known total minus cumulative
+observed counts through that lag to the second shape. Future lag hazards receive
+no exposure update. Draw these hazards independently, construct `p`, and allocate
+each remaining count sequentially with binomial draws. With complete cohorts this
+reduces to the usual `Dirichlet(alpha + column_sums)` posterior. `warmup` is ignored
+for this exact path; `sampler` reports `independent_conjugate`.
+
+Unknown ultimates instead have independent intensity priors:
+
+```text
+lambda_i ~ Gamma(total_shape, rate=total_rate)
+x_i,l | lambda_i, p ~ Poisson(lambda_i * p_l), independently across lags
+N_i = sum_l x_i,l
+```
+
+The prior ultimate mean is `total_shape / total_rate` and variance is
+`total_shape / total_rate + total_shape / total_rate**2`. Constructor defaults
+are shape 2 and rate 0.1, giving mean 20 and variance 220 events. Set these to a
+credible cohort-scale prior; the defaults are not calibrated to a business domain.
+All unknown cohorts use these same fixed hyperparameters, with independent
+intensities conditional on them. No hierarchy over intensities is inferred.
+
+Mixed known/unknown triangles use blocked latent-count Gibbs updates:
+
+1. Given `p`, draw each unknown intensity from
+   `Gamma(shape + observed_count, rate + observed_probability_mass)` and regenerate
+   its missing independent Poisson counts. For known totals, regenerate missing
+   counts by a multinomial allocation of the known remainder.
+2. Draw `p ~ Dirichlet(alpha + all_completed_column_sums)`.
+
+This targets the posterior of observed cells, integrating unknown totals rather
+than normalizing incomplete rows to one. An observed zero contributes exposure;
+a future cell does not. Fully unobserved cohorts retain their ultimate-count
+prior marginal. All-zero cohorts remain usable under proper priors. Intensities,
+completed allocations, and lag probabilities in each retained draw belong to the
+same joint posterior. `sampler` reports `latent_count_gibbs`; choose adequate warmup
+and retained draws and inspect diagnostics, especially with weak development data.
+
+## Returned paths and aggregation
+
+| Property or method | Shape and meaning |
+| --- | --- |
+| `allocation_samples` | `(chain, draw, cohort, lag)` complete integer counts, including observed cells and tail |
+| `ultimate_samples` | `(chain, draw, cohort)` sums of complete allocations |
+| `intensity_samples` | `(chain, draw, cohort)` Poisson intensity, NaN for known-total cohorts |
+| `lag_probability_samples` | `(chain, draw, lag)` shared probabilities, including tail |
+| `tail_samples` | `(chain, draw, cohort)` unobserved tail counts; closed observed tails return zero |
+| `calendar_samples(steps)` | `(chain, draw, steps)` aggregate regular-lag events at valuation+1 through valuation+steps |
+| `observed_mask` | `(cohort, lag)` true for observed cells |
+
+Each complete row sums to its ultimate in every draw. Observed cells remain fixed.
+Calendar aggregation uses the same draw across cohorts, retaining dependence
+induced by the shared lag probabilities. The calendar excludes the tail and any
+regular cells beyond the requested horizon. Sum **paths first**, then take
+quantiles for totals or cumulative intervals; summing marginal interval endpoints
+does not give an interval for the total. NumPy quantiles give equal-tailed
+posterior-predictive intervals, not HDIs or confidence intervals.
+
+`diagnostics()`, `summary()`, and `sampler_stats()` reuse the common parameter
+diagnostics. Coverage includes lag probabilities, unknown intensities, and unknown
+ultimate counts. Acceptance rates and Hamiltonian divergences are unavailable for
+both inference paths. Very short or constant traces have unavailable convergence
+metrics. Diagnostics do not validate the model's payment assumptions.
+
+## Limitations and evidence
+
+Lag probabilities are stationary and shared across cohorts. There are no calendar
+effects, cohort regressors, time-varying lags, refunds, negative counts, variable
+cohort-specific total priors, or endogenous new-cohort forecasts. A tail timing
+model and continuous monetary allocation model are separate extensions.
+
+Event counts can be combined with an explicitly specified severity model to form
+amounts. This API does not fit severity or infer dependence with a separate accrual
+forecast. Do not multiply independently fitted posterior arrays and describe the
+result as a joint model unless the independence and conditioning assumptions justify
+that construction. In particular, simply aligning draw indices does not establish
+posterior dependence between separate models.
+
+Tests check complete-triangle Dirichlet moments, censored Beta-binomial predictions,
+independent quadrature for an unknown-total posterior, Gamma-Poisson prior moments,
+zero-versus-future masks, total conservation, seeded reproducibility, shared-lag
+recovery, and a small rolling-valuation holdout against uniform remaining-lag
+allocation. The holdout is a deterministic simulated regression test, not a general
+calibration or performance claim. See `examples/payment_triangle_runoff.py` for an
+end-to-end example with a conservation check.

--- a/docs/runoff.md
+++ b/docs/runoff.md
@@ -38,6 +38,9 @@ The input matrix is a two-dimensional float64 NumPy array. Finite cells must be
 nonnegative integers no larger than `2**53 - 1`; this bound also applies to each
 cohort total. A literal zero is an observed zero. `NaN` means unobserved.
 Input is incremental, not cumulative; difference cumulative histories before use.
+Retained fit and calendar allocations are bounded at 25 million scalar values;
+oversized requests raise errors. This is an allocation guard, not a byte-level
+peak-memory guarantee, because nested arrays also carry metadata.
 
 `origins` and `valuation` are integer periods on a common calendar. For example,
 encode months as `12 * year + month - 1`. Lag zero falls in the origin period.

--- a/docs/runoff.md
+++ b/docs/runoff.md
@@ -137,7 +137,7 @@ quantiles for totals or cumulative intervals; summing marginal interval endpoint
 does not give an interval for the total. NumPy quantiles give equal-tailed
 posterior-predictive intervals, not HDIs or confidence intervals.
 
-`diagnostics()`, `summary()`, and `sampler_stats()` reuse the common parameter
+`diagnostics()`, `summary()`, and `sampler_stats` reuse the common parameter
 diagnostics. Coverage includes lag probabilities, unknown intensities, and unknown
 ultimate counts. Acceptance rates and Hamiltonian divergences are unavailable for
 both inference paths. Very short or constant traces have unavailable convergence

--- a/docs/sparse-amounts.md
+++ b/docs/sparse-amounts.md
@@ -91,3 +91,34 @@ The occurrence process has no calendar covariates or time dependence in this mod
 The positive severity component has a local level, without exogenous features or
 hierarchical pooling. Compare zero frequency, positive-amount tails, and cumulative
 coverage on rolling origins before choosing the model for a particular cell family.
+
+Independent sparse cells use the same [native batch API](forecast-batches.md) as
+Gaussian forecasting models:
+
+```python
+batch = model.fit_batch(
+    [np.zeros(12), np.array([0., np.nan, 110., 0.])],
+    ids=["no-payments", "one-payment"],
+    chains=4, draws=1000, warmup=500, seed=42,
+    threads=4, chunk_size=32, errors="collect",
+)
+print(batch.errors)
+print(batch["no-payments"].severity_informed_by_data)  # False
+print(batch.diagnostics())
+future = batch.forecast(12, seed=43, threads=4, errors="collect")
+paths = future["one-payment"].observation_samples
+```
+
+Supply `models=[model_for_first_cell, model_for_second_cell]` to vary occurrence
+priors, log-level priors, or variance bounds; `None` uses the calling model. Mixed
+batches can include the other supported forecasting models. Hurdle cells explicitly
+reject training or future `exog` and coefficient priors; regression cells in a mixed
+batch may supply them. All-zero and one-positive histories keep their distinct
+severity-information metadata and ordinary fit result types.
+
+Seeds use stable cell IDs for fitting and coherent forecasts, so results are
+unchanged by reordering, resuming a subset, chunk size, or worker count. Per-cell
+validation, allocation-limit and numerical failures can be collected alongside
+successful cells. The shared worker and retained-memory limits apply; use
+caller-managed slices to retain a larger workload. Each cell remains independent:
+batching introduces no shared occurrence shocks or hierarchical pooling.

--- a/docs/sparse-amounts.md
+++ b/docs/sparse-amounts.md
@@ -79,7 +79,7 @@ Forecast arrays have shape `(chain, draw, step)`:
 `mean_interval()` summarizes conditional mean uncertainty. With high zero probability,
 an interval can have zero as its lower bound or both endpoints. Diagnose probability,
 variance parameters, and the terminal log level using `diagnostics()`/`summary()`.
-`sampler_stats()` reports Hamiltonian divergences and acceptance as unavailable.
+`sampler_stats` reports Hamiltonian divergences and acceptance as unavailable.
 `to_arviz()` exports parameter draws and the observed amounts when ArviZ is installed.
 
 The standalone `hurdle_lognormal_logp(y, payment_probability, log_level, log_variance)`

--- a/docs/sparse-amounts.md
+++ b/docs/sparse-amounts.md
@@ -1,0 +1,93 @@
+# Sparse nonnegative amounts
+
+`BayesianHurdleLogNormal` fits a point mass at zero and a changing positive-payment
+level. It is suitable when each period either has no payment or a positive amount.
+It accepts exact zeros, one-positive histories, and all-zero histories; `NaN` marks
+missing observations and retains the time position. Negative amounts require a
+different model.
+
+```python
+import numpy as np
+import rustmc as rmc
+
+model = rmc.BayesianHurdleLogNormal(
+    process_variance_prior=rmc.InverseGammaPrior(4.0, 0.03),
+    observation_variance_prior=rmc.InverseGammaPrior(4.0, 0.3),
+    occurrence_alpha=1.0,
+    occurrence_beta=1.0,
+    initial_log_level=np.log(100.0),
+    initial_variance=0.2,
+    process_variance_upper=1.0,
+    observation_variance_upper=4.0,
+)
+fit = model.fit(
+    np.array([0., 0., 110., np.nan, 0., 90., 0., 0.]),
+    chains=4, warmup=500, draws=1000, seed=42,
+)
+forecast = fit.forecast(steps=12, seed=43)
+lower, upper = forecast.interval(0.95)
+total_draws = forecast.observation_samples.sum(axis=2)
+print(fit.summary())
+```
+
+The model is
+
+```text
+p ~ Beta(occurrence_alpha, occurrence_beta)
+paid[t] ~ Bernoulli(p)
+level[-1] ~ Normal(initial_log_level, initial_variance)
+level[t] ~ Normal(level[t-1], q)
+log(y[t]) | paid[t] = 1 ~ Normal(level[t], r)
+y[t] | paid[t] = 0 = 0
+```
+
+`q` and `r` have the specified inverse-gamma priors conditioned on
+`0 < q <= process_variance_upper` and `0 < r <= observation_variance_upper`.
+The upper bounds are part of the statistical model, not clipping of sampled draws.
+Their defaults are 1 and 4 in squared log units. Choose priors and bounds to match
+plausible period-to-period changes and positive-amount dispersion. Initial level and
+all variance settings are on the natural-log scale.
+
+Finite bounds ensure finite predictive amount moments over a finite horizon. Without
+bounds, inverse-gamma log-variance mixtures have infinite positive raw moments even
+after finite data. The exact conditional sampler rejects variance proposals above
+the bounds and reports an error if too little conditional mass falls below a bound.
+It never clips variance draws, discards inconvenient posterior draws, or converts an
+overflowing payment to zero. Very large log levels/horizons can still overflow machine
+arithmetic and are reported as inference failures.
+
+Occurrence probability is static, with posterior
+`Beta(alpha + positive_count, beta + observed_zero_count)`. Occurrence and positive
+severity have independent priors and factorized likelihoods. Severity is sampled by
+Gaussian FFBS and truncated inverse-gamma Gibbs updates. On zero months severity
+continues to evolve, but receives no amount observation. Missing months also give
+no occurrence observation. All-zero histories use independent prior severity draws;
+`fit.severity_informed_by_data` and sampler metadata make that distinction explicit.
+
+Forecast arrays have shape `(chain, draw, step)`:
+
+| Attribute | Meaning |
+| --- | --- |
+| `observation_samples` | Realized payments, including exact zeros |
+| `positive_mean_samples` | `exp(level + r/2)`, conditional mean given payment |
+| `mean_samples` | `p * exp(level + r/2)`, conditional mean including zero probability |
+| `mean` | Monte Carlo average of conditional means |
+| `observation_mean` | Monte Carlo average of realized payment draws |
+| `cumulative_observation_samples` | Cumulative payments computed inside each draw |
+
+`interval()` and `cumulative_interval()` return predictive equal-tailed intervals;
+`mean_interval()` summarizes conditional mean uncertainty. With high zero probability,
+an interval can have zero as its lower bound or both endpoints. Diagnose probability,
+variance parameters, and the terminal log level using `diagnostics()`/`summary()`.
+`sampler_stats()` reports Hamiltonian divergences and acceptance as unavailable.
+`to_arviz()` exports parameter draws and the observed amounts when ArviZ is installed.
+
+The standalone `hurdle_lognormal_logp(y, payment_probability, log_level, log_variance)`
+evaluates the mixed point-mass/continuous density. This release exposes a specialized
+dynamic fitted model; it does not add a new generic graph-builder likelihood or claim
+that arbitrary non-Gaussian observations can use the Gaussian FFBS kernel.
+
+The occurrence process has no calendar covariates or time dependence in this model.
+The positive severity component has a local level, without exogenous features or
+hierarchical pooling. Compare zero frequency, positive-amount tails, and cumulative
+coverage on rolling origins before choosing the model for a particular cell family.

--- a/examples/payment_triangle_runoff.py
+++ b/examples/payment_triangle_runoff.py
@@ -1,0 +1,42 @@
+"""Forecast payment-event counts with uncertain ultimates and an undated tail.
+
+Run after installing rustmc: python examples/payment_triangle_runoff.py
+These observations count payment events; they are not currency amounts.
+"""
+import numpy as np
+import rustmc
+
+
+def main():
+    counts = np.array([
+        [18., 9., 4., 1.],
+        [16., 8., 3., np.nan],
+        [12., 0., np.nan, np.nan],
+        [7., np.nan, np.nan, np.nan],
+        [np.nan, np.nan, np.nan, np.nan],
+    ])
+    model = rustmc.DirichletMultinomialRunoff(
+        [5., 3., 1.5, .5], total_shape=4., total_rate=.125,
+    )
+    fit = model.fit(
+        counts, [0, 1, 2, 3, 4], valuation=3,
+        totals=[32, None, None, None, None],
+        draws=1500, warmup=750, chains=4, seed=7,
+    )
+    future = fit.calendar_samples(3)
+    tail = fit.tail_samples.sum(axis=-1)
+    observed = int(np.nansum(counts))
+    ultimate = fit.ultimate_samples.sum(axis=-1)
+    # Horizon covers every remaining regular cell; the tail remains separate.
+    np.testing.assert_array_equal(future.sum(axis=-1) + tail + observed, ultimate)
+    print("Expected future event counts by period:", future.mean(axis=(0, 1)))
+    print("Total regular future events, equal-tailed 95% interval:",
+          np.quantile(future.sum(axis=-1), [.025, .975]))
+    print("Remaining undated tail events, equal-tailed 95% interval:",
+          np.quantile(tail, [.025, .975]))
+    print("Ultimate event counts by cohort:", fit.ultimate_samples.mean(axis=(0, 1)))
+    print(fit.summary())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rebate_accrual_forecast.py
+++ b/examples/rebate_accrual_forecast.py
@@ -73,19 +73,19 @@ def main() -> None:
     # Back-transform every coherent path before summarizing. exp(mean(log Y)) is not
     # generally equal to mean(Y), so transforming a summary would be wrong.
     payment_draws = np.exp(forecast.observation_samples)
-    expected_level_draws = np.exp(forecast.state_samples)
+    median_level_draws = np.exp(forecast.state_samples)
 
     print("Monthly forecast (thousands)")
-    print("month   payment mean and 95% predictive     expected level and 95% credible")
+    print("month   payment mean and 95% predictive     conditional median and 95% credible")
     for month in range(12):
         payment = payment_draws[:, :, month]
-        expected_level = expected_level_draws[:, :, month]
+        median_level = median_level_draws[:, :, month]
         payment_low, payment_high = interval(payment)
-        level_low, level_high = interval(expected_level)
+        level_low, level_high = interval(median_level)
         print(
             f"{month + 1:>5}   "
             f"{payment.mean():>8.2f} [{payment_low:>8.2f}, {payment_high:>8.2f}]   "
-            f"{expected_level.mean():>8.2f} [{level_low:>8.2f}, {level_high:>8.2f}]"
+            f"{median_level.mean():>8.2f} [{level_low:>8.2f}, {level_high:>8.2f}]"
         )
 
     print("\nCumulative payment forecast (thousands)")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,11 @@ nav:
     - Batch Inference: examples/batch-inference.md
     - High-Dimensional Regression: examples/high-dimensional.md
   - API Reference: reference.md
+  - Forecasting:
+    - Regression and Fourier terms: regression-forecasting.md
+    - Independent batches and diagnostics: forecast-batches.md
+    - Sparse amounts: sparse-amounts.md
+    - Payment-count runoff: runoff.md
   - Architecture:
     - Compiled models: architecture/compiled-model.md
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustmc"
-version = "0.10.0"
+version = "0.11.0"
 description = "Structure-aware Bayesian inference powered by Rust"
 readme = "README.md"
 license = "MIT"

--- a/python_bindings/Cargo.toml
+++ b/python_bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustmc"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 description = "Python extension module for rustmc"
@@ -14,7 +14,7 @@ name = "rustmc"
 crate-type = ["cdylib"]
 
 [dependencies]
-rustmc_core = { path = "../rust_core", version = "0.10.0" }
+rustmc_core = { path = "../rust_core", version = "0.11.0" }
 pyo3 = { version = "0.25", features = ["extension-module", "abi3-py39"] }
 numpy = "0.25"
 ndarray = "0.16"

--- a/python_bindings/src/forecast_batch.rs
+++ b/python_bindings/src/forecast_batch.rs
@@ -1,4 +1,5 @@
 //! Native independent-cell forecasting bindings. One pool spans cells and chains.
+use super::hurdle::{PyHurdleFit, PyHurdleForecast, PyHurdleLogNormal};
 use super::regression::{
     PyBayesianRegressionFit, PyBayesianRegressionForecast, PyGaussianCoefficientPrior,
 };
@@ -10,6 +11,7 @@ use rustmc_core::diagnostics::DiagnosticsReport;
 use rustmc_core::forecast_batch::{
     execute_batch, execute_batch_fail_fast, stable_cell_seed, BatchError,
 };
+use rustmc_core::hurdle::{fit_hurdle_lognormal, HurdleLogNormalConfig, HurdleLogNormalForecast};
 
 // Limit each call's retained scalar values and each cell's conservative FFBS
 // workspace estimate. Larger workloads must use caller-managed chunks.
@@ -33,6 +35,7 @@ pub(crate) enum Config {
     Seasonal(CoreBayesianSeasonalLocalLevelConfig),
     Trend(CoreBayesianLocalLinearTrendConfig),
     Ar(CoreBayesianArConfig),
+    Hurdle(HurdleLogNormalConfig),
     Regression(Box<RegressionConfig>, Vec<Vec<f64>>),
 }
 #[derive(Clone)]
@@ -41,6 +44,7 @@ enum CellFit {
     Seasonal(PyBayesianSeasonalLocalLevelFit),
     Trend(PyBayesianLocalLinearTrendFit),
     Ar(PyBayesianArFit),
+    Hurdle(PyHurdleFit),
     Regression(Box<PyBayesianRegressionFit>),
 }
 #[derive(Clone)]
@@ -49,11 +53,13 @@ enum CellForecast {
     Seasonal(CoreSeasonalPosteriorPredictiveForecast),
     Trend(CoreTrendPosteriorPredictiveForecast),
     Ar(CoreBayesianArForecast),
+    Hurdle(HurdleLogNormalForecast),
     Regression(RegressionForecast, bool, usize),
 }
 impl Config {
     fn allocation_size(&self, history: usize) -> Result<usize, String> {
         let (chains, draws, parameters, dimension) = match self {
+            Self::Hurdle(c) => (c.num_chains, c.num_draws, 4, 1),
             Self::Local(c) => (c.num_chains, c.num_draws, 3, 1),
             Self::Seasonal(c) => (
                 c.num_chains,
@@ -101,6 +107,7 @@ impl Config {
         prior: GaussianCoefficientPrior,
     ) -> Result<Self, String> {
         let config = match self {
+            Self::Hurdle(_) => return Err("hurdle exog is unsupported: occurrence is static and severity has no exogenous features".into()),
             Self::Local(config) => RegressionConfig::from_local_level(&config, prior),
             Self::Seasonal(config) => RegressionConfig::from_seasonal(&config, prior),
             Self::Trend(config) => RegressionConfig::from_trend(&config, prior),
@@ -112,6 +119,17 @@ impl Config {
     fn fit(&self, observations: &[f64], seed: u64) -> Result<CellFit, String> {
         self.allocation_size(observations.len())?;
         match self {
+            Self::Hurdle(base) => {
+                let mut config = base.clone();
+                config.seed = seed;
+                let posterior = fit_hurdle_lognormal(observations, &config)
+                    .map_err(|error| error.to_string())?;
+                Ok(CellFit::Hurdle(PyHurdleFit {
+                    posterior,
+                    observations: observations.to_vec(),
+                    config,
+                }))
+            }
             Self::Regression(base, design) => {
                 let mut config = (**base).clone();
                 config.seed = seed;
@@ -172,6 +190,11 @@ impl Config {
 impl CellFit {
     fn forecast_allocation_size(&self, steps: usize) -> Result<usize, String> {
         let (chains, draws, components) = match self {
+            Self::Hurdle(fit) => (
+                fit.posterior.chains.len(),
+                fit.posterior.chains.first().map_or(0, Vec::len),
+                3,
+            ),
             Self::Local(fit) => (fit.chains(), fit.draws(), 3),
             Self::Seasonal(fit) => (fit.chains(), fit.draws(), 4),
             Self::Trend(fit) => (fit.chains(), fit.draws(), 4),
@@ -187,6 +210,7 @@ impl CellFit {
     fn to_python(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         match self {
             Self::Regression(fit) => Ok(Py::new(py, (**fit).clone())?.into_any()),
+            Self::Hurdle(fit) => Ok(Py::new(py, fit.clone())?.into_any()),
             Self::Local(fit) => Ok(Py::new(py, fit.clone())?.into_any()),
             Self::Seasonal(fit) => Ok(Py::new(py, fit.clone())?.into_any()),
             Self::Trend(fit) => Ok(Py::new(py, fit.clone())?.into_any()),
@@ -196,6 +220,7 @@ impl CellFit {
     fn report(&self) -> DiagnosticsReport {
         match self {
             Self::Regression(fit) => fit.posterior.diagnostics(),
+            Self::Hurdle(fit) => fit.report(),
             Self::Local(fit) => fit.posterior.diagnostics(),
             Self::Seasonal(fit) => fit.posterior.diagnostics(),
             Self::Trend(fit) => fit.posterior.diagnostics(),
@@ -209,6 +234,9 @@ impl CellFit {
         exog: Option<&[Vec<f64>]>,
     ) -> Result<CellForecast, String> {
         self.forecast_allocation_size(steps)?;
+        if exog.is_some() && matches!(self, Self::Hurdle(_)) {
+            return Err("hurdle exog is unsupported: occurrence is static and severity has no exogenous features".into());
+        }
         if exog.is_some() && !matches!(self, Self::Regression(_)) {
             return Err("future exog was supplied to a fit without regression".into());
         }
@@ -229,6 +257,11 @@ impl CellFit {
                     })
                     .map_err(|error| error.to_string())
             }
+            Self::Hurdle(fit) => fit
+                .posterior
+                .forecast(steps, seed)
+                .map(CellForecast::Hurdle)
+                .map_err(|error| error.to_string()),
             Self::Local(fit) => fit
                 .posterior
                 .forecast(steps, seed)
@@ -261,6 +294,13 @@ impl CellForecast {
                     inner: inner.clone(),
                     seasonal: *seasonal,
                     dimension: *dimension,
+                },
+            )?
+            .into_any()),
+            Self::Hurdle(inner) => Ok(Py::new(
+                py,
+                PyHurdleForecast {
+                    inner: inner.clone(),
                 },
             )?
             .into_any()),
@@ -397,6 +437,8 @@ pub(crate) fn fit_batch(
                 let model = &models[index];
                 if model.is_none() {
                     default.clone()
+                } else if let Ok(model) = model.extract::<PyRef<'_, PyHurdleLogNormal>>() {
+                    model.batch_config(chains, draws, warmup, thin)
                 } else if let Ok(model) = model.extract::<PyRef<'_, PyBayesianLocalLevel>>() {
                     model.batch_config(chains, draws, warmup, thin)
                 } else if let Ok(model) = model.extract::<PyRef<'_, PyBayesianSeasonalLocalLevel>>()
@@ -423,6 +465,9 @@ pub(crate) fn fit_batch(
                 .as_ref()
                 .map(|items| &items[index])
                 .filter(|item| !item.is_none());
+            if matches!(&config, Config::Hurdle(_)) && (design.is_some() || prior.is_some()) {
+                return Err("hurdle exog is unsupported: occurrence is static and severity has no exogenous features".into());
+            }
             let config =
                 match (design, prior) {
                     (Some(design), Some(prior)) => {

--- a/python_bindings/src/forecast_batch.rs
+++ b/python_bindings/src/forecast_batch.rs
@@ -1,9 +1,31 @@
 //! Native independent-cell forecasting bindings. One pool spans cells and chains.
+use super::regression::{
+    PyBayesianRegressionFit, PyBayesianRegressionForecast, PyGaussianCoefficientPrior,
+};
 use super::*;
+use rustmc_core::bayesian_regression::{
+    fit_regression, GaussianCoefficientPrior, RegressionConfig, RegressionForecast,
+};
 use rustmc_core::diagnostics::DiagnosticsReport;
 use rustmc_core::forecast_batch::{
     execute_batch, execute_batch_fail_fast, stable_cell_seed, BatchError,
 };
+
+// Limit each call's retained scalar values and each cell's conservative FFBS
+// workspace estimate. Larger workloads must use caller-managed chunks.
+const MAX_BATCH_VALUES: usize = 25_000_000;
+fn allocation_product(values: &[usize]) -> Result<usize, String> {
+    values.iter().try_fold(1usize, |product, value| product.checked_mul(*value))
+        .filter(|count| *count <= MAX_BATCH_VALUES)
+        .ok_or_else(|| "allocation limit exceeded (25,000,000 scalar values); reduce draws, horizon or cell chunk size".into())
+}
+fn check_total_retention(mut values: impl Iterator<Item = usize>) -> PyResult<()> {
+    let total = values.try_fold(0usize, |sum, value| sum.checked_add(value));
+    if total.is_none_or(|total| total > MAX_BATCH_VALUES) {
+        return Err(PyValueError::new_err("batch retained-value limit exceeded (25,000,000); submit smaller caller-managed chunks"));
+    }
+    Ok(())
+}
 
 #[derive(Clone)]
 pub(crate) enum Config {
@@ -11,6 +33,7 @@ pub(crate) enum Config {
     Seasonal(CoreBayesianSeasonalLocalLevelConfig),
     Trend(CoreBayesianLocalLinearTrendConfig),
     Ar(CoreBayesianArConfig),
+    Regression(Box<RegressionConfig>, Vec<Vec<f64>>),
 }
 #[derive(Clone)]
 enum CellFit {
@@ -18,6 +41,7 @@ enum CellFit {
     Seasonal(PyBayesianSeasonalLocalLevelFit),
     Trend(PyBayesianLocalLinearTrendFit),
     Ar(PyBayesianArFit),
+    Regression(Box<PyBayesianRegressionFit>),
 }
 #[derive(Clone)]
 enum CellForecast {
@@ -25,10 +49,79 @@ enum CellForecast {
     Seasonal(CoreSeasonalPosteriorPredictiveForecast),
     Trend(CoreTrendPosteriorPredictiveForecast),
     Ar(CoreBayesianArForecast),
+    Regression(RegressionForecast, bool, usize),
 }
 impl Config {
+    fn allocation_size(&self, history: usize) -> Result<usize, String> {
+        let (chains, draws, parameters, dimension) = match self {
+            Self::Local(c) => (c.num_chains, c.num_draws, 3, 1),
+            Self::Seasonal(c) => (
+                c.num_chains,
+                c.num_draws,
+                c.period.checked_add(3).ok_or("dimension overflow")?,
+                c.period,
+            ),
+            Self::Trend(c) => (c.num_chains, c.num_draws, 5, 2),
+            Self::Ar(c) => (
+                c.num_chains,
+                c.num_draws,
+                c.order.checked_add(2).ok_or("dimension overflow")?,
+                c.order,
+            ),
+            Self::Regression(c, _) => {
+                let dimension = c
+                    .structural_model
+                    .dimension()
+                    .checked_add(c.coefficient_prior.mean.len())
+                    .ok_or("dimension overflow")?;
+                let parameters = dimension
+                    .checked_add(c.variance_priors.len())
+                    .and_then(|n| n.checked_add(1))
+                    .ok_or("dimension overflow")?;
+                (c.num_chains, c.num_draws, parameters, dimension)
+            }
+        };
+        // Include a pre-observation state and conservative dense filter/smoother buffers.
+        allocation_product(&[
+            chains.max(1),
+            history.checked_add(1).ok_or("history overflow")?,
+            dimension,
+            dimension,
+            8,
+        ])?;
+        let posterior = allocation_product(&[chains, draws, parameters])?;
+        let retained = posterior
+            .checked_add(history)
+            .ok_or("retained size overflow")?;
+        allocation_product(&[retained])
+    }
+    fn with_regression(
+        self,
+        design: Vec<Vec<f64>>,
+        prior: GaussianCoefficientPrior,
+    ) -> Result<Self, String> {
+        let config = match self {
+            Self::Local(config) => RegressionConfig::from_local_level(&config, prior),
+            Self::Seasonal(config) => RegressionConfig::from_seasonal(&config, prior),
+            Self::Trend(config) => RegressionConfig::from_trend(&config, prior),
+            _ => return Err("exog is supported for local-level, seasonal and trend models".into()),
+        }
+        .map_err(|error| error.to_string())?;
+        Ok(Self::Regression(Box::new(config), design))
+    }
     fn fit(&self, observations: &[f64], seed: u64) -> Result<CellFit, String> {
+        self.allocation_size(observations.len())?;
         match self {
+            Self::Regression(base, design) => {
+                let mut config = (**base).clone();
+                config.seed = seed;
+                let posterior = fit_regression(observations, design, &config)
+                    .map_err(|error| error.to_string())?;
+                Ok(CellFit::Regression(Box::new(PyBayesianRegressionFit {
+                    posterior,
+                    observations: observations.to_vec(),
+                })))
+            }
             Self::Local(base) => {
                 let mut config = base.clone();
                 config.seed = seed;
@@ -77,8 +170,23 @@ impl Config {
     }
 }
 impl CellFit {
+    fn forecast_allocation_size(&self, steps: usize) -> Result<usize, String> {
+        let (chains, draws, components) = match self {
+            Self::Local(fit) => (fit.chains(), fit.draws(), 3),
+            Self::Seasonal(fit) => (fit.chains(), fit.draws(), 4),
+            Self::Trend(fit) => (fit.chains(), fit.draws(), 4),
+            Self::Ar(fit) => (fit.chains(), fit.draws(), 3),
+            Self::Regression(fit) => (
+                fit.posterior.chains.len(),
+                fit.posterior.chains.first().map_or(0, Vec::len),
+                6,
+            ),
+        };
+        allocation_product(&[chains, draws, steps, components])
+    }
     fn to_python(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         match self {
+            Self::Regression(fit) => Ok(Py::new(py, (**fit).clone())?.into_any()),
             Self::Local(fit) => Ok(Py::new(py, fit.clone())?.into_any()),
             Self::Seasonal(fit) => Ok(Py::new(py, fit.clone())?.into_any()),
             Self::Trend(fit) => Ok(Py::new(py, fit.clone())?.into_any()),
@@ -87,14 +195,40 @@ impl CellFit {
     }
     fn report(&self) -> DiagnosticsReport {
         match self {
+            Self::Regression(fit) => fit.posterior.diagnostics(),
             Self::Local(fit) => fit.posterior.diagnostics(),
             Self::Seasonal(fit) => fit.posterior.diagnostics(),
             Self::Trend(fit) => fit.posterior.diagnostics(),
             Self::Ar(fit) => fit.posterior.diagnostics(),
         }
     }
-    fn forecast(&self, steps: usize, seed: u64) -> Result<CellForecast, String> {
+    fn forecast(
+        &self,
+        steps: usize,
+        seed: u64,
+        exog: Option<&[Vec<f64>]>,
+    ) -> Result<CellForecast, String> {
+        self.forecast_allocation_size(steps)?;
+        if exog.is_some() && !matches!(self, Self::Regression(_)) {
+            return Err("future exog was supplied to a fit without regression".into());
+        }
         match self {
+            Self::Regression(fit) => {
+                let design = exog.ok_or("future exog is required for regression forecasts")?;
+                if design.len() != steps {
+                    return Err("future exog row count must equal steps".into());
+                }
+                fit.posterior
+                    .forecast(design, seed)
+                    .map(|inner| {
+                        CellForecast::Regression(
+                            inner,
+                            fit.posterior.config.seasonal,
+                            fit.posterior.config.structural_model.dimension(),
+                        )
+                    })
+                    .map_err(|error| error.to_string())
+            }
             Self::Local(fit) => fit
                 .posterior
                 .forecast(steps, seed)
@@ -121,6 +255,15 @@ impl CellFit {
 impl CellForecast {
     fn to_python(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         match self {
+            Self::Regression(inner, seasonal, dimension) => Ok(Py::new(
+                py,
+                PyBayesianRegressionForecast {
+                    inner: inner.clone(),
+                    seasonal: *seasonal,
+                    dimension: *dimension,
+                },
+            )?
+            .into_any()),
             Self::Local(inner) => Ok(Py::new(
                 py,
                 PyBayesianForecastResult {
@@ -200,12 +343,30 @@ fn index_of(ids: &[String], id: &str) -> PyResult<usize> {
         .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err(id.to_string()))
 }
 
+fn aligned_optional<'py>(
+    values: Option<&Bound<'py, PyAny>>,
+    count: usize,
+    name: &str,
+) -> PyResult<Option<Vec<Bound<'py, PyAny>>>> {
+    let values = values
+        .map(|values| values.try_iter()?.collect::<PyResult<Vec<_>>>())
+        .transpose()?;
+    if values.as_ref().is_some_and(|values| values.len() != count) {
+        return Err(PyValueError::new_err(format!(
+            "{name} must have one entry per cell"
+        )));
+    }
+    Ok(values)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn fit_batch(
     py: Python<'_>,
     observations: &Bound<'_, PyAny>,
     ids: Vec<String>,
     models: Option<&Bound<'_, PyAny>>,
+    exog: Option<&Bound<'_, PyAny>>,
+    coefficient_priors: Option<&Bound<'_, PyAny>>,
     default: Config,
     chains: usize,
     draws: usize,
@@ -223,15 +384,9 @@ pub(crate) fn fit_batch(
             "ids and observations must have the same length",
         ));
     }
-    let models = models
-        .map(|values| values.try_iter()?.collect::<PyResult<Vec<_>>>())
-        .transpose()?;
-    if models
-        .as_ref()
-        .is_some_and(|values| values.len() != ids.len())
-    {
-        return Err(PyValueError::new_err("models must have one entry per cell"));
-    }
+    let models = aligned_optional(models, ids.len(), "models")?;
+    let designs = aligned_optional(exog, ids.len(), "exog")?;
+    let priors = aligned_optional(coefficient_priors, ids.len(), "coefficient_priors")?;
     let mut cells = Vec::with_capacity(ids.len());
     for (index, row) in rows.iter().enumerate() {
         let input = (|| -> Result<(Vec<f64>, Config), String> {
@@ -260,10 +415,44 @@ pub(crate) fn fit_batch(
             } else {
                 default.clone()
             };
+            let design = designs
+                .as_ref()
+                .map(|items| &items[index])
+                .filter(|item| !item.is_none());
+            let prior = priors
+                .as_ref()
+                .map(|items| &items[index])
+                .filter(|item| !item.is_none());
+            let config =
+                match (design, prior) {
+                    (Some(design), Some(prior)) => {
+                        let design = design
+                            .extract::<Vec<Vec<f64>>>()
+                            .map_err(|error| format!("invalid exog: {error}"))?;
+                        let prior = prior
+                            .extract::<PyRef<'_, PyGaussianCoefficientPrior>>()
+                            .map_err(|error| format!("invalid coefficient prior: {error}"))?
+                            .inner
+                            .clone();
+                        config.with_regression(design, prior)?
+                    }
+                    (None, None) => config,
+                    _ => return Err(
+                        "exog and coefficient_priors must both be supplied for a regression cell"
+                            .into(),
+                    ),
+                };
+            config.allocation_size(y.len())?;
             Ok((y, config))
         })();
         cells.push((ids[index].clone(), input));
     }
+    check_total_retention(
+        cells
+            .iter()
+            .filter_map(|(_, input)| input.as_ref().ok())
+            .filter_map(|(y, config)| config.allocation_size(y.len()).ok()),
+    )?;
     let results = py.allow_threads(|| {
         run_cells(
             &cells,
@@ -336,23 +525,51 @@ impl PyForecastBatchFit {
         }
         Ok(output)
     }
-    #[pyo3(signature = (steps, *, seed=43, threads=1, chunk_size=64, errors="raise"))]
+    #[pyo3(signature = (steps, *, exog=None, seed=43, threads=1, chunk_size=64, errors="raise"))]
+    #[allow(clippy::too_many_arguments)]
     fn forecast(
         &self,
         py: Python<'_>,
         steps: usize,
+        exog: Option<&Bound<'_, PyAny>>,
         seed: u64,
         threads: usize,
         chunk_size: usize,
         errors: &str,
     ) -> PyResult<PyForecastBatchForecast> {
         check_errors(errors)?;
+        let designs = aligned_optional(exog, self.ids.len(), "exog")?;
+        let designs = (0..self.ids.len())
+            .map(|index| {
+                designs
+                    .as_ref()
+                    .map(|items| &items[index])
+                    .filter(|item| !item.is_none())
+                    .map(|item| {
+                        item.extract::<Vec<Vec<f64>>>()
+                            .map_err(|error| format!("invalid future exog: {error}"))
+                    })
+                    .transpose()
+            })
+            .collect::<Vec<_>>();
         let cells = self
             .ids
             .iter()
             .zip(&self.results)
-            .map(|(id, result)| (id.clone(), (result, stable_cell_seed(seed, id, "forecast"))))
+            .zip(&designs)
+            .map(|((id, result), design)| {
+                (
+                    id.clone(),
+                    (result, design, stable_cell_seed(seed, id, "forecast")),
+                )
+            })
             .collect::<Vec<_>>();
+        check_total_retention(
+            self.results
+                .iter()
+                .filter_map(|result| result.as_ref().ok())
+                .filter_map(|fit| fit.forecast_allocation_size(steps).ok()),
+        )?;
         let results = py.allow_threads(|| {
             run_cells(
                 &cells,
@@ -360,9 +577,10 @@ impl PyForecastBatchFit {
                 threads,
                 chunk_size,
                 errors,
-                |(result, forecast_seed), _| {
+                |(result, design, forecast_seed), _| {
                     let fit = result.as_ref().map_err(Clone::clone)?;
-                    fit.forecast(steps, *forecast_seed)
+                    let design = design.as_ref().map_err(Clone::clone)?;
+                    fit.forecast(steps, *forecast_seed, design.as_deref())
                 },
             )
         })?;

--- a/python_bindings/src/forecast_batch.rs
+++ b/python_bindings/src/forecast_batch.rs
@@ -1,0 +1,426 @@
+//! Native independent-cell forecasting bindings. One pool spans cells and chains.
+use super::*;
+use rustmc_core::diagnostics::DiagnosticsReport;
+use rustmc_core::forecast_batch::{
+    execute_batch, execute_batch_fail_fast, stable_cell_seed, BatchError,
+};
+
+#[derive(Clone)]
+pub(crate) enum Config {
+    Local(CoreBayesianLocalLevelConfig),
+    Seasonal(CoreBayesianSeasonalLocalLevelConfig),
+    Trend(CoreBayesianLocalLinearTrendConfig),
+    Ar(CoreBayesianArConfig),
+}
+#[derive(Clone)]
+enum CellFit {
+    Local(PyBayesianLocalLevelFit),
+    Seasonal(PyBayesianSeasonalLocalLevelFit),
+    Trend(PyBayesianLocalLinearTrendFit),
+    Ar(PyBayesianArFit),
+}
+#[derive(Clone)]
+enum CellForecast {
+    Local(CorePosteriorPredictiveForecast),
+    Seasonal(CoreSeasonalPosteriorPredictiveForecast),
+    Trend(CoreTrendPosteriorPredictiveForecast),
+    Ar(CoreBayesianArForecast),
+}
+impl Config {
+    fn fit(&self, observations: &[f64], seed: u64) -> Result<CellFit, String> {
+        match self {
+            Self::Local(base) => {
+                let mut config = base.clone();
+                config.seed = seed;
+                let posterior =
+                    fit_bayesian_local_level(observations, &config).map_err(|e| e.to_string())?;
+                Ok(CellFit::Local(PyBayesianLocalLevelFit {
+                    posterior,
+                    observations: observations.to_vec(),
+                    config,
+                }))
+            }
+            Self::Seasonal(base) => {
+                let mut config = base.clone();
+                config.seed = seed;
+                let posterior = fit_bayesian_seasonal_local_level(observations, &config)
+                    .map_err(|e| e.to_string())?;
+                Ok(CellFit::Seasonal(PyBayesianSeasonalLocalLevelFit {
+                    posterior,
+                    observations: observations.to_vec(),
+                    config,
+                }))
+            }
+            Self::Trend(base) => {
+                let mut config = base.clone();
+                config.seed = seed;
+                let posterior = fit_bayesian_local_linear_trend(observations, &config)
+                    .map_err(|e| e.to_string())?;
+                Ok(CellFit::Trend(PyBayesianLocalLinearTrendFit {
+                    posterior,
+                    observations: observations.to_vec(),
+                    config,
+                }))
+            }
+            Self::Ar(base) => {
+                let mut config = base.clone();
+                config.seed = seed;
+                let posterior =
+                    fit_bayesian_ar(observations, &config).map_err(|e| e.to_string())?;
+                Ok(CellFit::Ar(PyBayesianArFit {
+                    posterior,
+                    observations: observations.to_vec(),
+                    config,
+                }))
+            }
+        }
+    }
+}
+impl CellFit {
+    fn to_python(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        match self {
+            Self::Local(fit) => Ok(Py::new(py, fit.clone())?.into_any()),
+            Self::Seasonal(fit) => Ok(Py::new(py, fit.clone())?.into_any()),
+            Self::Trend(fit) => Ok(Py::new(py, fit.clone())?.into_any()),
+            Self::Ar(fit) => Ok(Py::new(py, fit.clone())?.into_any()),
+        }
+    }
+    fn report(&self) -> DiagnosticsReport {
+        match self {
+            Self::Local(fit) => fit.posterior.diagnostics(),
+            Self::Seasonal(fit) => fit.posterior.diagnostics(),
+            Self::Trend(fit) => fit.posterior.diagnostics(),
+            Self::Ar(fit) => fit.posterior.diagnostics(),
+        }
+    }
+    fn forecast(&self, steps: usize, seed: u64) -> Result<CellForecast, String> {
+        match self {
+            Self::Local(fit) => fit
+                .posterior
+                .forecast(steps, seed)
+                .map(CellForecast::Local)
+                .map_err(|e| e.to_string()),
+            Self::Seasonal(fit) => fit
+                .posterior
+                .forecast(steps, seed)
+                .map(CellForecast::Seasonal)
+                .map_err(|e| e.to_string()),
+            Self::Trend(fit) => fit
+                .posterior
+                .forecast(steps, seed)
+                .map(CellForecast::Trend)
+                .map_err(|e| e.to_string()),
+            Self::Ar(fit) => fit
+                .posterior
+                .forecast(steps, seed)
+                .map(CellForecast::Ar)
+                .map_err(|e| e.to_string()),
+        }
+    }
+}
+impl CellForecast {
+    fn to_python(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        match self {
+            Self::Local(inner) => Ok(Py::new(
+                py,
+                PyBayesianForecastResult {
+                    inner: inner.clone(),
+                },
+            )?
+            .into_any()),
+            Self::Seasonal(inner) => Ok(Py::new(
+                py,
+                PyBayesianSeasonalForecast {
+                    inner: inner.clone(),
+                },
+            )?
+            .into_any()),
+            Self::Trend(inner) => Ok(Py::new(
+                py,
+                PyBayesianTrendForecast {
+                    inner: inner.clone(),
+                },
+            )?
+            .into_any()),
+            Self::Ar(inner) => Ok(Py::new(
+                py,
+                PyBayesianArForecast {
+                    inner: inner.clone(),
+                },
+            )?
+            .into_any()),
+        }
+    }
+}
+
+fn run_cells<T: Sync, R: Send>(
+    cells: &[(String, T)],
+    seed: u64,
+    threads: usize,
+    chunk_size: usize,
+    errors: &str,
+    fit: impl Fn(&T, u64) -> Result<R, String> + Sync,
+) -> PyResult<Vec<Result<R, String>>> {
+    if errors == "raise" {
+        execute_batch_fail_fast(cells, seed, threads, chunk_size, fit)
+            .map(|results| results.into_iter().map(Ok).collect())
+            .map_err(|error| match error {
+                BatchError::Configuration(error) => PyValueError::new_err(error),
+                BatchError::Cell { id, error } => {
+                    StateSpaceError::new_err(format!("cell {id:?}: {error}"))
+                }
+            })
+    } else {
+        execute_batch(cells, seed, threads, chunk_size, fit).map_err(PyValueError::new_err)
+    }
+}
+
+fn check_errors(errors: &str) -> PyResult<()> {
+    if errors != "raise" && errors != "collect" {
+        return Err(PyValueError::new_err("errors must be 'raise' or 'collect'"));
+    }
+    Ok(())
+}
+fn collected_errors<'py, T>(
+    py: Python<'py>,
+    ids: &[String],
+    results: &[Result<T, String>],
+) -> PyResult<Bound<'py, PyDict>> {
+    let errors = PyDict::new(py);
+    for (id, result) in ids.iter().zip(results) {
+        if let Err(error) = result {
+            errors.set_item(id, error)?;
+        }
+    }
+    Ok(errors)
+}
+fn index_of(ids: &[String], id: &str) -> PyResult<usize> {
+    ids.iter()
+        .position(|candidate| candidate == id)
+        .ok_or_else(|| pyo3::exceptions::PyKeyError::new_err(id.to_string()))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn fit_batch(
+    py: Python<'_>,
+    observations: &Bound<'_, PyAny>,
+    ids: Vec<String>,
+    models: Option<&Bound<'_, PyAny>>,
+    default: Config,
+    chains: usize,
+    draws: usize,
+    warmup: usize,
+    thin: usize,
+    seed: u64,
+    threads: usize,
+    chunk_size: usize,
+    errors: &str,
+) -> PyResult<PyForecastBatchFit> {
+    check_errors(errors)?;
+    let rows = observations.try_iter()?.collect::<PyResult<Vec<_>>>()?;
+    if ids.len() != rows.len() {
+        return Err(PyValueError::new_err(
+            "ids and observations must have the same length",
+        ));
+    }
+    let models = models
+        .map(|values| values.try_iter()?.collect::<PyResult<Vec<_>>>())
+        .transpose()?;
+    if models
+        .as_ref()
+        .is_some_and(|values| values.len() != ids.len())
+    {
+        return Err(PyValueError::new_err("models must have one entry per cell"));
+    }
+    let mut cells = Vec::with_capacity(ids.len());
+    for (index, row) in rows.iter().enumerate() {
+        let input = (|| -> Result<(Vec<f64>, Config), String> {
+            let y = row
+                .extract::<Vec<f64>>()
+                .map_err(|e| format!("invalid observations: {e}"))?;
+            let config = if let Some(models) = &models {
+                let model = &models[index];
+                if model.is_none() {
+                    default.clone()
+                } else if let Ok(model) = model.extract::<PyRef<'_, PyBayesianLocalLevel>>() {
+                    model.batch_config(chains, draws, warmup, thin)
+                } else if let Ok(model) = model.extract::<PyRef<'_, PyBayesianSeasonalLocalLevel>>()
+                {
+                    model.batch_config(chains, draws, warmup, thin)
+                } else if let Ok(model) = model.extract::<PyRef<'_, PyBayesianLocalLinearTrend>>() {
+                    model.batch_config(chains, draws, warmup, thin)
+                } else if let Ok(model) = model.extract::<PyRef<'_, PyBayesianAutoRegression>>() {
+                    model.batch_config(chains, draws, warmup, thin)
+                } else {
+                    return Err(
+                        "invalid configuration: models entries must be forecasting models or None"
+                            .into(),
+                    );
+                }
+            } else {
+                default.clone()
+            };
+            Ok((y, config))
+        })();
+        cells.push((ids[index].clone(), input));
+    }
+    let results = py.allow_threads(|| {
+        run_cells(
+            &cells,
+            seed,
+            threads,
+            chunk_size,
+            errors,
+            |input, cell_seed| {
+                let (y, config) = input.as_ref().map_err(Clone::clone)?;
+                config.fit(y, cell_seed)
+            },
+        )
+    })?;
+    if errors == "raise" {
+        for (id, result) in ids.iter().zip(&results) {
+            if let Err(error) = result {
+                return Err(StateSpaceError::new_err(format!("cell {id:?}: {error}")));
+            }
+        }
+    }
+    Ok(PyForecastBatchFit { ids, results })
+}
+
+/// Results preserve requested cell order; failed cells have None in `results`.
+#[pyclass(name = "ForecastBatchFit")]
+pub(crate) struct PyForecastBatchFit {
+    ids: Vec<String>,
+    results: Vec<Result<CellFit, String>>,
+}
+#[pymethods]
+impl PyForecastBatchFit {
+    #[getter]
+    fn ids(&self) -> Vec<String> {
+        self.ids.clone()
+    }
+    fn __len__(&self) -> usize {
+        self.ids.len()
+    }
+    fn __getitem__(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        self.results[index_of(&self.ids, id)?]
+            .as_ref()
+            .map_err(|error| StateSpaceError::new_err(format!("cell {id:?}: {error}")))?
+            .to_python(py)
+    }
+    #[getter]
+    fn results(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
+        self.results
+            .iter()
+            .map(|result| match result {
+                Ok(fit) => fit.to_python(py),
+                Err(_) => Ok(py.None()),
+            })
+            .collect()
+    }
+    #[getter]
+    fn errors<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        collected_errors(py, &self.ids, &self.results)
+    }
+    fn diagnostics<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let output = PyDict::new(py);
+        for (id, result) in self.ids.iter().zip(&self.results) {
+            if let Ok(fit) = result {
+                output.set_item(
+                    id,
+                    forecast_diagnostics::diagnostics_list(py, &fit.report())?,
+                )?;
+            } else {
+                output.set_item(id, py.None())?;
+            }
+        }
+        Ok(output)
+    }
+    #[pyo3(signature = (steps, *, seed=43, threads=1, chunk_size=64, errors="raise"))]
+    fn forecast(
+        &self,
+        py: Python<'_>,
+        steps: usize,
+        seed: u64,
+        threads: usize,
+        chunk_size: usize,
+        errors: &str,
+    ) -> PyResult<PyForecastBatchForecast> {
+        check_errors(errors)?;
+        let cells = self
+            .ids
+            .iter()
+            .zip(&self.results)
+            .map(|(id, result)| (id.clone(), (result, stable_cell_seed(seed, id, "forecast"))))
+            .collect::<Vec<_>>();
+        let results = py.allow_threads(|| {
+            run_cells(
+                &cells,
+                seed,
+                threads,
+                chunk_size,
+                errors,
+                |(result, forecast_seed), _| {
+                    let fit = result.as_ref().map_err(Clone::clone)?;
+                    fit.forecast(steps, *forecast_seed)
+                },
+            )
+        })?;
+        if errors == "raise" {
+            for (id, result) in self.ids.iter().zip(&results) {
+                if let Err(error) = result {
+                    return Err(StateSpaceError::new_err(format!("cell {id:?}: {error}")));
+                }
+            }
+        }
+        Ok(PyForecastBatchForecast {
+            ids: self.ids.clone(),
+            results,
+        })
+    }
+}
+#[pyclass(name = "ForecastBatchForecast")]
+pub(crate) struct PyForecastBatchForecast {
+    ids: Vec<String>,
+    results: Vec<Result<CellForecast, String>>,
+}
+#[pymethods]
+impl PyForecastBatchForecast {
+    #[getter]
+    fn ids(&self) -> Vec<String> {
+        self.ids.clone()
+    }
+    fn __len__(&self) -> usize {
+        self.ids.len()
+    }
+    fn __getitem__(&self, py: Python<'_>, id: &str) -> PyResult<Py<PyAny>> {
+        self.results[index_of(&self.ids, id)?]
+            .as_ref()
+            .map_err(|error| StateSpaceError::new_err(format!("cell {id:?}: {error}")))?
+            .to_python(py)
+    }
+    #[getter]
+    fn results(&self, py: Python<'_>) -> PyResult<Vec<Py<PyAny>>> {
+        self.results
+            .iter()
+            .map(|result| match result {
+                Ok(forecast) => forecast.to_python(py),
+                Err(_) => Ok(py.None()),
+            })
+            .collect()
+    }
+    #[getter]
+    fn errors<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        collected_errors(py, &self.ids, &self.results)
+    }
+}
+
+/// Stable seed for reproducing one independent cell using the ordinary fit API.
+#[pyfunction]
+#[pyo3(signature = (seed, cell_id, domain="fit"))]
+pub(crate) fn forecast_cell_seed(seed: u64, cell_id: &str, domain: &str) -> PyResult<u64> {
+    if domain != "fit" && domain != "forecast" {
+        return Err(PyValueError::new_err("domain must be 'fit' or 'forecast'"));
+    }
+    Ok(stable_cell_seed(seed, cell_id, domain))
+}

--- a/python_bindings/src/forecast_diagnostics.rs
+++ b/python_bindings/src/forecast_diagnostics.rs
@@ -1,0 +1,54 @@
+//! Shared non-Hamiltonian diagnostic conversion.
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use rustmc_core::diagnostics::DiagnosticsReport;
+
+pub(crate) fn diagnostics_list<'py>(
+    py: Python<'py>,
+    report: &DiagnosticsReport,
+) -> PyResult<Bound<'py, PyList>> {
+    let items = PyList::empty(py);
+    for parameter in &report.params {
+        let item = PyDict::new(py);
+        item.set_item("name", &parameter.name)?;
+        for (key, value) in [
+            ("mean", parameter.mean),
+            ("std", parameter.std),
+            ("hdi_3%", parameter.hdi_3),
+            ("hdi_97%", parameter.hdi_97),
+            ("ess_bulk", parameter.ess_bulk),
+            ("ess_tail", parameter.ess_tail),
+            ("r_hat", parameter.r_hat),
+            ("mcse_mean", parameter.mcse_mean),
+        ] {
+            item.set_item(key, value.is_finite().then_some(value))?;
+        }
+        // Infinity means detected nonconvergence, not insufficient information.
+        if parameter.r_hat.is_infinite() {
+            item.set_item("r_hat", parameter.r_hat)?;
+        }
+        items.append(item)?;
+    }
+    Ok(items)
+}
+
+pub(crate) fn sampler_stats<'py>(
+    py: Python<'py>,
+    sampler: &str,
+    chains: usize,
+    draws: usize,
+    coverage: &str,
+) -> PyResult<Bound<'py, PyDict>> {
+    let stats = PyDict::new(py);
+    stats.set_item("sampler", sampler)?;
+    stats.set_item("chains", chains)?;
+    stats.set_item("draws", draws)?;
+    stats.set_item("divergences", py.None())?;
+    stats.set_item("acceptance_rate", py.None())?;
+    stats.set_item("numerical_failures", 0)?;
+    stats.set_item("diagnostic_coverage", coverage)?;
+    stats.set_item("r_hat_method", "rank-normalized folded split")?;
+    stats.set_item("independent_chain_comparison", chains >= 2)?;
+    stats.set_item("diagnostics_available", draws >= 6)?;
+    Ok(stats)
+}

--- a/python_bindings/src/hurdle.rs
+++ b/python_bindings/src/hurdle.rs
@@ -11,8 +11,66 @@ pub(crate) struct PyHurdleLogNormal {
     pub(crate) config: HurdleLogNormalConfig,
 }
 
+impl PyHurdleLogNormal {
+    pub(crate) fn batch_config(
+        &self,
+        chains: usize,
+        draws: usize,
+        warmup: usize,
+        thin: usize,
+    ) -> forecast_batch::Config {
+        let mut config = self.config.clone();
+        config.num_chains = chains;
+        config.num_draws = draws;
+        config.num_warmup = warmup;
+        config.thinning = thin;
+        forecast_batch::Config::Hurdle(config)
+    }
+}
+
 #[pymethods]
 impl PyHurdleLogNormal {
+    /// Fit independent sparse-amount cells with stable IDs on one native worker pool.
+    /// Optional models permit per-cell priors and mixed forecasting model families.
+    /// Hurdle cells do not support exog; regression cells in a mixed batch may use it.
+    #[pyo3(signature = (observations, ids, *, models=None, exog=None, coefficient_priors=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
+    #[allow(clippy::too_many_arguments)]
+    fn fit_batch(
+        &self,
+        py: Python<'_>,
+        observations: &Bound<'_, PyAny>,
+        ids: Vec<String>,
+        models: Option<&Bound<'_, PyAny>>,
+        exog: Option<&Bound<'_, PyAny>>,
+        coefficient_priors: Option<&Bound<'_, PyAny>>,
+        chains: usize,
+        draws: usize,
+        warmup: usize,
+        thin: usize,
+        seed: u64,
+        threads: usize,
+        chunk_size: usize,
+        errors: &str,
+    ) -> PyResult<forecast_batch::PyForecastBatchFit> {
+        forecast_batch::fit_batch(
+            py,
+            observations,
+            ids,
+            models,
+            exog,
+            coefficient_priors,
+            self.batch_config(chains, draws, warmup, thin),
+            chains,
+            draws,
+            warmup,
+            thin,
+            seed,
+            threads,
+            chunk_size,
+            errors,
+        )
+    }
+
     /// Independent Beta occurrence and dynamic lognormal positive amounts.
     /// Log-variance inverse-gamma priors are truncated at the explicit upper bounds.
     #[new]

--- a/python_bindings/src/hurdle.rs
+++ b/python_bindings/src/hurdle.rs
@@ -225,6 +225,7 @@ impl PyHurdleFit {
         };
         self.report().to_table_with_sampler(Some(sampler))
     }
+    #[getter]
     fn sampler_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let name = if self.positive_count() == 0 {
             "independent_prior_and_beta"
@@ -262,9 +263,7 @@ impl PyHurdleFit {
         let observed = PyDict::new(py);
         observed.set_item("y", self.observations.clone().into_pyarray(py))?;
         kwargs.set_item("observed_data", observed)?;
-        py.import("arviz")?
-            .getattr("from_dict")?
-            .call((), Some(&kwargs))
+        arviz_from_groups(&py.import("arviz")?, kwargs)
     }
 }
 

--- a/python_bindings/src/hurdle.rs
+++ b/python_bindings/src/hurdle.rs
@@ -1,0 +1,361 @@
+//! Python bindings for sparse nonnegative amount forecasting.
+use super::*;
+use rustmc_core::forecast_diagnostics::parameter_diagnostics;
+use rustmc_core::hurdle::{
+    fit_hurdle_lognormal, HurdleLogNormalConfig, HurdleLogNormalForecast, HurdleLogNormalPosterior,
+};
+
+#[pyclass(name = "BayesianHurdleLogNormal", module = "rustmc")]
+#[derive(Clone)]
+pub(crate) struct PyHurdleLogNormal {
+    pub(crate) config: HurdleLogNormalConfig,
+}
+
+#[pymethods]
+impl PyHurdleLogNormal {
+    /// Independent Beta occurrence and dynamic lognormal positive amounts.
+    /// Log-variance inverse-gamma priors are truncated at the explicit upper bounds.
+    #[new]
+    #[pyo3(signature = (process_variance_prior, observation_variance_prior, occurrence_alpha=1.0, occurrence_beta=1.0, initial_log_level=0.0, initial_variance=1.0, process_variance_upper=1.0, observation_variance_upper=4.0))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        process_variance_prior: PyRef<'_, PyInverseGammaPrior>,
+        observation_variance_prior: PyRef<'_, PyInverseGammaPrior>,
+        occurrence_alpha: f64,
+        occurrence_beta: f64,
+        initial_log_level: f64,
+        initial_variance: f64,
+        process_variance_upper: f64,
+        observation_variance_upper: f64,
+    ) -> PyResult<Self> {
+        let config = HurdleLogNormalConfig {
+            process_variance_prior: process_variance_prior.inner,
+            observation_variance_prior: observation_variance_prior.inner,
+            occurrence_alpha,
+            occurrence_beta,
+            initial_log_level,
+            initial_variance,
+            process_variance_upper,
+            observation_variance_upper,
+            num_chains: 4,
+            num_draws: 1000,
+            num_warmup: 500,
+            thinning: 1,
+            seed: 42,
+        };
+        config.validate().map_err(bayesian_forecast_error)?;
+        Ok(Self { config })
+    }
+
+    #[pyo3(signature = (observations, chains=4, draws=1000, warmup=500, thin=1, seed=42))]
+    #[allow(clippy::too_many_arguments)]
+    fn fit(
+        &self,
+        py: Python<'_>,
+        observations: PyReadonlyArray1<'_, f64>,
+        chains: usize,
+        draws: usize,
+        warmup: usize,
+        thin: usize,
+        seed: u64,
+    ) -> PyResult<PyHurdleFit> {
+        let observations = state_space_vector(observations);
+        let mut config = self.config.clone();
+        config.num_chains = chains;
+        config.num_draws = draws;
+        config.num_warmup = warmup;
+        config.thinning = thin;
+        config.seed = seed;
+        let posterior = py
+            .allow_threads(|| fit_hurdle_lognormal(&observations, &config))
+            .map_err(bayesian_forecast_error)?;
+        Ok(PyHurdleFit {
+            posterior,
+            observations,
+            config,
+        })
+    }
+
+    #[getter]
+    fn process_variance_upper(&self) -> f64 {
+        self.config.process_variance_upper
+    }
+    #[getter]
+    fn observation_variance_upper(&self) -> f64 {
+        self.config.observation_variance_upper
+    }
+    fn __repr__(&self) -> String {
+        format!("BayesianHurdleLogNormal(occurrence_alpha={}, occurrence_beta={}, initial_log_level={}, process_variance_upper={}, observation_variance_upper={})",
+            self.config.occurrence_alpha, self.config.occurrence_beta, self.config.initial_log_level,
+            self.config.process_variance_upper, self.config.observation_variance_upper)
+    }
+}
+
+#[pyclass(name = "BayesianHurdleLogNormalFit", module = "rustmc")]
+#[derive(Clone)]
+pub(crate) struct PyHurdleFit {
+    pub(crate) posterior: HurdleLogNormalPosterior,
+    pub(crate) observations: Vec<f64>,
+    pub(crate) config: HurdleLogNormalConfig,
+}
+
+impl PyHurdleFit {
+    pub(crate) fn report(&self) -> rustmc_core::diagnostics::DiagnosticsReport {
+        parameter_diagnostics(
+            &self.posterior.parameter_samples(),
+            &HurdleLogNormalPosterior::parameter_names(),
+        )
+    }
+}
+
+#[pymethods]
+impl PyHurdleFit {
+    #[getter]
+    fn chains(&self) -> usize {
+        self.posterior.chains.len()
+    }
+    #[getter]
+    fn draws(&self) -> usize {
+        self.posterior.chains[0].len()
+    }
+    #[getter]
+    fn time_count(&self) -> usize {
+        self.posterior.time_count
+    }
+    #[getter]
+    fn observed_count(&self) -> usize {
+        self.posterior.observed_count
+    }
+    #[getter]
+    fn positive_count(&self) -> usize {
+        self.posterior.positive_count
+    }
+    #[getter]
+    fn severity_informed_by_data(&self) -> bool {
+        self.positive_count() > 0
+    }
+    #[getter]
+    fn warmup(&self) -> usize {
+        self.config.num_warmup
+    }
+    #[getter]
+    fn thin(&self) -> usize {
+        self.config.thinning
+    }
+
+    fn get_samples_2d<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let samples = PyDict::new(py);
+        let values = self.posterior.parameter_samples();
+        for (i, name) in HurdleLogNormalPosterior::parameter_names()
+            .iter()
+            .enumerate()
+        {
+            let array =
+                Array2::from_shape_fn((self.chains(), self.draws()), |(c, d)| values[c][d][i]);
+            samples.set_item(name, array.into_pyarray(py))?;
+        }
+        Ok(samples)
+    }
+    fn diagnostics<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        forecast_diagnostics::diagnostics_list(py, &self.report())
+    }
+    fn summary(&self) -> String {
+        let sampler = if self.positive_count() == 0 {
+            "Sampler: independent Beta and truncated-prior severity draws (no positive observations)"
+        } else {
+            "Sampler: Beta occurrence and conjugate truncated-variance Gibbs/FFBS severity"
+        };
+        self.report().to_table_with_sampler(Some(sampler))
+    }
+    fn sampler_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let name = if self.positive_count() == 0 {
+            "independent_prior_and_beta"
+        } else {
+            "gibbs_ffbs_hurdle_lognormal"
+        };
+        let stats = forecast_diagnostics::sampler_stats(
+            py,
+            name,
+            self.chains(),
+            self.draws(),
+            "payment probability, variance parameters, and terminal log level",
+        )?;
+        stats.set_item(
+            "severity_informed_by_data",
+            self.severity_informed_by_data(),
+        )?;
+        stats.set_item("process_variance_upper", self.config.process_variance_upper)?;
+        stats.set_item(
+            "observation_variance_upper",
+            self.config.observation_variance_upper,
+        )?;
+        Ok(stats)
+    }
+    #[pyo3(signature = (steps, seed=43))]
+    fn forecast(&self, py: Python<'_>, steps: usize, seed: u64) -> PyResult<PyHurdleForecast> {
+        let inner = py
+            .allow_threads(|| self.posterior.forecast(steps, seed))
+            .map_err(bayesian_forecast_error)?;
+        Ok(PyHurdleForecast { inner })
+    }
+    fn to_arviz<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("posterior", self.get_samples_2d(py)?)?;
+        let observed = PyDict::new(py);
+        observed.set_item("y", self.observations.clone().into_pyarray(py))?;
+        kwargs.set_item("observed_data", observed)?;
+        py.import("arviz")?
+            .getattr("from_dict")?
+            .call((), Some(&kwargs))
+    }
+}
+
+#[pyclass(name = "BayesianHurdleLogNormalForecast", module = "rustmc")]
+#[derive(Clone)]
+pub(crate) struct PyHurdleForecast {
+    pub(crate) inner: HurdleLogNormalForecast,
+}
+
+#[pymethods]
+impl PyHurdleForecast {
+    #[getter]
+    fn chains(&self) -> usize {
+        self.inner.paths.observation_paths.len()
+    }
+    #[getter]
+    fn draws(&self) -> usize {
+        self.inner.paths.observation_paths[0].len()
+    }
+    #[getter]
+    fn steps(&self) -> usize {
+        self.inner.paths.horizon()
+    }
+    #[getter]
+    fn observation_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        local_level_path_array(py, &self.inner.paths.observation_paths)
+    }
+    /// Conditional arithmetic means including probability of no payment.
+    #[getter]
+    fn mean_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        local_level_path_array(py, &self.inner.paths.state_paths)
+    }
+    #[getter]
+    fn positive_mean_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        local_level_path_array(py, &self.inner.positive_mean_paths)
+    }
+    #[getter]
+    fn observation_mean<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        Ok(self
+            .inner
+            .paths
+            .observation_means()
+            .map_err(bayesian_forecast_error)?
+            .into_pyarray(py))
+    }
+    #[getter]
+    fn mean<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        Ok(self
+            .inner
+            .paths
+            .state_means()
+            .map_err(bayesian_forecast_error)?
+            .into_pyarray(py))
+    }
+    #[getter]
+    fn cumulative_observation_samples<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, PyArray3<f64>>> {
+        Ok(local_level_path_array(py, &self.cumulative_paths()?))
+    }
+    #[pyo3(signature = (level=0.95))]
+    fn interval<'py>(&self, py: Python<'py>, level: f64) -> PyResult<PyIntervalArrays<'py>> {
+        self.quantile_interval(py, &self.inner.paths, level, false)
+    }
+    #[pyo3(signature = (level=0.95))]
+    fn mean_interval<'py>(&self, py: Python<'py>, level: f64) -> PyResult<PyIntervalArrays<'py>> {
+        self.quantile_interval(py, &self.inner.paths, level, true)
+    }
+    #[pyo3(signature = (level=0.95))]
+    fn cumulative_interval<'py>(
+        &self,
+        py: Python<'py>,
+        level: f64,
+    ) -> PyResult<PyIntervalArrays<'py>> {
+        let paths = CorePosteriorPredictiveForecast {
+            state_paths: Vec::new(),
+            observation_paths: self.cumulative_paths()?,
+        };
+        self.quantile_interval(py, &paths, level, false)
+    }
+    #[getter]
+    fn uncertainty_kind(&self) -> &'static str {
+        "parameter_integrated_posterior_predictive"
+    }
+    #[getter]
+    fn interval_kind(&self) -> &'static str {
+        "pointwise_equal_tailed"
+    }
+}
+
+impl PyHurdleForecast {
+    fn cumulative_paths(&self) -> PyResult<Vec<Vec<Vec<f64>>>> {
+        self.inner
+            .paths
+            .observation_paths
+            .iter()
+            .map(|chain| {
+                chain
+                    .iter()
+                    .map(|path| {
+                        let mut sum = 0.0;
+                        path.iter()
+                            .map(|x| {
+                                sum += x;
+                                if sum.is_finite() {
+                                    Ok(sum)
+                                } else {
+                                    Err(InferenceError::new_err("cumulative payment overflowed"))
+                                }
+                            })
+                            .collect()
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+    fn quantile_interval<'py>(
+        &self,
+        py: Python<'py>,
+        paths: &CorePosteriorPredictiveForecast,
+        level: f64,
+        mean: bool,
+    ) -> PyResult<PyIntervalArrays<'py>> {
+        validate_interval_level(level)?;
+        let probs = [(1.0 - level) / 2.0, (1.0 + level) / 2.0];
+        let q = if mean {
+            paths.state_quantiles(&probs)
+        } else {
+            paths.observation_quantiles(&probs)
+        }
+        .map_err(bayesian_forecast_error)?;
+        Ok((
+            q[0].values.clone().into_pyarray(py),
+            q[1].values.clone().into_pyarray(py),
+        ))
+    }
+}
+
+#[pyfunction(name = "hurdle_lognormal_logp")]
+fn logp(y: f64, payment_probability: f64, log_level: f64, log_variance: f64) -> PyResult<f64> {
+    rustmc_core::hurdle::hurdle_lognormal_logp(y, payment_probability, log_level, log_variance)
+        .map_err(bayesian_forecast_error)
+}
+
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyHurdleLogNormal>()?;
+    m.add_class::<PyHurdleFit>()?;
+    m.add_class::<PyHurdleForecast>()?;
+    m.add_function(wrap_pyfunction!(logp, m)?)?;
+    Ok(())
+}

--- a/python_bindings/src/lib.rs
+++ b/python_bindings/src/lib.rs
@@ -1,6 +1,7 @@
 mod forecast_batch;
 mod forecast_diagnostics;
 mod regression;
+mod runoff;
 use ndarray::{Array2, Array3, Array4};
 use numpy::{
     IntoPyArray, PyArray1, PyArray2, PyArray3, PyArray4, PyReadonlyArray1, PyReadonlyArray2,
@@ -7224,6 +7225,7 @@ fn validate_interval_level(level: f64) -> PyResult<()> {
 #[pymodule]
 fn rustmc(m: &Bound<'_, PyModule>) -> PyResult<()> {
     regression::register(m)?;
+    runoff::register(m)?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<ModelBuilder>()?;
     m.add_class::<ModelSpec>()?;

--- a/python_bindings/src/lib.rs
+++ b/python_bindings/src/lib.rs
@@ -1,5 +1,6 @@
 mod forecast_batch;
 mod forecast_diagnostics;
+mod regression;
 use ndarray::{Array2, Array3, Array4};
 use numpy::{
     IntoPyArray, PyArray1, PyArray2, PyArray3, PyArray4, PyReadonlyArray1, PyReadonlyArray2,
@@ -4064,7 +4065,8 @@ fn state_covariances_array<'py>(
     .into_pyarray(py)
 }
 
-/// A time-homogeneous linear Gaussian state-space model with scalar observations.
+/// A linear Gaussian state-space model with scalar observations and constant
+/// transition and process matrices. Observation rows may vary by time.
 /// Initial moments describe the state immediately before the first observation;
 /// filtering performs one prediction before updating on observations[0].
 #[pyclass(name = "LinearGaussianStateSpace")]
@@ -4209,6 +4211,17 @@ impl PyLinearGaussianStateSpace {
         self.inner.dimension()
     }
 
+    /// Return a model with a finite observation row for each training time.
+    fn with_observation_rows(&self, observation_rows: PyReadonlyArray2<'_, f64>) -> PyResult<Self> {
+        Ok(Self {
+            inner: self
+                .inner
+                .clone()
+                .with_observation_rows(regression::rows(observation_rows))
+                .map_err(state_space_error)?,
+        })
+    }
+
     fn filter(
         &self,
         py: Python<'_>,
@@ -4233,15 +4246,28 @@ impl PyLinearGaussianStateSpace {
         Ok(PyKalmanSmootherResult::new(result, self.inner.dimension()))
     }
 
+    #[pyo3(signature=(observations, steps, *, future_observation_rows=None))]
     fn forecast(
         &self,
         py: Python<'_>,
         observations: PyReadonlyArray1<'_, f64>,
         steps: usize,
+        future_observation_rows: Option<PyReadonlyArray2<'_, f64>>,
     ) -> PyResult<PyForecastResult> {
         let observations = state_space_vector(observations);
+        let future_rows = future_observation_rows.map(regression::rows);
+        if future_rows.as_ref().is_some_and(|rows| rows.len() != steps) {
+            return Err(StateSpaceError::new_err(
+                "future observation row count must equal steps",
+            ));
+        }
         let result = py
-            .allow_threads(|| self.inner.forecast(&observations, steps))
+            .allow_threads(|| match future_rows {
+                Some(rows) => self
+                    .inner
+                    .forecast_with_observation_rows(&observations, &rows),
+                None => self.inner.forecast(&observations, steps),
+            })
             .map_err(state_space_error)?;
         Ok(PyForecastResult::new(result, self.inner.dimension()))
     }
@@ -5363,7 +5389,7 @@ impl PyBayesianLocalLevel {
         }
     }
 
-    #[pyo3(signature = (observations, chains=4, draws=1000, warmup=500, thin=1, seed=42))]
+    #[pyo3(signature = (observations, chains=4, draws=1000, warmup=500, thin=1, seed=42, *, exog=None, coefficient_prior=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &self,
@@ -5374,8 +5400,30 @@ impl PyBayesianLocalLevel {
         warmup: usize,
         thin: usize,
         seed: u64,
-    ) -> PyResult<PyBayesianLocalLevelFit> {
+        exog: Option<PyReadonlyArray2<'_, f64>>,
+        coefficient_prior: Option<PyRef<'_, regression::PyGaussianCoefficientPrior>>,
+    ) -> PyResult<PyObject> {
         let observations = state_space_vector(observations);
+        if let Some(exog) = exog {
+            let config = regression::config(
+                CoreLinearGaussianStateSpace::local_level(
+                    1.0,
+                    1.0,
+                    self.initial_mean,
+                    self.initial_variance,
+                )
+                .map_err(state_space_error)?,
+                vec![self.process_variance_prior],
+                vec!["process_variance"],
+                self.observation_variance_prior,
+                false,
+                (chains, draws, warmup, thin, seed),
+            );
+            return regression::fit(py, observations, exog, coefficient_prior, config);
+        }
+        if coefficient_prior.is_some() {
+            return Err(StateSpaceError::new_err("coefficient_prior requires exog"));
+        }
         let config = CoreBayesianLocalLevelConfig {
             initial_mean: self.initial_mean,
             initial_variance: self.initial_variance,
@@ -5390,11 +5438,15 @@ impl PyBayesianLocalLevel {
         let posterior = py
             .allow_threads(|| fit_bayesian_local_level(&observations, &config))
             .map_err(bayesian_forecast_error)?;
-        Ok(PyBayesianLocalLevelFit {
-            posterior,
-            observations,
-            config,
-        })
+        Ok(Py::new(
+            py,
+            PyBayesianLocalLevelFit {
+                posterior,
+                observations,
+                config,
+            },
+        )?
+        .into_any())
     }
 
     fn __repr__(&self) -> String {
@@ -5777,7 +5829,7 @@ impl PyBayesianSeasonalLocalLevel {
         self.initial_seasonal_effects.clone().into_pyarray(py)
     }
 
-    #[pyo3(signature = (observations, chains=4, draws=1000, warmup=500, thin=1, seed=42))]
+    #[pyo3(signature = (observations, chains=4, draws=1000, warmup=500, thin=1, seed=42, *, exog=None, coefficient_prior=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &self,
@@ -5788,8 +5840,34 @@ impl PyBayesianSeasonalLocalLevel {
         warmup: usize,
         thin: usize,
         seed: u64,
-    ) -> PyResult<PyBayesianSeasonalLocalLevelFit> {
+        exog: Option<PyReadonlyArray2<'_, f64>>,
+        coefficient_prior: Option<PyRef<'_, regression::PyGaussianCoefficientPrior>>,
+    ) -> PyResult<PyObject> {
         let observations = state_space_vector(observations);
+        if let Some(exog) = exog {
+            let config = regression::config(
+                CoreLinearGaussianStateSpace::seasonal_local_level(
+                    self.period,
+                    1.0,
+                    1.0,
+                    1.0,
+                    self.initial_level,
+                    self.initial_seasonal_effects.clone(),
+                    self.initial_level_variance,
+                    self.initial_seasonal_variance,
+                )
+                .map_err(state_space_error)?,
+                vec![self.level_variance_prior, self.seasonal_variance_prior],
+                vec!["level_variance", "seasonal_variance"],
+                self.observation_variance_prior,
+                true,
+                (chains, draws, warmup, thin, seed),
+            );
+            return regression::fit(py, observations, exog, coefficient_prior, config);
+        }
+        if coefficient_prior.is_some() {
+            return Err(StateSpaceError::new_err("coefficient_prior requires exog"));
+        }
         let config = CoreBayesianSeasonalLocalLevelConfig {
             period: self.period,
             initial_level: self.initial_level,
@@ -5808,11 +5886,15 @@ impl PyBayesianSeasonalLocalLevel {
         let posterior = py
             .allow_threads(|| fit_bayesian_seasonal_local_level(&observations, &config))
             .map_err(bayesian_forecast_error)?;
-        Ok(PyBayesianSeasonalLocalLevelFit {
-            posterior,
-            observations,
-            config,
-        })
+        Ok(Py::new(
+            py,
+            PyBayesianSeasonalLocalLevelFit {
+                posterior,
+                observations,
+                config,
+            },
+        )?
+        .into_any())
     }
 
     fn __repr__(&self) -> String {
@@ -6297,7 +6379,7 @@ impl PyBayesianLocalLinearTrend {
         }
     }
 
-    #[pyo3(signature = (observations, chains=4, draws=1000, warmup=500, thin=1, seed=42))]
+    #[pyo3(signature = (observations, chains=4, draws=1000, warmup=500, thin=1, seed=42, *, exog=None, coefficient_prior=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &self,
@@ -6308,8 +6390,33 @@ impl PyBayesianLocalLinearTrend {
         warmup: usize,
         thin: usize,
         seed: u64,
-    ) -> PyResult<PyBayesianLocalLinearTrendFit> {
+        exog: Option<PyReadonlyArray2<'_, f64>>,
+        coefficient_prior: Option<PyRef<'_, regression::PyGaussianCoefficientPrior>>,
+    ) -> PyResult<PyObject> {
         let observations = state_space_vector(observations);
+        if let Some(exog) = exog {
+            let config = regression::config(
+                CoreLinearGaussianStateSpace::new(
+                    2,
+                    vec![1.0, 1.0, 0.0, 1.0],
+                    vec![1.0, 0.0],
+                    vec![1.0, 0.0, 0.0, 1.0],
+                    1.0,
+                    self.initial_mean.to_vec(),
+                    self.initial_covariance.to_vec(),
+                )
+                .map_err(state_space_error)?,
+                vec![self.level_variance_prior, self.slope_variance_prior],
+                vec!["level_variance", "slope_variance"],
+                self.observation_variance_prior,
+                false,
+                (chains, draws, warmup, thin, seed),
+            );
+            return regression::fit(py, observations, exog, coefficient_prior, config);
+        }
+        if coefficient_prior.is_some() {
+            return Err(StateSpaceError::new_err("coefficient_prior requires exog"));
+        }
         let config = CoreBayesianLocalLinearTrendConfig {
             initial_mean: self.initial_mean,
             initial_covariance: self.initial_covariance,
@@ -6325,11 +6432,15 @@ impl PyBayesianLocalLinearTrend {
         let posterior = py
             .allow_threads(|| fit_bayesian_local_linear_trend(&observations, &config))
             .map_err(bayesian_forecast_error)?;
-        Ok(PyBayesianLocalLinearTrendFit {
-            posterior,
-            observations,
-            config,
-        })
+        Ok(Py::new(
+            py,
+            PyBayesianLocalLinearTrendFit {
+                posterior,
+                observations,
+                config,
+            },
+        )?
+        .into_any())
     }
 
     fn __repr__(&self) -> String {
@@ -7112,6 +7223,7 @@ fn validate_interval_level(level: f64) -> PyResult<()> {
 
 #[pymodule]
 fn rustmc(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    regression::register(m)?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_class::<ModelBuilder>()?;
     m.add_class::<ModelSpec>()?;

--- a/python_bindings/src/lib.rs
+++ b/python_bindings/src/lib.rs
@@ -1,3 +1,5 @@
+mod forecast_batch;
+mod forecast_diagnostics;
 use ndarray::{Array2, Array3, Array4};
 use numpy::{
     IntoPyArray, PyArray1, PyArray2, PyArray3, PyArray4, PyReadonlyArray1, PyReadonlyArray2,
@@ -4961,34 +4963,24 @@ impl PyBayesianHierarchicalMeanFit {
 
     /// Formatted rank-normalized R-hat, ESS, MCSE, and HDI diagnostics.
     fn summary(&self) -> String {
-        self.posterior.diagnostics().to_table().replace(
-            "Mean accept rate: 1.00  │  Divergences: 0",
-            "Sampler: conjugate Gibbs (no Metropolis acceptance or divergences)",
-        )
+        self.posterior.diagnostics().to_table_with_sampler(Some(
+            "Sampler: conjugate Gibbs (acceptance and divergences unavailable)",
+        ))
     }
 
-    /// Per-parameter convergence diagnostics. Variance-component ESS is
-    /// particularly important when the hierarchy is weakly identified.
     fn diagnostics<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
-        let report = self.posterior.diagnostics();
-        let items = report
-            .params
-            .iter()
-            .map(|parameter| {
-                let item = PyDict::new(py);
-                item.set_item("name", &parameter.name)?;
-                item.set_item("mean", parameter.mean)?;
-                item.set_item("std", parameter.std)?;
-                item.set_item("hdi_3%", parameter.hdi_3)?;
-                item.set_item("hdi_97%", parameter.hdi_97)?;
-                item.set_item("ess_bulk", parameter.ess_bulk)?;
-                item.set_item("ess_tail", parameter.ess_tail)?;
-                item.set_item("r_hat", parameter.r_hat)?;
-                item.set_item("mcse_mean", parameter.mcse_mean)?;
-                Ok(item)
-            })
-            .collect::<PyResult<Vec<_>>>()?;
-        PyList::new(py, &items)
+        forecast_diagnostics::diagnostics_list(py, &self.posterior.diagnostics())
+    }
+
+    #[getter]
+    fn sampler_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        forecast_diagnostics::sampler_stats(
+            py,
+            "conjugate Gibbs",
+            self.chains(),
+            self.draws(),
+            "all retained hierarchical parameters",
+        )
     }
 
     #[pyo3(signature = (steps, seed=43))]
@@ -5286,6 +5278,41 @@ struct PyBayesianLocalLevel {
 
 #[pymethods]
 impl PyBayesianLocalLevel {
+    /// Fit independent ragged cells on one bounded native worker pool.
+    #[pyo3(signature = (observations, ids, *, models=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
+    #[allow(clippy::too_many_arguments)]
+    fn fit_batch(
+        &self,
+        py: Python<'_>,
+        observations: &Bound<'_, PyAny>,
+        ids: Vec<String>,
+        models: Option<&Bound<'_, PyAny>>,
+        chains: usize,
+        draws: usize,
+        warmup: usize,
+        thin: usize,
+        seed: u64,
+        threads: usize,
+        chunk_size: usize,
+        errors: &str,
+    ) -> PyResult<forecast_batch::PyForecastBatchFit> {
+        forecast_batch::fit_batch(
+            py,
+            observations,
+            ids,
+            models,
+            self.batch_config(chains, draws, warmup, thin),
+            chains,
+            draws,
+            warmup,
+            thin,
+            seed,
+            threads,
+            chunk_size,
+            errors,
+        )
+    }
+
     #[new]
     #[pyo3(signature = (process_variance_prior, observation_variance_prior, initial_mean=0.0, initial_variance=100.0))]
     fn new(
@@ -5384,6 +5411,7 @@ impl PyBayesianLocalLevel {
 }
 
 #[pyclass(name = "BayesianLocalLevelFit")]
+#[derive(Clone)]
 struct PyBayesianLocalLevelFit {
     posterior: CoreLocalLevelPosterior,
     observations: Vec<f64>,
@@ -5392,6 +5420,28 @@ struct PyBayesianLocalLevelFit {
 
 #[pymethods]
 impl PyBayesianLocalLevelFit {
+    /// Rank-normalized folded split R-hat, bulk/tail ESS, MCSE and HDIs.
+    fn summary(&self) -> String {
+        self.posterior.diagnostics().to_table_with_sampler(Some(
+            "Sampler: conjugate Gibbs/FFBS; acceptance and divergences unavailable",
+        ))
+    }
+
+    fn diagnostics<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        forecast_diagnostics::diagnostics_list(py, &self.posterior.diagnostics())
+    }
+
+    #[getter]
+    fn sampler_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        forecast_diagnostics::sampler_stats(
+            py,
+            "conjugate Gibbs/FFBS",
+            self.chains(),
+            self.draws(),
+            "variance parameters and terminal level; historical states are not retained",
+        )
+    }
+
     #[getter]
     fn chains(&self) -> usize {
         self.posterior.chains.len()
@@ -5643,6 +5693,41 @@ struct PyBayesianSeasonalLocalLevel {
 
 #[pymethods]
 impl PyBayesianSeasonalLocalLevel {
+    /// Fit independent ragged cells on one bounded native worker pool.
+    #[pyo3(signature = (observations, ids, *, models=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
+    #[allow(clippy::too_many_arguments)]
+    fn fit_batch(
+        &self,
+        py: Python<'_>,
+        observations: &Bound<'_, PyAny>,
+        ids: Vec<String>,
+        models: Option<&Bound<'_, PyAny>>,
+        chains: usize,
+        draws: usize,
+        warmup: usize,
+        thin: usize,
+        seed: u64,
+        threads: usize,
+        chunk_size: usize,
+        errors: &str,
+    ) -> PyResult<forecast_batch::PyForecastBatchFit> {
+        forecast_batch::fit_batch(
+            py,
+            observations,
+            ids,
+            models,
+            self.batch_config(chains, draws, warmup, thin),
+            chains,
+            draws,
+            warmup,
+            thin,
+            seed,
+            threads,
+            chunk_size,
+            errors,
+        )
+    }
+
     #[new]
     #[pyo3(signature = (period, level_variance_prior, seasonal_variance_prior, observation_variance_prior, initial_level=0.0, initial_seasonal_effects=None, initial_level_variance=100.0, initial_seasonal_variance=10.0))]
     #[allow(clippy::too_many_arguments)]
@@ -5739,6 +5824,7 @@ impl PyBayesianSeasonalLocalLevel {
 }
 
 #[pyclass(name = "BayesianSeasonalLocalLevelFit")]
+#[derive(Clone)]
 struct PyBayesianSeasonalLocalLevelFit {
     posterior: CoreSeasonalLocalLevelPosterior,
     observations: Vec<f64>,
@@ -5747,6 +5833,22 @@ struct PyBayesianSeasonalLocalLevelFit {
 
 #[pymethods]
 impl PyBayesianSeasonalLocalLevelFit {
+    /// Rank-normalized folded split R-hat, bulk/tail ESS, MCSE and HDIs.
+    fn summary(&self) -> String {
+        self.posterior.diagnostics().to_table_with_sampler(Some(
+            "Sampler: conjugate Gibbs/FFBS; acceptance and divergences unavailable",
+        ))
+    }
+
+    fn diagnostics<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        forecast_diagnostics::diagnostics_list(py, &self.posterior.diagnostics())
+    }
+
+    #[getter]
+    fn sampler_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        forecast_diagnostics::sampler_stats(py, "conjugate Gibbs/FFBS", self.chains(), self.draws(), "variance parameters and all terminal seasonal state coordinates; historical states are not retained")
+    }
+
     #[getter]
     fn chains(&self) -> usize {
         self.posterior.chains.len()
@@ -6062,6 +6164,41 @@ struct PyBayesianLocalLinearTrend {
 
 #[pymethods]
 impl PyBayesianLocalLinearTrend {
+    /// Fit independent ragged cells on one bounded native worker pool.
+    #[pyo3(signature = (observations, ids, *, models=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
+    #[allow(clippy::too_many_arguments)]
+    fn fit_batch(
+        &self,
+        py: Python<'_>,
+        observations: &Bound<'_, PyAny>,
+        ids: Vec<String>,
+        models: Option<&Bound<'_, PyAny>>,
+        chains: usize,
+        draws: usize,
+        warmup: usize,
+        thin: usize,
+        seed: u64,
+        threads: usize,
+        chunk_size: usize,
+        errors: &str,
+    ) -> PyResult<forecast_batch::PyForecastBatchFit> {
+        forecast_batch::fit_batch(
+            py,
+            observations,
+            ids,
+            models,
+            self.batch_config(chains, draws, warmup, thin),
+            chains,
+            draws,
+            warmup,
+            thin,
+            seed,
+            threads,
+            chunk_size,
+            errors,
+        )
+    }
+
     #[new]
     #[pyo3(signature = (
         level_variance_prior,
@@ -6204,6 +6341,7 @@ impl PyBayesianLocalLinearTrend {
 }
 
 #[pyclass(name = "BayesianLocalLinearTrendFit")]
+#[derive(Clone)]
 struct PyBayesianLocalLinearTrendFit {
     posterior: CoreLocalLinearTrendPosterior,
     observations: Vec<f64>,
@@ -6212,6 +6350,28 @@ struct PyBayesianLocalLinearTrendFit {
 
 #[pymethods]
 impl PyBayesianLocalLinearTrendFit {
+    /// Rank-normalized folded split R-hat, bulk/tail ESS, MCSE and HDIs.
+    fn summary(&self) -> String {
+        self.posterior.diagnostics().to_table_with_sampler(Some(
+            "Sampler: conjugate Gibbs/FFBS; acceptance and divergences unavailable",
+        ))
+    }
+
+    fn diagnostics<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        forecast_diagnostics::diagnostics_list(py, &self.posterior.diagnostics())
+    }
+
+    #[getter]
+    fn sampler_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        forecast_diagnostics::sampler_stats(
+            py,
+            "conjugate Gibbs/FFBS",
+            self.chains(),
+            self.draws(),
+            "variance parameters, terminal level and slope; historical states are not retained",
+        )
+    }
+
     #[getter]
     fn chains(&self) -> usize {
         self.posterior.chains.len()
@@ -6601,6 +6761,41 @@ struct PyBayesianAutoRegression {
 
 #[pymethods]
 impl PyBayesianAutoRegression {
+    /// Fit independent ragged cells on one bounded native worker pool.
+    #[pyo3(signature = (observations, ids, *, models=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
+    #[allow(clippy::too_many_arguments)]
+    fn fit_batch(
+        &self,
+        py: Python<'_>,
+        observations: &Bound<'_, PyAny>,
+        ids: Vec<String>,
+        models: Option<&Bound<'_, PyAny>>,
+        chains: usize,
+        draws: usize,
+        warmup: usize,
+        thin: usize,
+        seed: u64,
+        threads: usize,
+        chunk_size: usize,
+        errors: &str,
+    ) -> PyResult<forecast_batch::PyForecastBatchFit> {
+        forecast_batch::fit_batch(
+            py,
+            observations,
+            ids,
+            models,
+            self.batch_config(chains, draws, warmup, thin),
+            chains,
+            draws,
+            warmup,
+            thin,
+            seed,
+            threads,
+            chunk_size,
+            errors,
+        )
+    }
+
     #[new]
     fn new(order: usize, prior: PyRef<'_, PyNormalInverseGammaPrior>) -> PyResult<Self> {
         if order == 0 {
@@ -6673,6 +6868,7 @@ impl PyBayesianAutoRegression {
 }
 
 #[pyclass(name = "BayesianARFit")]
+#[derive(Clone)]
 struct PyBayesianArFit {
     posterior: CoreBayesianArPosterior,
     observations: Vec<f64>,
@@ -6681,6 +6877,28 @@ struct PyBayesianArFit {
 
 #[pymethods]
 impl PyBayesianArFit {
+    /// Rank-normalized folded split R-hat, bulk/tail ESS, MCSE and HDIs.
+    fn summary(&self) -> String {
+        self.posterior.diagnostics().to_table_with_sampler(Some(
+            "Sampler: exact conjugate independent draws; acceptance and divergences unavailable",
+        ))
+    }
+
+    fn diagnostics<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        forecast_diagnostics::diagnostics_list(py, &self.posterior.diagnostics())
+    }
+
+    #[getter]
+    fn sampler_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        forecast_diagnostics::sampler_stats(
+            py,
+            "exact conjugate independent draws",
+            self.chains(),
+            self.draws(),
+            "coefficients and innovation variance",
+        )
+    }
+
     #[getter]
     fn order(&self) -> usize {
         self.posterior.order
@@ -6905,6 +7123,9 @@ fn rustmc(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyCompiledModel>()?;
     m.add_class::<PyBoundModel>()?;
     m.add_class::<PyBatchFit>()?;
+    m.add_function(wrap_pyfunction!(forecast_batch::forecast_cell_seed, m)?)?;
+    m.add_class::<forecast_batch::PyForecastBatchFit>()?;
+    m.add_class::<forecast_batch::PyForecastBatchForecast>()?;
     m.add_class::<PyLinearGaussianStateSpace>()?;
     m.add_class::<PyKalmanFilterResult>()?;
     m.add_class::<PyKalmanSmootherResult>()?;
@@ -6934,4 +7155,101 @@ fn rustmc(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(batch_sample, m)?)?;
     m.add_function(wrap_pyfunction!(sample_prior_predictive, m)?)?;
     Ok(())
+}
+
+impl PyBayesianLocalLevel {
+    fn batch_config(
+        &self,
+        chains: usize,
+        draws: usize,
+        warmup: usize,
+        thin: usize,
+    ) -> forecast_batch::Config {
+        let seed = 0;
+
+        forecast_batch::Config::Local(CoreBayesianLocalLevelConfig {
+            initial_mean: self.initial_mean,
+            initial_variance: self.initial_variance,
+            process_variance_prior: self.process_variance_prior,
+            observation_variance_prior: self.observation_variance_prior,
+            num_chains: chains,
+            num_warmup: warmup,
+            num_draws: draws,
+            thinning: thin,
+            seed,
+        })
+    }
+}
+
+impl PyBayesianSeasonalLocalLevel {
+    fn batch_config(
+        &self,
+        chains: usize,
+        draws: usize,
+        warmup: usize,
+        thin: usize,
+    ) -> forecast_batch::Config {
+        let seed = 0;
+
+        forecast_batch::Config::Seasonal(CoreBayesianSeasonalLocalLevelConfig {
+            period: self.period,
+            initial_level: self.initial_level,
+            initial_seasonal_effects: self.initial_seasonal_effects.clone(),
+            initial_level_variance: self.initial_level_variance,
+            initial_seasonal_variance: self.initial_seasonal_variance,
+            level_variance_prior: self.level_variance_prior,
+            seasonal_variance_prior: self.seasonal_variance_prior,
+            observation_variance_prior: self.observation_variance_prior,
+            num_chains: chains,
+            num_warmup: warmup,
+            num_draws: draws,
+            thinning: thin,
+            seed,
+        })
+    }
+}
+
+impl PyBayesianLocalLinearTrend {
+    fn batch_config(
+        &self,
+        chains: usize,
+        draws: usize,
+        warmup: usize,
+        thin: usize,
+    ) -> forecast_batch::Config {
+        let seed = 0;
+
+        forecast_batch::Config::Trend(CoreBayesianLocalLinearTrendConfig {
+            initial_mean: self.initial_mean,
+            initial_covariance: self.initial_covariance,
+            level_variance_prior: self.level_variance_prior,
+            slope_variance_prior: self.slope_variance_prior,
+            observation_variance_prior: self.observation_variance_prior,
+            num_chains: chains,
+            num_warmup: warmup,
+            num_draws: draws,
+            thinning: thin,
+            seed,
+        })
+    }
+}
+
+impl PyBayesianAutoRegression {
+    fn batch_config(
+        &self,
+        chains: usize,
+        draws: usize,
+        warmup: usize,
+        thin: usize,
+    ) -> forecast_batch::Config {
+        let seed = 0;
+        let _ = (warmup, thin);
+        forecast_batch::Config::Ar(CoreBayesianArConfig {
+            order: self.order,
+            prior: self.prior.clone(),
+            num_chains: chains,
+            num_draws: draws,
+            seed,
+        })
+    }
 }

--- a/python_bindings/src/lib.rs
+++ b/python_bindings/src/lib.rs
@@ -5307,7 +5307,7 @@ struct PyBayesianLocalLevel {
 #[pymethods]
 impl PyBayesianLocalLevel {
     /// Fit independent ragged cells on one bounded native worker pool.
-    #[pyo3(signature = (observations, ids, *, models=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
+    #[pyo3(signature = (observations, ids, *, models=None, exog=None, coefficient_priors=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
     #[allow(clippy::too_many_arguments)]
     fn fit_batch(
         &self,
@@ -5315,6 +5315,8 @@ impl PyBayesianLocalLevel {
         observations: &Bound<'_, PyAny>,
         ids: Vec<String>,
         models: Option<&Bound<'_, PyAny>>,
+        exog: Option<&Bound<'_, PyAny>>,
+        coefficient_priors: Option<&Bound<'_, PyAny>>,
         chains: usize,
         draws: usize,
         warmup: usize,
@@ -5329,6 +5331,8 @@ impl PyBayesianLocalLevel {
             observations,
             ids,
             models,
+            exog,
+            coefficient_priors,
             self.batch_config(chains, draws, warmup, thin),
             chains,
             draws,
@@ -5748,7 +5752,7 @@ struct PyBayesianSeasonalLocalLevel {
 #[pymethods]
 impl PyBayesianSeasonalLocalLevel {
     /// Fit independent ragged cells on one bounded native worker pool.
-    #[pyo3(signature = (observations, ids, *, models=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
+    #[pyo3(signature = (observations, ids, *, models=None, exog=None, coefficient_priors=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
     #[allow(clippy::too_many_arguments)]
     fn fit_batch(
         &self,
@@ -5756,6 +5760,8 @@ impl PyBayesianSeasonalLocalLevel {
         observations: &Bound<'_, PyAny>,
         ids: Vec<String>,
         models: Option<&Bound<'_, PyAny>>,
+        exog: Option<&Bound<'_, PyAny>>,
+        coefficient_priors: Option<&Bound<'_, PyAny>>,
         chains: usize,
         draws: usize,
         warmup: usize,
@@ -5770,6 +5776,8 @@ impl PyBayesianSeasonalLocalLevel {
             observations,
             ids,
             models,
+            exog,
+            coefficient_priors,
             self.batch_config(chains, draws, warmup, thin),
             chains,
             draws,
@@ -6249,7 +6257,7 @@ struct PyBayesianLocalLinearTrend {
 #[pymethods]
 impl PyBayesianLocalLinearTrend {
     /// Fit independent ragged cells on one bounded native worker pool.
-    #[pyo3(signature = (observations, ids, *, models=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
+    #[pyo3(signature = (observations, ids, *, models=None, exog=None, coefficient_priors=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
     #[allow(clippy::too_many_arguments)]
     fn fit_batch(
         &self,
@@ -6257,6 +6265,8 @@ impl PyBayesianLocalLinearTrend {
         observations: &Bound<'_, PyAny>,
         ids: Vec<String>,
         models: Option<&Bound<'_, PyAny>>,
+        exog: Option<&Bound<'_, PyAny>>,
+        coefficient_priors: Option<&Bound<'_, PyAny>>,
         chains: usize,
         draws: usize,
         warmup: usize,
@@ -6271,6 +6281,8 @@ impl PyBayesianLocalLinearTrend {
             observations,
             ids,
             models,
+            exog,
+            coefficient_priors,
             self.batch_config(chains, draws, warmup, thin),
             chains,
             draws,
@@ -6875,7 +6887,7 @@ struct PyBayesianAutoRegression {
 #[pymethods]
 impl PyBayesianAutoRegression {
     /// Fit independent ragged cells on one bounded native worker pool.
-    #[pyo3(signature = (observations, ids, *, models=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
+    #[pyo3(signature = (observations, ids, *, models=None, exog=None, coefficient_priors=None, chains=4, draws=1000, warmup=500, thin=1, seed=42, threads=1, chunk_size=64, errors="raise"))]
     #[allow(clippy::too_many_arguments)]
     fn fit_batch(
         &self,
@@ -6883,6 +6895,8 @@ impl PyBayesianAutoRegression {
         observations: &Bound<'_, PyAny>,
         ids: Vec<String>,
         models: Option<&Bound<'_, PyAny>>,
+        exog: Option<&Bound<'_, PyAny>>,
+        coefficient_priors: Option<&Bound<'_, PyAny>>,
         chains: usize,
         draws: usize,
         warmup: usize,
@@ -6897,6 +6911,8 @@ impl PyBayesianAutoRegression {
             observations,
             ids,
             models,
+            exog,
+            coefficient_priors,
             self.batch_config(chains, draws, warmup, thin),
             chains,
             draws,

--- a/python_bindings/src/lib.rs
+++ b/python_bindings/src/lib.rs
@@ -1,5 +1,6 @@
 mod forecast_batch;
 mod forecast_diagnostics;
+mod hurdle;
 mod regression;
 mod runoff;
 use ndarray::{Array2, Array3, Array4};
@@ -7224,6 +7225,7 @@ fn validate_interval_level(level: f64) -> PyResult<()> {
 
 #[pymodule]
 fn rustmc(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    hurdle::register(m)?;
     regression::register(m)?;
     runoff::register(m)?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;

--- a/python_bindings/src/regression.rs
+++ b/python_bindings/src/regression.rs
@@ -129,6 +129,19 @@ pub(crate) struct PyBayesianRegressionFit {
 }
 #[pymethods]
 impl PyBayesianRegressionFit {
+    fn summary(&self) -> String {
+        self.posterior.diagnostics().to_table_with_sampler(Some(
+            "Sampler: joint conjugate Gibbs/FFBS; acceptance and divergences unavailable",
+        ))
+    }
+    fn diagnostics<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        forecast_diagnostics::diagnostics_list(py, &self.posterior.diagnostics())
+    }
+    #[getter]
+    fn sampler_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        forecast_diagnostics::sampler_stats(py, "joint conjugate Gibbs/FFBS", self.chains(), self.draws(),
+            "all variance parameters, regression coefficients and terminal structural states; historical states are not retained")
+    }
     #[getter]
     fn chains(&self) -> usize {
         self.posterior.chains.len()

--- a/python_bindings/src/regression.rs
+++ b/python_bindings/src/regression.rs
@@ -1,0 +1,379 @@
+type IntervalArrays<'py> = (Bound<'py, PyArray1<f64>>, Bound<'py, PyArray1<f64>>);
+use super::*;
+use rustmc_core::bayesian_regression::{
+    self as core, GaussianCoefficientPrior, RegressionConfig, RegressionForecast,
+    RegressionPosterior,
+};
+
+#[pyclass(name = "GaussianCoefficientPrior", frozen)]
+#[derive(Clone)]
+pub(crate) struct PyGaussianCoefficientPrior {
+    pub(crate) inner: GaussianCoefficientPrior,
+}
+#[pymethods]
+impl PyGaussianCoefficientPrior {
+    #[new]
+    fn new(
+        mean: PyReadonlyArray1<'_, f64>,
+        covariance: PyReadonlyArray2<'_, f64>,
+    ) -> PyResult<Self> {
+        let mean = state_space_vector(mean);
+        let (covariance, p) = state_space_matrix("coefficient covariance", covariance)?;
+        if mean.len() != p || p == 0 {
+            return Err(StateSpaceError::new_err(
+                "coefficient mean and covariance dimensions must agree and be nonempty",
+            ));
+        }
+        CoreLinearGaussianStateSpace::local_level(1.0, 1.0, 0.0, 1.0)
+            .map_err(state_space_error)?
+            .with_static_regression(&[], &mean, &covariance)
+            .map_err(state_space_error)?;
+        Ok(Self {
+            inner: GaussianCoefficientPrior { mean, covariance },
+        })
+    }
+    #[getter]
+    fn mean<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        self.inner.mean.clone().into_pyarray(py)
+    }
+    #[getter]
+    fn covariance<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray2<f64>> {
+        let p = self.inner.mean.len();
+        Array2::from_shape_fn((p, p), |(i, j)| self.inner.covariance[i * p + j]).into_pyarray(py)
+    }
+}
+pub(crate) fn rows(array: PyReadonlyArray2<'_, f64>) -> Vec<Vec<f64>> {
+    array
+        .as_array()
+        .rows()
+        .into_iter()
+        .map(|r| r.iter().copied().collect())
+        .collect()
+}
+
+#[pyfunction]
+#[pyo3(signature=(count, period, harmonics, start=0))]
+fn fourier_design<'py>(
+    py: Python<'py>,
+    count: usize,
+    period: usize,
+    harmonics: usize,
+    start: i64,
+) -> PyResult<Bound<'py, PyArray2<f64>>> {
+    let rows = core::fourier_design(count, period, harmonics, start).map_err(state_space_error)?;
+    let p = 2 * harmonics - usize::from(2 * harmonics == period);
+    Ok(Array2::from_shape_fn((count, p), |(i, j)| rows[i][j]).into_pyarray(py))
+}
+
+pub(crate) fn fit(
+    py: Python<'_>,
+    observations: Vec<f64>,
+    exog: PyReadonlyArray2<'_, f64>,
+    prior: Option<PyRef<'_, PyGaussianCoefficientPrior>>,
+    mut config: RegressionConfig,
+) -> PyResult<PyObject> {
+    config.coefficient_prior = prior
+        .ok_or_else(|| {
+            StateSpaceError::new_err(
+                "exog requires an explicit GaussianCoefficientPrior via coefficient_prior",
+            )
+        })?
+        .inner
+        .clone();
+    let design = rows(exog);
+    let posterior = py
+        .allow_threads(|| core::fit_regression(&observations, &design, &config))
+        .map_err(state_space_error)?;
+    Ok(Py::new(
+        py,
+        PyBayesianRegressionFit {
+            posterior,
+            observations,
+        },
+    )?
+    .into_any())
+}
+pub(crate) fn config(
+    structural_model: CoreLinearGaussianStateSpace,
+    variance_priors: Vec<CoreInverseGammaPrior>,
+    variance_names: Vec<&str>,
+    observation_variance_prior: CoreInverseGammaPrior,
+    seasonal: bool,
+    sampling: (usize, usize, usize, usize, u64),
+) -> RegressionConfig {
+    let (num_chains, num_draws, num_warmup, thinning, seed) = sampling;
+    RegressionConfig {
+        innovation_indices: (0..variance_priors.len()).collect(),
+        structural_model,
+        variance_priors,
+        variance_names: variance_names.into_iter().map(str::to_string).collect(),
+        observation_variance_prior,
+        coefficient_prior: GaussianCoefficientPrior {
+            mean: vec![],
+            covariance: vec![],
+        },
+        num_chains,
+        num_draws,
+        num_warmup,
+        thinning,
+        seed,
+        seasonal,
+    }
+}
+
+#[pyclass(name = "BayesianRegressionFit")]
+#[derive(Clone)]
+pub(crate) struct PyBayesianRegressionFit {
+    pub(crate) posterior: RegressionPosterior,
+    pub(crate) observations: Vec<f64>,
+}
+#[pymethods]
+impl PyBayesianRegressionFit {
+    #[getter]
+    fn chains(&self) -> usize {
+        self.posterior.chains.len()
+    }
+    #[getter]
+    fn draws(&self) -> usize {
+        self.posterior.chains[0].len()
+    }
+    #[getter]
+    fn time_count(&self) -> usize {
+        self.observations.len()
+    }
+    #[getter]
+    fn observed_count(&self) -> usize {
+        self.observations.iter().filter(|v| v.is_finite()).count()
+    }
+    #[getter]
+    fn warmup(&self) -> usize {
+        self.posterior.config.num_warmup
+    }
+    #[getter]
+    fn thin(&self) -> usize {
+        self.posterior.config.thinning
+    }
+    fn get_samples_2d<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let result = PyDict::new(py);
+        for (i, name) in self.posterior.config.variance_names.iter().enumerate() {
+            result.set_item(
+                name,
+                Array2::from_shape_fn((self.chains(), self.draws()), |(c, d)| {
+                    self.posterior.chains[c][d].variances[i]
+                })
+                .into_pyarray(py),
+            )?;
+        }
+        result.set_item(
+            "observation_variance",
+            Array2::from_shape_fn((self.chains(), self.draws()), |(c, d)| {
+                self.posterior.chains[c][d].observation_variance
+            })
+            .into_pyarray(py),
+        )?;
+        let p = self.posterior.config.coefficient_prior.mean.len();
+        result.set_item(
+            "coefficients",
+            Array3::from_shape_fn((self.chains(), self.draws(), p), |(c, d, p)| {
+                self.posterior.chains[c][d].coefficients[p]
+            })
+            .into_pyarray(py),
+        )?;
+        let n = self.posterior.config.structural_model.dimension();
+        result.set_item(
+            "terminal_state",
+            Array3::from_shape_fn((self.chains(), self.draws(), n), |(c, d, p)| {
+                self.posterior.chains[c][d].terminal_state[p]
+            })
+            .into_pyarray(py),
+        )?;
+        Ok(result)
+    }
+    #[pyo3(signature=(steps, seed=43, *, exog=None))]
+    fn forecast(
+        &self,
+        py: Python<'_>,
+        steps: usize,
+        seed: u64,
+        exog: Option<PyReadonlyArray2<'_, f64>>,
+    ) -> PyResult<PyBayesianRegressionForecast> {
+        let design = rows(exog.ok_or_else(|| {
+            StateSpaceError::new_err("future exog is required for regression forecasts")
+        })?);
+        if design.len() != steps {
+            return Err(StateSpaceError::new_err(
+                "future exog row count must equal steps",
+            ));
+        }
+        let inner = py
+            .allow_threads(|| self.posterior.forecast(&design, seed))
+            .map_err(state_space_error)?;
+        Ok(PyBayesianRegressionForecast {
+            inner,
+            seasonal: self.posterior.config.seasonal,
+            dimension: self.posterior.config.structural_model.dimension(),
+        })
+    }
+    fn to_arviz<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let az = py.import("arviz")?;
+        let groups = PyDict::new(py);
+        groups.set_item("posterior", self.get_samples_2d(py)?)?;
+        let observed = PyDict::new(py);
+        observed.set_item("y", self.observations.clone().into_pyarray(py))?;
+        groups.set_item("observed_data", observed)?;
+        arviz_from_groups(&az, groups)
+    }
+}
+
+#[pyclass(name = "BayesianRegressionForecast")]
+pub(crate) struct PyBayesianRegressionForecast {
+    pub(crate) inner: RegressionForecast,
+    pub(crate) seasonal: bool,
+    pub(crate) dimension: usize,
+}
+#[pymethods]
+impl PyBayesianRegressionForecast {
+    #[getter]
+    fn chains(&self) -> usize {
+        self.inner.observation_paths.len()
+    }
+    #[getter]
+    fn draws(&self) -> usize {
+        self.inner.observation_paths[0].len()
+    }
+    #[getter]
+    fn steps(&self) -> usize {
+        self.inner.observation_paths[0][0].len()
+    }
+    #[getter]
+    fn observation_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        local_level_path_array(py, &self.inner.observation_paths)
+    }
+    #[getter]
+    fn cumulative_observation_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        local_level_path_array(py, &self.inner.cumulative_observation_paths)
+    }
+    #[getter]
+    fn state_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        local_level_path_array(py, &self.inner.level_paths)
+    }
+    #[getter]
+    fn level_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        self.state_samples(py)
+    }
+    #[getter]
+    fn seasonal_samples<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f64>>> {
+        if !self.seasonal {
+            return Err(PyValueError::new_err(
+                "model has no stochastic seasonal component",
+            ));
+        }
+        Ok(local_level_path_array(py, &self.inner.secondary_paths))
+    }
+    #[getter]
+    fn slope_samples<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f64>>> {
+        if self.seasonal || self.dimension != 2 {
+            return Err(PyValueError::new_err("model has no slope component"));
+        }
+        Ok(local_level_path_array(py, &self.inner.secondary_paths))
+    }
+    #[getter]
+    fn regression_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        local_level_path_array(py, &self.inner.regression_paths)
+    }
+    #[getter]
+    fn mean_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        local_level_path_array(py, &self.inner.mean_paths)
+    }
+    #[getter]
+    fn observation_mean<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        means(&self.inner.observation_paths).into_pyarray(py)
+    }
+    #[getter]
+    fn cumulative_observation_mean<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<f64>> {
+        means(&self.inner.cumulative_observation_paths).into_pyarray(py)
+    }
+    #[pyo3(signature=(probability=0.9))]
+    fn observation_interval<'py>(
+        &self,
+        py: Python<'py>,
+        probability: f64,
+    ) -> PyResult<IntervalArrays<'py>> {
+        interval(py, &self.inner.observation_paths, probability)
+    }
+    #[pyo3(signature=(probability=0.9))]
+    fn cumulative_observation_interval<'py>(
+        &self,
+        py: Python<'py>,
+        probability: f64,
+    ) -> PyResult<IntervalArrays<'py>> {
+        interval(py, &self.inner.cumulative_observation_paths, probability)
+    }
+    #[pyo3(signature=(level=0.95))]
+    fn interval<'py>(&self, py: Python<'py>, level: f64) -> PyResult<IntervalArrays<'py>> {
+        if !level.is_finite() || level <= 0.0 || level >= 1.0 {
+            return Err(PyValueError::new_err(
+                "level must be strictly between zero and one",
+            ));
+        }
+        interval(py, &self.inner.observation_paths, level)
+    }
+    #[pyo3(signature=(level=0.95))]
+    fn cumulative_interval<'py>(
+        &self,
+        py: Python<'py>,
+        level: f64,
+    ) -> PyResult<IntervalArrays<'py>> {
+        if !level.is_finite() || level <= 0.0 || level >= 1.0 {
+            return Err(PyValueError::new_err(
+                "level must be strictly between zero and one",
+            ));
+        }
+        interval(py, &self.inner.cumulative_observation_paths, level)
+    }
+    #[getter]
+    fn uncertainty_kind(&self) -> &'static str {
+        "parameter_integrated_posterior_predictive"
+    }
+    #[getter]
+    fn interval_kind(&self) -> &'static str {
+        "pointwise_equal_tailed"
+    }
+}
+fn means(paths: &core::Paths) -> Vec<f64> {
+    (0..paths[0][0].len())
+        .map(|i| {
+            paths.iter().flatten().map(|p| p[i]).sum::<f64>()
+                / (paths.len() * paths[0].len()) as f64
+        })
+        .collect()
+}
+fn interval<'py>(
+    py: Python<'py>,
+    paths: &core::Paths,
+    probability: f64,
+) -> PyResult<IntervalArrays<'py>> {
+    validate_probability(probability)?;
+    let mut lower = vec![];
+    let mut upper = vec![];
+    for i in 0..paths[0][0].len() {
+        let mut values: Vec<f64> = paths.iter().flatten().map(|p| p[i]).collect();
+        values.sort_by(f64::total_cmp);
+        let quantile = |p: f64| {
+            let index = p * (values.len() - 1) as f64;
+            let lo = index.floor() as usize;
+            let hi = index.ceil() as usize;
+            values[lo] * (1.0 - index.fract()) + values[hi] * index.fract()
+        };
+        lower.push(quantile((1.0 - probability) / 2.0));
+        upper.push(quantile((1.0 + probability) / 2.0));
+    }
+    Ok((lower.into_pyarray(py), upper.into_pyarray(py)))
+}
+pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyGaussianCoefficientPrior>()?;
+    m.add_class::<PyBayesianRegressionFit>()?;
+    m.add_class::<PyBayesianRegressionForecast>()?;
+    m.add_function(wrap_pyfunction!(fourier_design, m)?)?;
+    Ok(())
+}

--- a/python_bindings/src/runoff.rs
+++ b/python_bindings/src/runoff.rs
@@ -1,0 +1,255 @@
+use ndarray::{Array2, Array3, Array4};
+use numpy::{IntoPyArray, PyArray2, PyArray3, PyArray4, PyReadonlyArray2};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use rustmc_core::runoff::{fit_runoff, PaymentTriangle, RunoffConfig, RunoffPosterior};
+
+/// Pooled Dirichlet lag probabilities for integer payment-event counts.
+/// The last alpha entry is an unscheduled tail. Unknown ultimate counts use an
+/// independent Gamma(total_shape, rate=total_rate) Poisson intensity per cohort.
+/// This model does not accept currency as multinomial event counts.
+#[pyclass(name = "DirichletMultinomialRunoff")]
+pub struct PyRunoff {
+    alpha: Vec<f64>,
+    total_shape: f64,
+    total_rate: f64,
+}
+
+#[pymethods]
+impl PyRunoff {
+    #[new]
+    #[pyo3(signature = (alpha, *, total_shape=2.0, total_rate=0.1))]
+    fn new(alpha: Vec<f64>, total_shape: f64, total_rate: f64) -> PyResult<Self> {
+        if alpha.len() < 2
+            || alpha.iter().any(|a| !a.is_finite() || *a <= 0.0)
+            || !alpha.iter().sum::<f64>().is_finite()
+            || !total_shape.is_finite()
+            || total_shape <= 0.0
+            || !total_rate.is_finite()
+            || total_rate <= 0.0
+        {
+            return Err(PyValueError::new_err("alpha requires at least two finite positive entries; total_shape and total_rate must be finite and positive"));
+        }
+        Ok(Self {
+            alpha,
+            total_shape,
+            total_rate,
+        })
+    }
+
+    /// Fit incremental counts[cohort, lag], with NaN for future/unobserved cells.
+    /// Elapsed regular lags must be observed, including exact zeros. The last column
+    /// is an unobserved tail unless explicitly closed. Origins/valuation use integer
+    /// periods and lag zero occurs at origin. None totals infer unknown ultimates.
+    /// All-known totals use exact independent draws; warmup is ignored in that case.
+    #[pyo3(signature = (counts, origins, valuation, totals=None, *, draws=1000, warmup=500, chains=4, seed=42))]
+    #[allow(clippy::too_many_arguments)]
+    fn fit(
+        &self,
+        py: Python<'_>,
+        counts: PyReadonlyArray2<'_, f64>,
+        origins: Vec<i64>,
+        valuation: i64,
+        totals: Option<Vec<Option<u64>>>,
+        draws: usize,
+        warmup: usize,
+        chains: usize,
+        seed: u64,
+    ) -> PyResult<PyRunoffFit> {
+        let counts = counts.as_array().rows().into_iter().map(|row| {
+            row.iter().map(|n| {
+                if n.is_nan() {
+                    Ok(None)
+                } else if !n.is_finite() || *n < 0.0 || n.fract() != 0.0 || *n > ((1_u64 << 53) - 1) as f64 {
+                    Err(PyValueError::new_err("counts must be nonnegative integers <= 2**53 - 1, or NaN for unobserved cells"))
+                } else {
+                    Ok(Some(*n as u64))
+                }
+            }).collect::<PyResult<Vec<_>>>()
+        }).collect::<PyResult<Vec<_>>>()?;
+        let triangle = PaymentTriangle {
+            known_totals: totals.unwrap_or_else(|| vec![None; counts.len()]),
+            counts,
+            origins,
+            valuation,
+        };
+        let config = RunoffConfig {
+            alpha: self.alpha.clone(),
+            total_shape: self.total_shape,
+            total_rate: self.total_rate,
+            draws,
+            warmup,
+            chains,
+            seed,
+        };
+        let inner = py
+            .allow_threads(|| fit_runoff(&triangle, &config))
+            .map_err(PyValueError::new_err)?;
+        Ok(PyRunoffFit { inner })
+    }
+}
+
+#[pyclass(name = "RunoffFit")]
+pub struct PyRunoffFit {
+    inner: RunoffPosterior,
+}
+
+fn array3<'py, T: numpy::Element>(
+    py: Python<'py>,
+    data: Vec<Vec<Vec<T>>>,
+) -> Bound<'py, PyArray3<T>> {
+    let shape = (data.len(), data[0].len(), data[0][0].len());
+    Array3::from_shape_vec(shape, data.into_iter().flatten().flatten().collect())
+        .unwrap()
+        .into_pyarray(py)
+}
+
+#[pymethods]
+impl PyRunoffFit {
+    fn diagnostics<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        crate::forecast_diagnostics::diagnostics_list(py, &self.inner.diagnostics())
+    }
+
+    fn summary(&self) -> String {
+        self.inner
+            .diagnostics()
+            .to_table_with_sampler(Some(&format!("Sampler: {}", self.sampler())))
+    }
+
+    fn sampler_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        crate::forecast_diagnostics::sampler_stats(
+            py,
+            self.sampler(),
+            self.inner.chains.len(),
+            self.inner.chains[0].len(),
+            "shared lag probabilities; unknown cohort intensities and ultimate counts",
+        )
+    }
+
+    /// Complete integer allocations, shape (chain, draw, cohort, lag including tail).
+    #[getter]
+    fn allocation_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray4<u64>> {
+        let shape = (
+            self.inner.chains.len(),
+            self.inner.chains[0].len(),
+            self.inner.triangle.counts.len(),
+            self.inner.triangle.counts[0].len(),
+        );
+        let data = self
+            .inner
+            .chains
+            .iter()
+            .flatten()
+            .flat_map(|d| d.counts.iter().flatten().copied())
+            .collect();
+        Array4::from_shape_vec(shape, data)
+            .unwrap()
+            .into_pyarray(py)
+    }
+
+    /// Shared lag probabilities, shape (chain, draw, lag including tail).
+    #[getter]
+    fn lag_probability_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        array3(
+            py,
+            self.inner
+                .chains
+                .iter()
+                .map(|c| c.iter().map(|d| d.lag_probabilities.clone()).collect())
+                .collect(),
+        )
+    }
+
+    /// Ultimate event counts, shape (chain, draw, cohort).
+    #[getter]
+    fn ultimate_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<u64>> {
+        array3(
+            py,
+            self.inner
+                .chains
+                .iter()
+                .map(|c| c.iter().map(|d| d.totals.clone()).collect())
+                .collect(),
+        )
+    }
+
+    /// Gamma-Poisson intensity draws; known-total cohorts have NaN, not a parameter.
+    #[getter]
+    fn intensity_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<f64>> {
+        array3(
+            py,
+            self.inner
+                .chains
+                .iter()
+                .map(|c| {
+                    c.iter()
+                        .map(|d| {
+                            d.intensities
+                                .iter()
+                                .map(|v| v.unwrap_or(f64::NAN))
+                                .collect()
+                        })
+                        .collect()
+                })
+                .collect(),
+        )
+    }
+
+    /// Remaining unscheduled tail counts, shape (chain, draw, cohort).
+    #[getter]
+    fn tail_samples<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray3<u64>> {
+        array3(py, self.inner.tail_samples())
+    }
+
+    /// Aggregate future regular-lag paths at valuation+1,...,valuation+steps.
+    /// Tail counts and regular cells beyond steps are excluded; use tail_samples
+    /// and allocation_samples to account for the full reserve.
+    fn calendar_samples<'py>(
+        &self,
+        py: Python<'py>,
+        steps: usize,
+    ) -> PyResult<Bound<'py, PyArray3<u64>>> {
+        let values = self
+            .inner
+            .calendar_samples(steps)
+            .map_err(PyValueError::new_err)?;
+        Ok(array3(py, values))
+    }
+
+    #[getter]
+    fn observed_mask<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray2<bool>> {
+        let rows = &self.inner.triangle.counts;
+        Array2::from_shape_vec(
+            (rows.len(), rows[0].len()),
+            rows.iter().flatten().map(Option::is_some).collect(),
+        )
+        .unwrap()
+        .into_pyarray(py)
+    }
+
+    #[getter]
+    fn origins(&self) -> Vec<i64> {
+        self.inner.triangle.origins.clone()
+    }
+
+    #[getter]
+    fn valuation(&self) -> i64 {
+        self.inner.triangle.valuation
+    }
+
+    #[getter]
+    fn sampler(&self) -> &'static str {
+        if self.inner.exact {
+            "independent_conjugate"
+        } else {
+            "latent_count_gibbs"
+        }
+    }
+}
+
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyRunoff>()?;
+    m.add_class::<PyRunoffFit>()?;
+    Ok(())
+}

--- a/python_bindings/src/runoff.rs
+++ b/python_bindings/src/runoff.rs
@@ -117,6 +117,7 @@ impl PyRunoffFit {
             .to_table_with_sampler(Some(&format!("Sampler: {}", self.sampler())))
     }
 
+    #[getter]
     fn sampler_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         crate::forecast_diagnostics::sampler_stats(
             py,

--- a/rust_core/Cargo.toml
+++ b/rust_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustmc_core"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Structure-aware Bayesian inference engine"
 license = "MIT"

--- a/rust_core/README.md
+++ b/rust_core/README.md
@@ -41,8 +41,13 @@ population → group → program Gaussian posterior with a specialized conjugate
 kernel. Its forecast paths are indexed `[chain][draw][program][step]`, so downstream
 Rust code can aggregate aligned draws without discarding cross-program dependence.
 
-Current limitations include no fitted covariate or multiple-seasonality state-space
-model, no stable serialized deployment format, and no stability guarantee for the alpha Rust API. See the
+`bayesian_regression` jointly samples Gaussian coefficient, structural-state, and
+variance uncertainty with time-varying designs. `forecast_batch` provides independent
+cell execution with stable ID seeds. `hurdle` fits sparse nonnegative amounts, and
+`runoff` provides censored payment-count development with known or uncertain ultimates.
+
+Current limitations include no automatic inference planner, no stable serialized
+deployment format, and no stability guarantee for the alpha Rust API. See the
 [repository](https://github.com/tbosier/rustmc) for Python documentation, examples, and the
 ordered roadmap.
 

--- a/rust_core/README.md
+++ b/rust_core/README.md
@@ -11,7 +11,7 @@ process. It is not presented as a general replacement for Stan or PyMC.
 
 ```toml
 [dependencies]
-rustmc_core = "0.10"
+rustmc_core = "0.11"
 ```
 
 ```rust

--- a/rust_core/src/bayesian_regression.rs
+++ b/rust_core/src/bayesian_regression.rs
@@ -1,0 +1,632 @@
+//! Joint Gaussian regression and structural-state Gibbs/FFBS inference.
+//!
+//! Proper Gaussian coefficient priors are independent of variance priors.
+//! Coefficients are static latent states with exactly zero innovation variance;
+//! every forecast path retains one joint coefficient/state/variance draw.
+use crate::bayesian_forecast::InverseGammaPrior;
+use crate::state_space::{LinearGaussianStateSpace, StateSpaceError};
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use rand_distr::{Distribution, Gamma, StandardNormal};
+use rayon::prelude::*;
+
+#[derive(Clone, Debug)]
+pub struct GaussianCoefficientPrior {
+    pub mean: Vec<f64>,
+    /// Full, positive-definite covariance in row-major order.
+    pub covariance: Vec<f64>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RegressionConfig {
+    pub structural_model: LinearGaussianStateSpace,
+    /// Coordinates with independent Gaussian state innovations.
+    pub innovation_indices: Vec<usize>,
+    pub variance_priors: Vec<InverseGammaPrior>,
+    pub variance_names: Vec<String>,
+    pub observation_variance_prior: InverseGammaPrior,
+    pub coefficient_prior: GaussianCoefficientPrior,
+    pub num_chains: usize,
+    pub num_draws: usize,
+    pub num_warmup: usize,
+    pub thinning: usize,
+    pub seed: u64,
+    /// A structural seasonal observation uses coordinates zero and one.
+    pub seasonal: bool,
+}
+
+impl RegressionConfig {
+    pub fn from_local_level(
+        c: &crate::bayesian_forecast::BayesianLocalLevelConfig,
+        coefficient_prior: GaussianCoefficientPrior,
+    ) -> Result<Self, StateSpaceError> {
+        Ok(Self {
+            structural_model: LinearGaussianStateSpace::local_level(
+                1.0,
+                1.0,
+                c.initial_mean,
+                c.initial_variance,
+            )?,
+            innovation_indices: vec![0],
+            variance_priors: vec![c.process_variance_prior],
+            variance_names: vec!["process_variance".into()],
+            observation_variance_prior: c.observation_variance_prior,
+            coefficient_prior,
+            num_chains: c.num_chains,
+            num_draws: c.num_draws,
+            num_warmup: c.num_warmup,
+            thinning: c.thinning,
+            seed: c.seed,
+            seasonal: false,
+        })
+    }
+    pub fn from_trend(
+        c: &crate::bayesian_trend::BayesianLocalLinearTrendConfig,
+        coefficient_prior: GaussianCoefficientPrior,
+    ) -> Result<Self, StateSpaceError> {
+        Ok(Self {
+            structural_model: LinearGaussianStateSpace::new(
+                2,
+                vec![1.0, 1.0, 0.0, 1.0],
+                vec![1.0, 0.0],
+                vec![1.0, 0.0, 0.0, 1.0],
+                1.0,
+                c.initial_mean.to_vec(),
+                c.initial_covariance.to_vec(),
+            )?,
+            innovation_indices: vec![0, 1],
+            variance_priors: vec![c.level_variance_prior, c.slope_variance_prior],
+            variance_names: vec!["level_variance".into(), "slope_variance".into()],
+            observation_variance_prior: c.observation_variance_prior,
+            coefficient_prior,
+            num_chains: c.num_chains,
+            num_draws: c.num_draws,
+            num_warmup: c.num_warmup,
+            thinning: c.thinning,
+            seed: c.seed,
+            seasonal: false,
+        })
+    }
+    pub fn from_seasonal(
+        c: &crate::bayesian_seasonal::BayesianSeasonalLocalLevelConfig,
+        coefficient_prior: GaussianCoefficientPrior,
+    ) -> Result<Self, StateSpaceError> {
+        Ok(Self {
+            structural_model: LinearGaussianStateSpace::seasonal_local_level(
+                c.period,
+                1.0,
+                1.0,
+                1.0,
+                c.initial_level,
+                c.initial_seasonal_effects.clone(),
+                c.initial_level_variance,
+                c.initial_seasonal_variance,
+            )?,
+            innovation_indices: vec![0, 1],
+            variance_priors: vec![c.level_variance_prior, c.seasonal_variance_prior],
+            variance_names: vec!["level_variance".into(), "seasonal_variance".into()],
+            observation_variance_prior: c.observation_variance_prior,
+            coefficient_prior,
+            num_chains: c.num_chains,
+            num_draws: c.num_draws,
+            num_warmup: c.num_warmup,
+            thinning: c.thinning,
+            seed: c.seed,
+            seasonal: true,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RegressionDraw {
+    pub variances: Vec<f64>,
+    pub observation_variance: f64,
+    pub coefficients: Vec<f64>,
+    pub terminal_state: Vec<f64>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RegressionPosterior {
+    pub config: RegressionConfig,
+    pub chains: Vec<Vec<RegressionDraw>>,
+}
+
+pub type Paths = Vec<Vec<Vec<f64>>>;
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct RegressionForecast {
+    pub level_paths: Paths,
+    pub secondary_paths: Paths,
+    pub regression_paths: Paths,
+    pub mean_paths: Paths,
+    pub observation_paths: Paths,
+    pub cumulative_observation_paths: Paths,
+}
+
+fn invalid(message: &str) -> StateSpaceError {
+    StateSpaceError::InvalidParameter(message.into())
+}
+fn seed_for(seed: u64, chain: usize, domain: u64) -> u64 {
+    let mut x = seed
+        .wrapping_add(domain)
+        .wrapping_add((chain as u64).wrapping_mul(0x9E3779B97F4A7C15));
+    x = (x ^ (x >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94D049BB133111EB);
+    x ^ (x >> 31)
+}
+fn draw_variance(
+    prior: InverseGammaPrior,
+    count: usize,
+    ss: f64,
+    rng: &mut ChaCha8Rng,
+) -> Result<f64, StateSpaceError> {
+    let gamma = Gamma::new(
+        prior.shape + count as f64 / 2.0,
+        1.0 / (prior.scale + ss / 2.0),
+    )
+    .map_err(|_| invalid("invalid inverse-gamma update"))?;
+    let v = 1.0 / gamma.sample(rng);
+    if !v.is_finite() || v <= 0.0 {
+        return Err(StateSpaceError::NumericalFailure(
+            "sampled variance is not finite and positive".into(),
+        ));
+    }
+    Ok(v)
+}
+fn normal(rng: &mut ChaCha8Rng) -> f64 {
+    StandardNormal.sample(rng)
+}
+
+pub fn fit_regression(
+    y: &[f64],
+    design: &[Vec<f64>],
+    config: &RegressionConfig,
+) -> Result<RegressionPosterior, StateSpaceError> {
+    if y.iter().any(|x| x.is_infinite()) || y.iter().filter(|x| x.is_finite()).count() < 2 {
+        return Err(invalid(
+            "observations require at least two finite values and no infinities",
+        ));
+    }
+    if design.len() != y.len() {
+        return Err(invalid(
+            "exog must have one row per observation, including missing observations",
+        ));
+    }
+    if config.num_chains == 0 || config.num_draws == 0 || config.thinning == 0 {
+        return Err(invalid("chains, draws and thinning must be positive"));
+    }
+    let iterations = config
+        .num_draws
+        .checked_mul(config.thinning)
+        .and_then(|n| n.checked_add(config.num_warmup))
+        .ok_or_else(|| invalid("too many iterations"))?;
+    let d = config.structural_model.dimension();
+    if config.innovation_indices.len() != config.variance_priors.len()
+        || config.variance_names.len() != config.variance_priors.len()
+        || config.innovation_indices.iter().any(|&i| i >= d)
+    {
+        return Err(invalid("innovation indices, priors and names must align"));
+    }
+    for prior in config
+        .variance_priors
+        .iter()
+        .chain(std::iter::once(&config.observation_variance_prior))
+    {
+        if !prior.shape.is_finite()
+            || prior.shape <= 0.0
+            || !prior.scale.is_finite()
+            || prior.scale <= 0.0
+        {
+            return Err(invalid(
+                "variance priors require finite positive shape and scale",
+            ));
+        }
+    }
+    let template = config.structural_model.with_static_regression(
+        design,
+        &config.coefficient_prior.mean,
+        &config.coefficient_prior.covariance,
+    )?;
+    let observed = y.iter().filter(|x| x.is_finite()).count();
+    let chains = (0..config.num_chains)
+        .into_par_iter()
+        .map(|chain| {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed_for(config.seed, chain, 0x5245475f464954));
+            let mut model = template.clone();
+            let mut variances: Vec<f64> = config
+                .variance_priors
+                .iter()
+                .map(|p| p.scale / (p.shape + 1.0))
+                .collect();
+            let mut observation_variance = config.observation_variance_prior.scale
+                / (config.observation_variance_prior.shape + 1.0);
+            let mut draws = Vec::with_capacity(config.num_draws);
+            for iteration in 0..iterations {
+                model.set_variances(&config.innovation_indices, &variances, observation_variance);
+                let states = model.sample_states_ffbs(y, &mut rng)?;
+                for (variance, (&index, &prior)) in variances.iter_mut().zip(
+                    config
+                        .innovation_indices
+                        .iter()
+                        .zip(&config.variance_priors),
+                ) {
+                    let ss = states
+                        .windows(2)
+                        .map(|pair| {
+                            let predicted: f64 = config.structural_model.transition()
+                                [index * d..(index + 1) * d]
+                                .iter()
+                                .zip(&pair[0][..d])
+                                .map(|(a, b)| a * b)
+                                .sum();
+                            (pair[1][index] - predicted).powi(2)
+                        })
+                        .sum();
+                    *variance = draw_variance(prior, y.len(), ss, &mut rng)?;
+                }
+                let ss = y
+                    .iter()
+                    .zip(design)
+                    .zip(&states[1..])
+                    .filter(|((y, _), _)| y.is_finite())
+                    .map(|((&y, x), state)| {
+                        let structural: f64 = config
+                            .structural_model
+                            .observation()
+                            .iter()
+                            .zip(state)
+                            .map(|(a, b)| a * b)
+                            .sum();
+                        let regression: f64 = x.iter().zip(&state[d..]).map(|(a, b)| a * b).sum();
+                        (y - structural - regression).powi(2)
+                    })
+                    .sum();
+                observation_variance =
+                    draw_variance(config.observation_variance_prior, observed, ss, &mut rng)?;
+                if iteration >= config.num_warmup
+                    && (iteration + 1 - config.num_warmup).is_multiple_of(config.thinning)
+                {
+                    let state = states.last().expect("validated nonempty data");
+                    draws.push(RegressionDraw {
+                        variances: variances.clone(),
+                        observation_variance,
+                        coefficients: state[d..].to_vec(),
+                        terminal_state: state[..d].to_vec(),
+                    });
+                }
+            }
+            Ok(draws)
+        })
+        .collect::<Result<Vec<_>, StateSpaceError>>()?;
+    Ok(RegressionPosterior {
+        config: config.clone(),
+        chains,
+    })
+}
+
+impl RegressionPosterior {
+    pub fn forecast(
+        &self,
+        design: &[Vec<f64>],
+        seed: u64,
+    ) -> Result<RegressionForecast, StateSpaceError> {
+        let p = self.config.coefficient_prior.mean.len();
+        if design.is_empty()
+            || design
+                .iter()
+                .any(|row| row.len() != p || row.iter().any(|v| !v.is_finite()))
+        {
+            return Err(invalid(
+                "future exog must be nonempty, finite, and match training feature count/order",
+            ));
+        }
+        let d = self.config.structural_model.dimension();
+        if self.chains.is_empty()
+            || self.chains.iter().any(Vec::is_empty)
+            || self
+                .config
+                .innovation_indices
+                .iter()
+                .any(|&index| index >= d)
+            || self.chains.iter().flatten().any(|draw| {
+                draw.coefficients.len() != p
+                    || draw.terminal_state.len() != d
+                    || draw.variances.len() != self.config.innovation_indices.len()
+                    || draw
+                        .coefficients
+                        .iter()
+                        .chain(&draw.terminal_state)
+                        .any(|v| !v.is_finite())
+                    || draw
+                        .variances
+                        .iter()
+                        .chain(std::iter::once(&draw.observation_variance))
+                        .any(|v| !v.is_finite() || *v <= 0.0)
+            })
+        {
+            return Err(invalid(
+                "posterior chains must contain finite, dimensionally valid joint draws",
+            ));
+        }
+        let chains = self
+            .chains
+            .par_iter()
+            .enumerate()
+            .map(|(chain, draws)| {
+                let mut rng = ChaCha8Rng::seed_from_u64(seed_for(seed, chain, 0x5245475f50524544));
+                let mut result = RegressionForecast::default();
+                let (
+                    mut levels,
+                    mut secondary,
+                    mut regression,
+                    mut means,
+                    mut observations,
+                    mut cumulative,
+                ) = (vec![], vec![], vec![], vec![], vec![], vec![]);
+                for draw in draws {
+                    let mut state = draw.terminal_state.clone();
+                    let (mut l, mut s, mut r, mut m, mut o, mut c) =
+                        (vec![], vec![], vec![], vec![], vec![], vec![]);
+                    let mut total = 0.0;
+                    for row in design {
+                        let mut next: Vec<f64> = self
+                            .config
+                            .structural_model
+                            .transition()
+                            .chunks(d)
+                            .map(|a| a.iter().zip(&state).map(|(a, b)| a * b).sum())
+                            .collect();
+                        for (&i, &v) in self.config.innovation_indices.iter().zip(&draw.variances) {
+                            next[i] += normal(&mut rng) * v.sqrt();
+                        }
+                        let reg: f64 = row.iter().zip(&draw.coefficients).map(|(a, b)| a * b).sum();
+                        let mean = reg
+                            + self
+                                .config
+                                .structural_model
+                                .observation()
+                                .iter()
+                                .zip(&next)
+                                .map(|(a, b)| a * b)
+                                .sum::<f64>();
+                        let observation =
+                            mean + normal(&mut rng) * draw.observation_variance.sqrt();
+                        total += observation;
+                        if !total.is_finite() || next.iter().any(|v| !v.is_finite()) {
+                            return Err(StateSpaceError::NumericalFailure(
+                                "forecast overflowed".into(),
+                            ));
+                        }
+                        l.push(next[0]);
+                        s.push(if d > 1 { next[1] } else { 0.0 });
+                        r.push(reg);
+                        m.push(mean);
+                        o.push(observation);
+                        c.push(total);
+                        state = next;
+                    }
+                    levels.push(l);
+                    secondary.push(s);
+                    regression.push(r);
+                    means.push(m);
+                    observations.push(o);
+                    cumulative.push(c);
+                }
+                result.level_paths.push(levels);
+                result.secondary_paths.push(secondary);
+                result.regression_paths.push(regression);
+                result.mean_paths.push(means);
+                result.observation_paths.push(observations);
+                result.cumulative_observation_paths.push(cumulative);
+                Ok(result)
+            })
+            .collect::<Result<Vec<_>, StateSpaceError>>()?;
+        let mut result = RegressionForecast::default();
+        for c in chains {
+            result.level_paths.extend(c.level_paths);
+            result.secondary_paths.extend(c.secondary_paths);
+            result.regression_paths.extend(c.regression_paths);
+            result.mean_paths.extend(c.mean_paths);
+            result.observation_paths.extend(c.observation_paths);
+            result
+                .cumulative_observation_paths
+                .extend(c.cumulative_observation_paths);
+        }
+        Ok(result)
+    }
+}
+
+/// Calendar Fourier rows at integer positions `start..start+count`. Column order
+/// is sin(1), cos(1), ..., with only cos at the even-period Nyquist harmonic.
+pub fn fourier_design(
+    count: usize,
+    period: usize,
+    harmonics: usize,
+    start: i64,
+) -> Result<Vec<Vec<f64>>, StateSpaceError> {
+    if period < 2 || harmonics == 0 || harmonics > period / 2 {
+        return Err(invalid(
+            "period must be at least two; harmonics must be between one and floor(period/2)",
+        ));
+    }
+    let mut rows = Vec::with_capacity(count);
+    for offset in 0..count {
+        let time = i128::from(start) + offset as i128;
+        let phase = time.rem_euclid(period as i128) as f64;
+        let mut row = Vec::with_capacity(2 * harmonics);
+        for k in 1..=harmonics {
+            let angle = std::f64::consts::TAU * k as f64 * phase / period as f64;
+            if 2 * k != period {
+                row.push(angle.sin());
+            }
+            row.push(angle.cos());
+        }
+        rows.push(row);
+    }
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn joint_static_regression_matches_analytic_posterior_and_future_covariance() {
+        let y = vec![1.0, 2.0, f64::NAN, 4.0];
+        let x = vec![vec![-1.0], vec![0.0], vec![1.0], vec![2.0]];
+        let model = LinearGaussianStateSpace::local_level(0.0, 0.5, 0.0, 2.0)
+            .unwrap()
+            .with_static_regression(&x, &[0.0], &[3.0])
+            .unwrap();
+        // Posterior precision: diag(1/2,1/3) + Z'Z / .5, omitting missing y.
+        let (a, b, c) = (6.5, 2.0, 10.0 + 1.0 / 3.0);
+        let det = a * c - b * b;
+        let covariance = [c / det, -b / det, -b / det, a / det];
+        let mean = [
+            covariance[0] * 14.0 + covariance[1] * 14.0,
+            covariance[2] * 14.0 + covariance[3] * 14.0,
+        ];
+        let smooth = model.smooth(&y).unwrap();
+        for m in &smooth.smoothed_means {
+            for i in 0..2 {
+                assert!((m[i] - mean[i]).abs() < 1e-10);
+            }
+        }
+        for v in &smooth.smoothed_covariances {
+            for i in 0..4 {
+                assert!((v[i] - covariance[i]).abs() < 1e-10);
+            }
+        }
+        let future = vec![vec![1.0, 3.0], vec![1.0, -2.0]];
+        let forecast = model.forecast_with_observation_rows(&y, &future).unwrap();
+        for i in 0..2 {
+            for j in 0..2 {
+                let expected = covariance[0]
+                    + future[i][1] * covariance[2]
+                    + future[j][1] * covariance[1]
+                    + future[i][1] * future[j][1] * covariance[3]
+                    + if i == j { 0.5 } else { 0.0 };
+                assert!((forecast.observation_covariance[2 * i + j] - expected).abs() < 1e-10);
+            }
+        }
+        assert!(
+            (forecast.cumulative_observation_variances[1]
+                - forecast.observation_covariance.iter().sum::<f64>())
+            .abs()
+                < 1e-10
+        );
+        let mut rng = ChaCha8Rng::seed_from_u64(182);
+        let mut draws = vec![];
+        for _ in 0..6000 {
+            let states = model.sample_states_ffbs(&y, &mut rng).unwrap();
+            for state in &states {
+                for (i, value) in state.iter().enumerate() {
+                    assert!((value - states[0][i]).abs() < 1e-6);
+                }
+            }
+            draws.push(states[0].clone());
+        }
+        let empirical: Vec<f64> = (0..2)
+            .map(|i| draws.iter().map(|d| d[i]).sum::<f64>() / draws.len() as f64)
+            .collect();
+        for i in 0..2 {
+            assert!((empirical[i] - mean[i]).abs() < 0.025);
+            for j in 0..2 {
+                let v = draws
+                    .iter()
+                    .map(|d| (d[i] - empirical[i]) * (d[j] - empirical[j]))
+                    .sum::<f64>()
+                    / draws.len() as f64;
+                assert!((v - covariance[2 * i + j]).abs() < 0.012);
+            }
+        }
+    }
+    fn config() -> RegressionConfig {
+        RegressionConfig {
+            structural_model: LinearGaussianStateSpace::local_level(1.0, 1.0, 0.0, 2.0).unwrap(),
+            innovation_indices: vec![0],
+            variance_priors: vec![InverseGammaPrior {
+                shape: 3.0,
+                scale: 0.08,
+            }],
+            variance_names: vec!["process_variance".into()],
+            observation_variance_prior: InverseGammaPrior {
+                shape: 3.0,
+                scale: 0.4,
+            },
+            coefficient_prior: GaussianCoefficientPrior {
+                mean: vec![0.0],
+                covariance: vec![9.0],
+            },
+            num_chains: 2,
+            num_draws: 180,
+            num_warmup: 120,
+            thinning: 1,
+            seed: 32,
+            seasonal: false,
+        }
+    }
+    #[test]
+    fn seeded_recovery_and_pool_independence() {
+        let mut rng = ChaCha8Rng::seed_from_u64(188);
+        let mut level = 0.0;
+        let x: Vec<Vec<f64>> = (0..100).map(|_| vec![normal(&mut rng)]).collect();
+        let y: Vec<f64> = x
+            .iter()
+            .map(|x| {
+                level += normal(&mut rng) * 0.02_f64.sqrt();
+                level + 1.8 * x[0] + normal(&mut rng) * 0.1_f64.sqrt()
+            })
+            .collect();
+        let fit = fit_regression(&y, &x, &config()).unwrap();
+        let single = rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap()
+            .install(|| fit_regression(&y, &x, &config()))
+            .unwrap();
+        assert_eq!(fit.chains, single.chains);
+        let coefficients: Vec<f64> = fit
+            .chains
+            .iter()
+            .flatten()
+            .map(|d| d.coefficients[0])
+            .collect();
+        let mean = coefficients.iter().sum::<f64>() / coefficients.len() as f64;
+        assert!((mean - 1.8).abs() < 0.12, "{mean}");
+        let obs = fit
+            .chains
+            .iter()
+            .flatten()
+            .map(|d| d.observation_variance)
+            .sum::<f64>()
+            / coefficients.len() as f64;
+        assert!((0.05..0.2).contains(&obs), "{obs}");
+        let future = vec![vec![1.0]; 4];
+        let paths = fit.forecast(&future, 7).unwrap();
+        assert_eq!(paths, fit.forecast(&future, 7).unwrap());
+        for ((reg, means), levels) in paths
+            .regression_paths
+            .iter()
+            .flatten()
+            .zip(paths.mean_paths.iter().flatten())
+            .zip(paths.level_paths.iter().flatten())
+        {
+            assert!(reg.iter().all(|v| *v == reg[0]));
+            for h in 0..4 {
+                assert!((means[h] - reg[h] - levels[h]).abs() < 1e-12);
+            }
+        }
+    }
+    #[test]
+    fn fourier_phase_and_nyquist() {
+        let all = fourier_design(30, 12, 6, 0).unwrap();
+        assert_eq!(all[0].len(), 11);
+        assert_eq!(fourier_design(12, 12, 6, 18).unwrap(), all[18..]);
+        assert_eq!(all[0], all[12]);
+        assert!(fourier_design(1, 12, 7, 0).is_err());
+        assert!(fourier_design(1, 1, 1, 0).is_err());
+        assert_eq!(
+            fourier_design(1, 12, 2, -1).unwrap(),
+            fourier_design(1, 12, 2, 11).unwrap()
+        );
+    }
+}

--- a/rust_core/src/bayesian_seasonal.rs
+++ b/rust_core/src/bayesian_seasonal.rs
@@ -347,23 +347,24 @@ pub fn fit_bayesian_seasonal_local_level(
     })
 }
 
-fn validate_observations(observations: &[f64], period: usize) -> Result<(), BayesianForecastError> {
-    if observations.len() < period.saturating_mul(2) {
-        return Err(BayesianForecastError::InvalidObservations(format!(
-            "at least two full seasonal periods ({} time points) are required",
-            period * 2
-        )));
-    }
+fn validate_observations(
+    observations: &[f64],
+    _period: usize,
+) -> Result<(), BayesianForecastError> {
     if observations.iter().any(|value| value.is_infinite()) {
         return Err(BayesianForecastError::InvalidObservations(
             "observations may be finite or NaN, but not infinite".into(),
         ));
     }
-    if observations.iter().filter(|value| !value.is_nan()).count() < period + 2 {
-        return Err(BayesianForecastError::InvalidObservations(format!(
-            "at least {} finite observations are required",
-            period + 2
-        )));
+    if observations
+        .iter()
+        .filter(|value| value.is_finite())
+        .count()
+        < 2
+    {
+        return Err(BayesianForecastError::InvalidObservations(
+            "at least two finite observations are required".into(),
+        ));
     }
     Ok(())
 }
@@ -575,7 +576,8 @@ mod tests {
     }
 
     #[test]
-    fn validation_requires_two_cycles_and_sum_to_zero_effects() {
+    fn validation_requires_finite_data_and_sum_to_zero_effects() {
+        assert!(fit_bayesian_seasonal_local_level(&[0.0; 2], &config()).is_ok());
         let mut invalid_config = config();
         invalid_config.initial_seasonal_effects[0] += 1.0;
         assert!(matches!(
@@ -583,7 +585,7 @@ mod tests {
             Err(BayesianForecastError::InvalidConfiguration(_))
         ));
         assert!(matches!(
-            fit_bayesian_seasonal_local_level(&[0.0; 7], &config()),
+            fit_bayesian_seasonal_local_level(&[0.0, f64::NAN], &config()),
             Err(BayesianForecastError::InvalidObservations(_))
         ));
     }

--- a/rust_core/src/diagnostics.rs
+++ b/rust_core/src/diagnostics.rs
@@ -218,6 +218,27 @@ pub fn compute_diagnostics(
     let n_draws = if n_chains > 0 { samples[0].len() } else { 0 };
     let n_params = param_names.len();
 
+    // Validate before rank normalization: ragged arrays cannot preserve chain
+    // axes, and empty arrays do not define a sampling distribution.
+    if n_chains == 0
+        || n_draws == 0
+        || samples
+            .iter()
+            .any(|chain| chain.len() != n_draws || chain.iter().any(|draw| draw.len() != n_params))
+    {
+        return DiagnosticsReport {
+            params: param_names
+                .iter()
+                .cloned()
+                .map(unavailable_parameter)
+                .collect(),
+            num_chains: n_chains,
+            num_draws: n_draws,
+            accept_rates: accept_rates.to_vec(),
+            divergences,
+        };
+    }
+
     let mut params = Vec::with_capacity(n_params);
 
     for pidx in 0..n_params {
@@ -226,6 +247,10 @@ pub fn compute_diagnostics(
             .map(|c| samples[c].iter().map(|draw| draw[pidx]).collect())
             .collect();
 
+        if chains.iter().flatten().any(|value| !value.is_finite()) {
+            params.push(unavailable_parameter(param_names[pidx].clone()));
+            continue;
+        }
         let mean = chain_mean_all(&chains);
         let std = chain_std_all(&chains, mean);
         let mut all: Vec<f64> = chains.iter().flat_map(|c| c.iter().copied()).collect();
@@ -260,6 +285,20 @@ pub fn compute_diagnostics(
         num_draws: n_draws,
         accept_rates: accept_rates.to_vec(),
         divergences,
+    }
+}
+
+fn unavailable_parameter(name: String) -> ParamDiagnostics {
+    ParamDiagnostics {
+        name,
+        mean: f64::NAN,
+        std: f64::NAN,
+        hdi_3: f64::NAN,
+        hdi_97: f64::NAN,
+        ess_bulk: f64::NAN,
+        ess_tail: f64::NAN,
+        r_hat: f64::NAN,
+        mcse_mean: f64::NAN,
     }
 }
 
@@ -525,7 +564,7 @@ fn rank_normalize(chains: &[Vec<f64>]) -> Vec<Vec<f64>> {
     let mut ranks = vec![0.0f64; total];
     let mut i = 0;
     while i < total {
-        let mut j = i;
+        let mut j = i + 1;
         while j < total && indexed[j].0 == indexed[i].0 {
             j += 1;
         }

--- a/rust_core/src/diagnostics.rs
+++ b/rust_core/src/diagnostics.rs
@@ -69,6 +69,11 @@ pub struct TransitionDiagnosticsReport {
 impl DiagnosticsReport {
     /// Render the diagnostics as a formatted table string.
     pub fn to_table(&self) -> String {
+        self.to_table_with_sampler(None)
+    }
+
+    /// Supply sampler-specific metadata instead of Hamiltonian telemetry.
+    pub fn to_table_with_sampler(&self, sampler: Option<&str>) -> String {
         let mut lines = Vec::new();
         lines.push(format!(
             "{} chains × {} draws per chain",
@@ -116,15 +121,19 @@ impl DiagnosticsReport {
 
         lines.push("─".repeat(96));
 
-        let avg_accept: f64 = if self.accept_rates.is_empty() {
-            0.0
+        if let Some(sampler) = sampler {
+            lines.push(sampler.to_string());
         } else {
-            self.accept_rates.iter().sum::<f64>() / self.accept_rates.len() as f64
-        };
-        lines.push(format!(
-            "Mean accept rate: {:.2}  │  Divergences: {}",
-            avg_accept, self.divergences
-        ));
+            let avg_accept: f64 = if self.accept_rates.is_empty() {
+                0.0
+            } else {
+                self.accept_rates.iter().sum::<f64>() / self.accept_rates.len() as f64
+            };
+            lines.push(format!(
+                "Mean accept rate: {:.2}  │  Divergences: {}",
+                avg_accept, self.divergences
+            ));
+        }
 
         let any_bad_rhat = self
             .params
@@ -145,7 +154,7 @@ impl DiagnosticsReport {
                 "WARNING: Some ESS values < 400; consider increasing draws or tuning.".to_string(),
             );
         }
-        if self.divergences > 0 {
+        if sampler.is_none() && self.divergences > 0 {
             lines.push(format!(
                 "WARNING: {} divergent transitions; results may be unreliable.",
                 self.divergences
@@ -371,6 +380,9 @@ fn chain_std_all(chains: &[Vec<f64>], mean: f64) -> f64 {
             sum_sq += d * d;
             n += 1;
         }
+    }
+    if n < 2 {
+        return f64::NAN;
     }
     (sum_sq / (n - 1) as f64).sqrt()
 }

--- a/rust_core/src/forecast_batch.rs
+++ b/rust_core/src/forecast_batch.rs
@@ -1,0 +1,185 @@
+//! Independent forecasting execution with stable cell identity and bounded workers.
+use rayon::prelude::*;
+use std::collections::HashSet;
+
+/// Version-one FNV-1a encoding: ASCII `rustmc-cell-v1`, little-endian seed,
+/// little-endian UTF-8 ID byte length, ID bytes, then domain bytes.
+/// Kernels further derive their existing model/domain/chain streams from this seed.
+/// IDs are exact UTF-8 strings; normalization is the caller's responsibility.
+pub fn stable_cell_seed(seed: u64, id: &str, domain: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in b"rustmc-cell-v1"
+        .iter()
+        .copied()
+        .chain(seed.to_le_bytes())
+        .chain((id.len() as u64).to_le_bytes())
+        .chain(id.bytes())
+        .chain(domain.bytes())
+    {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+/// Run cells in input order on one private pool, also used by nested chain work.
+/// At most `chunk_size` cells are dispatched together. Outputs are retained; for
+/// bounded total retention, call this on caller-managed chunks and persist/drop
+/// each result. IDs and seeds must remain unchanged when resuming.
+/// Per-cell errors are collected; pool/configuration errors are outer errors.
+pub fn execute_batch<T: Sync, R: Send, E: Send>(
+    cells: &[(String, T)],
+    seed: u64,
+    threads: usize,
+    chunk_size: usize,
+    fit: impl Fn(&T, u64) -> Result<R, E> + Sync,
+) -> Result<Vec<Result<R, E>>, String> {
+    if threads == 0 || chunk_size == 0 {
+        return Err("threads and chunk_size must be positive".into());
+    }
+    let mut ids = HashSet::with_capacity(cells.len());
+    if cells.iter().any(|(id, _)| !ids.insert(id)) {
+        return Err("cell IDs must be unique".into());
+    }
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build()
+        .map_err(|error| format!("could not build batch worker pool: {error}"))?;
+    let mut results = Vec::with_capacity(cells.len());
+    for chunk in cells.chunks(chunk_size) {
+        let output = pool.install(|| {
+            chunk
+                .par_iter()
+                .map(|(id, cell)| fit(cell, stable_cell_seed(seed, id, "fit")))
+                .collect::<Vec<_>>()
+        });
+        results.extend(output);
+    }
+    Ok(results)
+}
+
+/// A batch setup failure or the first observed cell failure. Concurrent work
+/// already running may finish; later chunks are never dispatched after failure.
+#[derive(Debug)]
+pub enum BatchError<E> {
+    Configuration(String),
+    Cell { id: String, error: E },
+}
+
+/// Fail-fast variant of `execute_batch`, with cooperative Rayon cancellation.
+pub fn execute_batch_fail_fast<T: Sync, R: Send, E: Send>(
+    cells: &[(String, T)],
+    seed: u64,
+    threads: usize,
+    chunk_size: usize,
+    fit: impl Fn(&T, u64) -> Result<R, E> + Sync,
+) -> Result<Vec<R>, BatchError<E>> {
+    if threads == 0 || chunk_size == 0 {
+        return Err(BatchError::Configuration(
+            "threads and chunk_size must be positive".into(),
+        ));
+    }
+    let mut ids = HashSet::with_capacity(cells.len());
+    if cells.iter().any(|(id, _)| !ids.insert(id)) {
+        return Err(BatchError::Configuration("cell IDs must be unique".into()));
+    }
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build()
+        .map_err(|error| {
+            BatchError::Configuration(format!("could not build batch worker pool: {error}"))
+        })?;
+    let mut results = Vec::with_capacity(cells.len());
+    for chunk in cells.chunks(chunk_size) {
+        let output = pool.install(|| {
+            chunk
+                .par_iter()
+                .map(|(id, cell)| {
+                    fit(cell, stable_cell_seed(seed, id, "fit")).map_err(|error| BatchError::Cell {
+                        id: id.clone(),
+                        error,
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })?;
+        results.extend(output);
+    }
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bayesian_forecast::*;
+    fn config(seed: u64) -> BayesianLocalLevelConfig {
+        BayesianLocalLevelConfig {
+            initial_mean: 0.,
+            initial_variance: 2.,
+            process_variance_prior: InverseGammaPrior::new(3., 1.).unwrap(),
+            observation_variance_prior: InverseGammaPrior::new(3., 1.).unwrap(),
+            num_chains: 2,
+            num_draws: 12,
+            num_warmup: 5,
+            thinning: 1,
+            seed,
+        }
+    }
+    #[test]
+    fn seeded_fits_survive_order_chunks_resume_threads_and_bad_cells() {
+        let cells = vec![
+            ("alpha".into(), vec![1., 2., 3.]),
+            ("β".into(), vec![2., f64::NAN, 1., 2.]),
+            ("bad".into(), vec![]),
+        ];
+        let run = |cells: &[(String, Vec<f64>)], threads, chunk| {
+            execute_batch(cells, 91, threads, chunk, |y, seed| {
+                fit_bayesian_local_level(y, &config(seed))
+            })
+            .unwrap()
+        };
+        let first = run(&cells, 1, 3);
+        let other = run(&cells, 3, 1);
+        assert_eq!(first[0].as_ref().unwrap(), other[0].as_ref().unwrap());
+        assert_eq!(first[1].as_ref().unwrap(), other[1].as_ref().unwrap());
+        assert!(first[2].is_err());
+        let reversed = run(&[cells[1].clone(), cells[0].clone()], 2, 2);
+        assert_eq!(first[0].as_ref().unwrap(), reversed[1].as_ref().unwrap());
+        assert_eq!(
+            first[1].as_ref().unwrap(),
+            run(&cells[1..2], 1, 1)[0].as_ref().unwrap()
+        );
+        assert_ne!(
+            stable_cell_seed(91, "alpha", "fit"),
+            stable_cell_seed(91, "alpha", "forecast")
+        );
+        assert_ne!(
+            stable_cell_seed(91, "alpha", "fit"),
+            stable_cell_seed(91, "β", "fit")
+        );
+    }
+    #[test]
+    fn fail_fast_does_not_dispatch_later_chunks() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = AtomicUsize::new(0);
+        let cells = vec![("bad".into(), false), ("later".into(), true)];
+        let result = execute_batch_fail_fast(&cells, 3, 2, 1, |_, _| {
+            calls.fetch_add(1, Ordering::Relaxed);
+            Err::<(), _>("failed")
+        });
+        assert!(matches!(result, Err(BatchError::Cell { id, .. }) if id == "bad"));
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+    }
+    #[test]
+    fn version_one_seed_encoding_is_fixed() {
+        assert_eq!(stable_cell_seed(91, "β", "fit"), 5_264_580_120_131_183_224);
+    }
+    #[test]
+    fn invalid_execution_options_fail_before_work() {
+        let run =
+            |cells, threads, chunk| execute_batch(cells, 1, threads, chunk, |_, _| Ok::<_, ()>(()));
+        let duplicate = [("x".into(), ()), ("x".into(), ())];
+        assert!(run(&duplicate, 1, 1).is_err());
+        assert!(run(&[], 0, 1).is_err());
+        assert!(run(&[], 1, 0).is_err());
+    }
+}

--- a/rust_core/src/forecast_diagnostics.rs
+++ b/rust_core/src/forecast_diagnostics.rs
@@ -10,6 +10,14 @@ use crate::diagnostics::{compute_diagnostics, DiagnosticsReport};
 /// unavailable convergence metrics (NaN in Rust, None in specialized Python APIs).
 pub fn parameter_diagnostics(samples: &[Vec<Vec<f64>>], names: &[String]) -> DiagnosticsReport {
     let mut report = compute_diagnostics(samples, names, &[], 0);
+    // The shared engine rejects empty/ragged parameter matrices before ranking.
+    if samples
+        .iter()
+        .flatten()
+        .any(|draw| draw.len() != names.len())
+    {
+        return report;
+    }
     for (index, parameter) in report.params.iter_mut().enumerate() {
         let first = samples
             .first()
@@ -133,9 +141,63 @@ impl BayesianArPosterior {
     }
 }
 
+impl crate::bayesian_regression::RegressionPosterior {
+    /// Variances, regression coefficients and every terminal structural state.
+    pub fn diagnostics(&self) -> DiagnosticsReport {
+        let mut names = self.config.variance_names.clone();
+        names.push("observation_variance".into());
+        names.extend(
+            (0..self.config.coefficient_prior.mean.len()).map(|i| format!("coefficient[{i}]")),
+        );
+        names.extend(
+            (0..self.config.structural_model.dimension()).map(|i| format!("terminal_state[{i}]")),
+        );
+        let samples = self
+            .chains
+            .iter()
+            .map(|chain| {
+                chain
+                    .iter()
+                    .map(|draw| {
+                        let mut values = draw.variances.clone();
+                        values.push(draw.observation_variance);
+                        values.extend_from_slice(&draw.coefficients);
+                        values.extend_from_slice(&draw.terminal_state);
+                        values
+                    })
+                    .collect()
+            })
+            .collect::<Vec<_>>();
+        parameter_diagnostics(&samples, &names)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn malformed_and_nonfinite_samples_are_unavailable_without_panics_or_hangs() {
+        let invalid = vec![
+            vec![],
+            vec![vec![]],
+            vec![vec![vec![1.]], vec![vec![1.]; 3]],
+            vec![vec![vec![]; 8]],
+            vec![vec![vec![f64::NAN]; 8]],
+            vec![vec![vec![f64::INFINITY]; 8]],
+        ];
+        for samples in invalid {
+            let report = parameter_diagnostics(&samples, &["x".into()]);
+            assert_eq!(report.params.len(), 1);
+            assert!(report.params[0].r_hat.is_nan());
+            assert!(report.params[0].ess_bulk.is_nan());
+        }
+    }
+    #[test]
+    fn separated_constant_chains_retain_infinite_rhat() {
+        let samples = vec![vec![vec![0.0]; 20], vec![vec![10.0]; 20]];
+        let report = parameter_diagnostics(&samples, &["x".into()]);
+        assert!(report.params[0].r_hat.is_infinite());
+    }
     #[test]
     fn unavailable_short_and_constant_traces() {
         for samples in [vec![vec![vec![1.]; 3]; 2], vec![vec![vec![1.]; 40]; 2]] {

--- a/rust_core/src/forecast_diagnostics.rs
+++ b/rust_core/src/forecast_diagnostics.rs
@@ -1,0 +1,151 @@
+//! Parameter diagnostics for non-Hamiltonian forecasting samplers.
+use crate::bayesian_ar::BayesianArPosterior;
+use crate::bayesian_forecast::LocalLevelPosterior;
+use crate::bayesian_seasonal::SeasonalLocalLevelPosterior;
+use crate::bayesian_trend::LocalLinearTrendPosterior;
+use crate::diagnostics::{compute_diagnostics, DiagnosticsReport};
+
+/// Reuse the rank-normalized folded split diagnostics without fabricating
+/// Hamiltonian sampler telemetry. Nonfinite or insufficient/constant traces have
+/// unavailable convergence metrics (NaN in Rust, None in specialized Python APIs).
+pub fn parameter_diagnostics(samples: &[Vec<Vec<f64>>], names: &[String]) -> DiagnosticsReport {
+    let mut report = compute_diagnostics(samples, names, &[], 0);
+    for (index, parameter) in report.params.iter_mut().enumerate() {
+        let first = samples
+            .first()
+            .and_then(|chain| chain.first())
+            .map(|draw| draw[index]);
+        let unavailable = samples.is_empty()
+            || samples.iter().any(|chain| chain.len() < 6)
+            || samples
+                .iter()
+                .flatten()
+                .any(|draw| !draw[index].is_finite())
+            || first.is_some_and(|first| samples.iter().flatten().all(|draw| draw[index] == first));
+        if unavailable {
+            parameter.r_hat = f64::NAN;
+            parameter.ess_bulk = f64::NAN;
+            parameter.ess_tail = f64::NAN;
+            parameter.mcse_mean = f64::NAN;
+        }
+    }
+    report
+}
+
+impl LocalLevelPosterior {
+    pub fn diagnostics(&self) -> DiagnosticsReport {
+        let names =
+            ["process_variance", "observation_variance", "terminal_level"].map(String::from);
+        let samples = self
+            .chains
+            .iter()
+            .map(|chain| {
+                chain
+                    .iter()
+                    .map(|d| vec![d.process_variance, d.observation_variance, d.terminal_level])
+                    .collect()
+            })
+            .collect::<Vec<_>>();
+        parameter_diagnostics(&samples, &names)
+    }
+}
+impl LocalLinearTrendPosterior {
+    pub fn diagnostics(&self) -> DiagnosticsReport {
+        let names = [
+            "level_variance",
+            "slope_variance",
+            "observation_variance",
+            "terminal_level",
+            "terminal_slope",
+        ]
+        .map(String::from);
+        let samples = self
+            .chains
+            .iter()
+            .map(|chain| {
+                chain
+                    .iter()
+                    .map(|d| {
+                        vec![
+                            d.level_variance,
+                            d.slope_variance,
+                            d.observation_variance,
+                            d.terminal_level,
+                            d.terminal_slope,
+                        ]
+                    })
+                    .collect()
+            })
+            .collect::<Vec<_>>();
+        parameter_diagnostics(&samples, &names)
+    }
+}
+impl SeasonalLocalLevelPosterior {
+    pub fn diagnostics(&self) -> DiagnosticsReport {
+        let mut names = vec![
+            "level_variance".into(),
+            "seasonal_variance".into(),
+            "observation_variance".into(),
+            "terminal_level".into(),
+        ];
+        names.extend((1..self.period).map(|i| format!("terminal_seasonal[{}]", i - 1)));
+        let samples = self
+            .chains
+            .iter()
+            .map(|chain| {
+                chain
+                    .iter()
+                    .map(|d| {
+                        let mut values = vec![
+                            d.level_variance,
+                            d.seasonal_variance,
+                            d.observation_variance,
+                        ];
+                        values.extend_from_slice(&d.terminal_state);
+                        values
+                    })
+                    .collect()
+            })
+            .collect::<Vec<_>>();
+        parameter_diagnostics(&samples, &names)
+    }
+}
+impl BayesianArPosterior {
+    pub fn diagnostics(&self) -> DiagnosticsReport {
+        let mut names = vec!["intercept".into()];
+        names.extend((1..=self.order).map(|i| format!("lag_{i}")));
+        names.push("innovation_variance".into());
+        let samples = self
+            .chains
+            .iter()
+            .map(|chain| {
+                chain
+                    .iter()
+                    .map(|d| {
+                        let mut values = d.coefficients.clone();
+                        values.push(d.innovation_variance);
+                        values
+                    })
+                    .collect()
+            })
+            .collect::<Vec<_>>();
+        parameter_diagnostics(&samples, &names)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn unavailable_short_and_constant_traces() {
+        for samples in [vec![vec![vec![1.]; 3]; 2], vec![vec![vec![1.]; 40]; 2]] {
+            let report = parameter_diagnostics(&samples, &["x".into()]);
+            assert!(report.params[0].r_hat.is_nan());
+            assert!(report.params[0].ess_bulk.is_nan());
+            assert!(report.params[0].mcse_mean.is_nan());
+            assert!(!report
+                .to_table_with_sampler(Some("Sampler: Gibbs"))
+                .contains("Mean accept rate"));
+        }
+    }
+}

--- a/rust_core/src/hierarchical.rs
+++ b/rust_core/src/hierarchical.rs
@@ -16,7 +16,7 @@
 //! `NaN` values are retained as missing positions and ignored by the likelihood.
 
 use crate::bayesian_forecast::{BayesianForecastError, InverseGammaPrior};
-use crate::diagnostics::{self, DiagnosticsReport};
+use crate::diagnostics::DiagnosticsReport;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use rand_distr::{Distribution, Gamma, StandardNormal};
@@ -145,7 +145,7 @@ impl HierarchicalMeanPosterior {
                     .collect()
             })
             .collect::<Vec<_>>();
-        diagnostics::compute_diagnostics(&samples, &names, &vec![1.0; self.chains.len()], 0)
+        crate::forecast_diagnostics::parameter_diagnostics(&samples, &names)
     }
 
     /// Generate aligned future paths. Summing the program axis within a draw

--- a/rust_core/src/hurdle.rs
+++ b/rust_core/src/hurdle.rs
@@ -2,7 +2,9 @@
 //!
 //! `P(y[t] > 0) = p`, `p ~ Beta(a,b)`, and conditional on a positive amount,
 //! `log(y[t]) = level[t] + Normal(0,r)`, with a Gaussian random-walk level
-//! and explicit inverse-gamma priors on q and r. Zeros inform occurrence only;
+//! and explicitly upper-truncated inverse-gamma priors on q and r. The finite
+//! variance caps give finite positive predictive amount moments at finite horizons.
+//! Zeros inform occurrence only;
 //! missing values inform neither component, but both retain their time position.
 //! Occurrence is static and independent of severity a priori. This factorization
 //! permits exact Beta occurrence draws and conjugate Gaussian severity FFBS/Gibbs.
@@ -17,6 +19,7 @@ use rand_distr::{Beta, Distribution, Gamma, StandardNormal};
 use rayon::prelude::*;
 
 const MAX_VALUES: usize = 25_000_000;
+const MAX_TRUNCATION_ATTEMPTS: usize = 100_000;
 
 #[derive(Debug, Clone)]
 pub struct HurdleLogNormalConfig {
@@ -26,6 +29,10 @@ pub struct HurdleLogNormalConfig {
     pub initial_variance: f64,
     pub process_variance_prior: InverseGammaPrior,
     pub observation_variance_prior: InverseGammaPrior,
+    /// Fixed upper support bound on process log variance, part of the prior.
+    pub process_variance_upper: f64,
+    /// Fixed upper support bound on observation log variance, part of the prior.
+    pub observation_variance_upper: f64,
     pub num_chains: usize,
     pub num_draws: usize,
     pub num_warmup: usize,
@@ -39,6 +46,11 @@ impl HurdleLogNormalConfig {
             ("occurrence alpha", self.occurrence_alpha),
             ("occurrence beta", self.occurrence_beta),
             ("initial variance", self.initial_variance),
+            ("process variance upper bound", self.process_variance_upper),
+            (
+                "observation variance upper bound",
+                self.observation_variance_upper,
+            ),
         ] {
             if !value.is_finite() || value <= 0.0 {
                 return Err(invalid(format!("{name} must be finite and positive")));
@@ -46,6 +58,9 @@ impl HurdleLogNormalConfig {
         }
         if !self.initial_log_level.is_finite() {
             return Err(invalid("initial log level must be finite"));
+        }
+        if !(self.occurrence_alpha + self.occurrence_beta).is_finite() {
+            return Err(invalid("occurrence prior shape sum must be finite"));
         }
         InverseGammaPrior::new(
             self.process_variance_prior.shape,
@@ -140,11 +155,18 @@ pub fn fit_hurdle_lognormal(
         ));
     }
     allocation(&[observations.len(), config.num_chains, 10])?;
-    let occurrence = Beta::new(
-        config.occurrence_alpha + positive_count as f64,
-        config.occurrence_beta + (observed_count - positive_count) as f64,
-    )
-    .map_err(|e| numerical(e.to_string()))?;
+    let occurrence_alpha = config.occurrence_alpha + positive_count as f64;
+    let occurrence_beta = config.occurrence_beta + (observed_count - positive_count) as f64;
+    if !occurrence_alpha.is_finite()
+        || !occurrence_beta.is_finite()
+        || !(occurrence_alpha + occurrence_beta).is_finite()
+    {
+        return Err(numerical(
+            "occurrence posterior shape arithmetic overflowed",
+        ));
+    }
+    let occurrence =
+        Beta::new(occurrence_alpha, occurrence_beta).map_err(|e| numerical(e.to_string()))?;
     let log_observations: Vec<f64> = observations
         .iter()
         .map(|y| if *y > 0.0 { y.ln() } else { f64::NAN })
@@ -159,15 +181,23 @@ pub fn fit_hurdle_lognormal(
             // Direct independent draws avoid an uninformative augmented Gibbs chain.
             if positive_count == 0 {
                 for _ in 0..config.num_draws {
-                    let q = inverse_gamma(config.process_variance_prior, &mut rng)?;
-                    let r = inverse_gamma(config.observation_variance_prior, &mut rng)?;
+                    let q = inverse_gamma(
+                        config.process_variance_prior,
+                        config.process_variance_upper,
+                        &mut rng,
+                    )?;
+                    let r = inverse_gamma(
+                        config.observation_variance_prior,
+                        config.observation_variance_upper,
+                        &mut rng,
+                    )?;
                     let variance = config.initial_variance + observations.len() as f64 * q;
                     let level = config.initial_log_level + normal(&mut rng) * variance.sqrt();
                     if !level.is_finite() {
                         return Err(numerical("prior terminal level overflowed"));
                     }
                     draws.push(HurdleLogNormalDraw {
-                        payment_probability: occurrence.sample(&mut rng),
+                        payment_probability: probability_draw(&occurrence, &mut rng)?,
                         process_variance: q,
                         observation_variance: r,
                         terminal_log_level: level,
@@ -175,10 +205,13 @@ pub fn fit_hurdle_lognormal(
                 }
                 return Ok(draws);
             }
+            // These are starting values, not clipped draws from either prior.
             let mut q =
-                config.process_variance_prior.scale / (config.process_variance_prior.shape + 1.0);
-            let mut r = config.observation_variance_prior.scale
-                / (config.observation_variance_prior.shape + 1.0);
+                initial_variance(config.process_variance_prior, config.process_variance_upper)?;
+            let mut r = initial_variance(
+                config.observation_variance_prior,
+                config.observation_variance_upper,
+            )?;
             let iterations = config.num_warmup + config.num_draws * config.thinning;
             for iteration in 0..iterations {
                 let model = LinearGaussianStateSpace::local_level(
@@ -201,6 +234,7 @@ pub fn fit_hurdle_lognormal(
                             + observations.len() as f64 / 2.0,
                         scale: config.process_variance_prior.scale + process_ss / 2.0,
                     },
+                    config.process_variance_upper,
                     &mut rng,
                 )?;
                 let observation_ss: f64 = log_observations
@@ -215,13 +249,14 @@ pub fn fit_hurdle_lognormal(
                             + positive_count as f64 / 2.0,
                         scale: config.observation_variance_prior.scale + observation_ss / 2.0,
                     },
+                    config.observation_variance_upper,
                     &mut rng,
                 )?;
                 if iteration >= config.num_warmup
                     && (iteration + 1 - config.num_warmup).is_multiple_of(config.thinning)
                 {
                     draws.push(HurdleLogNormalDraw {
-                        payment_probability: occurrence.sample(&mut rng),
+                        payment_probability: probability_draw(&occurrence, &mut rng)?,
                         process_variance: q,
                         observation_variance: r,
                         terminal_log_level: states.last().expect("nonempty input")[0],
@@ -349,22 +384,62 @@ fn allocation(factors: &[usize]) -> Result<(), BayesianForecastError> {
 }
 fn inverse_gamma(
     prior: InverseGammaPrior,
+    upper: f64,
     rng: &mut ChaCha8Rng,
 ) -> Result<f64, BayesianForecastError> {
     if !prior.shape.is_finite()
         || prior.shape <= 0.0
         || !prior.scale.is_finite()
         || prior.scale <= 0.0
+        || !upper.is_finite()
+        || upper <= 0.0
     {
-        return Err(numerical("invalid inverse-gamma conditional"));
+        return Err(numerical(
+            "invalid upper-truncated inverse-gamma conditional",
+        ));
     }
-    let gamma = Gamma::new(prior.shape, 1.0 / prior.scale).map_err(|e| numerical(e.to_string()))?;
-    let value = 1.0 / gamma.sample(rng);
-    if value.is_finite() && value > 0.0 {
-        Ok(value)
-    } else {
-        Err(numerical("inverse-gamma draw is nonfinite or nonpositive"))
+    let gamma_scale = 1.0 / prior.scale;
+    if !gamma_scale.is_finite() || gamma_scale <= 0.0 {
+        return Err(numerical(
+            "inverse-gamma reciprocal scale is unrepresentable",
+        ));
     }
+    let gamma = Gamma::new(prior.shape, gamma_scale).map_err(|e| numerical(e.to_string()))?;
+    for _ in 0..MAX_TRUNCATION_ATTEMPTS {
+        let precision = gamma.sample(rng);
+        if !precision.is_finite() || precision < 0.0 {
+            return Err(numerical(
+                "inverse-gamma precision draw is nonfinite or negative",
+            ));
+        }
+        let value = 1.0 / precision;
+        // A zero precision represents a proposal beyond the upper support bound;
+        // rejecting it also avoids turning a heavy-tail underflow into a sample.
+        if value > upper {
+            continue;
+        }
+        if value.is_finite() && value > 0.0 {
+            return Ok(value);
+        }
+        return Err(numerical("inverse-gamma draw is nonfinite or nonpositive"));
+    }
+    Err(numerical(format!("upper-truncated inverse-gamma rejection exhausted {MAX_TRUNCATION_ATTEMPTS} attempts (shape={}, scale={}, upper={upper}); the fixed cap retains too little conditional mass; review the prior cap and data scale", prior.shape, prior.scale)))
+}
+fn initial_variance(prior: InverseGammaPrior, upper: f64) -> Result<f64, BayesianForecastError> {
+    let value = (prior.scale / (prior.shape + 1.0)).min(upper / 2.0);
+    if !value.is_finite() || value <= 0.0 {
+        return Err(numerical(
+            "initial log variance inside its cap is unrepresentable",
+        ));
+    }
+    Ok(value)
+}
+fn probability_draw(beta: &Beta<f64>, rng: &mut ChaCha8Rng) -> Result<f64, BayesianForecastError> {
+    let value = beta.sample(rng);
+    if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+        return Err(numerical("occurrence probability draw is nonfinite or outside [0,1]; rescale extreme Beta concentrations"));
+    }
+    Ok(value)
 }
 fn normal(rng: &mut ChaCha8Rng) -> f64 {
     StandardNormal.sample(rng)
@@ -393,6 +468,8 @@ mod tests {
             initial_variance: 0.2,
             process_variance_prior: InverseGammaPrior::new(4., 0.03).unwrap(),
             observation_variance_prior: InverseGammaPrior::new(4., 0.3).unwrap(),
+            process_variance_upper: 1.0,
+            observation_variance_upper: 4.0,
             num_chains: 2,
             num_draws: 2000,
             num_warmup: 50,
@@ -480,5 +557,197 @@ mod tests {
         let mut cfg = config();
         cfg.num_draws = usize::MAX;
         assert!(fit_hurdle_lognormal(&[0.], &cfg).is_err());
+    }
+
+    #[test]
+    fn truncated_prior_matches_analytic_mean_cdf_and_terminal_variance() {
+        let mut cfg = config();
+        cfg.process_variance_prior = InverseGammaPrior::new(2., 0.2).unwrap();
+        cfg.observation_variance_prior = InverseGammaPrior::new(2., 0.8).unwrap();
+        cfg.process_variance_upper = 0.1;
+        cfg.observation_variance_upper = 0.4;
+        cfg.num_draws = 10000;
+        let fit = fit_hurdle_lognormal(&[0., f64::NAN, 0.], &cfg).unwrap();
+        let samples: Vec<_> = fit.chains.iter().flatten().collect();
+        let n = samples.len() as f64;
+        // X~IG(2,b), X<=c: P(X<=c)=exp(-b/c)(1+b/c),
+        // and E[X | X<=c] = b/(1+b/c).
+        let q_mean = samples.iter().map(|d| d.process_variance).sum::<f64>() / n;
+        let r_mean = samples.iter().map(|d| d.observation_variance).sum::<f64>() / n;
+        assert!((q_mean - 0.2 / 3.).abs() < 0.001);
+        assert!((r_mean - 0.8 / 3.).abs() < 0.003);
+        let q_cdf = samples
+            .iter()
+            .filter(|d| d.process_variance <= 0.05)
+            .count() as f64
+            / n;
+        assert!((q_cdf - (-2_f64).exp() * 5. / 3.).abs() < 0.012);
+        assert!(samples
+            .iter()
+            .all(|d| d.process_variance < 0.1 && d.observation_variance < 0.4));
+        let variance = samples
+            .iter()
+            .map(|d| (d.terminal_log_level - 1.).powi(2))
+            .sum::<f64>()
+            / n;
+        assert!((variance - (0.2 + 3. * 0.2 / 3.)).abs() < 0.015);
+        // The integrated arithmetic mean is finite under the capped priors.
+        // Independently integrate their bounded exponential moments by quadrature.
+        let exponential_moment = |scale: f64, cap: f64, multiplier: f64| {
+            let mut weight_sum = 0.;
+            let mut moment_sum = 0.;
+            for i in 0..20000 {
+                let x = (i as f64 + 0.5) * cap / 20000.;
+                let weight = (-3. * x.ln() - scale / x).exp();
+                weight_sum += weight;
+                moment_sum += weight * (multiplier * x).exp();
+            }
+            moment_sum / weight_sum
+        };
+        let expected = (2. / 7.)
+            * 1.1_f64.exp()
+            * exponential_moment(0.2, 0.1, 2.)
+            * exponential_moment(0.8, 0.4, 0.5);
+        let forecast = fit.forecast(1, 561).unwrap();
+        let actual = forecast
+            .paths
+            .observation_paths
+            .iter()
+            .flatten()
+            .map(|d| d[0])
+            .sum::<f64>()
+            / n;
+        assert!(
+            (actual - expected).abs() < 0.055,
+            "integrated mean {actual} vs {expected}"
+        );
+    }
+
+    #[test]
+    fn one_positive_matches_independent_truncated_prior_importance_integral() {
+        let mut cfg = config();
+        cfg.process_variance_prior = InverseGammaPrior::new(4., 0.3).unwrap();
+        cfg.observation_variance_prior = InverseGammaPrior::new(4., 0.6).unwrap();
+        cfg.process_variance_upper = 0.15;
+        cfg.observation_variance_upper = 0.3;
+        cfg.num_draws = 20000;
+        cfg.num_warmup = 1000;
+        let fit = fit_hurdle_lognormal(&[1.7_f64.exp()], &cfg).unwrap();
+        let mut actual = [0.; 3];
+        for d in fit.chains.iter().flatten() {
+            actual[0] += d.process_variance;
+            actual[1] += d.observation_variance;
+            actual[2] += d.terminal_log_level;
+            assert!(d.process_variance <= cfg.process_variance_upper);
+            assert!(d.observation_variance <= cfg.observation_variance_upper);
+        }
+        for mean in &mut actual {
+            *mean /= (cfg.num_chains * cfg.num_draws) as f64;
+        }
+        // Integrate out both initial and observed states independently of FFBS:
+        // log(y) | q,r ~ N(initial_mean, initial_variance + q + r).
+        let mut rng = ChaCha8Rng::seed_from_u64(814);
+        let gamma = Gamma::new(4., 1.).unwrap();
+        let mut weighted = [0.; 4];
+        for _ in 0..500000 {
+            let q = 0.3 / gamma.sample(&mut rng);
+            let r = 0.6 / gamma.sample(&mut rng);
+            if q > cfg.process_variance_upper || r > cfg.observation_variance_upper {
+                continue;
+            }
+            let variance: f64 = 0.2 + q + r;
+            let weight = (-0.7_f64.powi(2) / (2. * variance)).exp() / variance.sqrt();
+            weighted[0] += weight;
+            weighted[1] += weight * q;
+            weighted[2] += weight * r;
+            weighted[3] += weight * (1. + (0.2 + q) / variance * 0.7);
+        }
+        for (i, tolerance) in [0.002, 0.003, 0.015].iter().enumerate() {
+            let expected = weighted[i + 1] / weighted[0];
+            assert!(
+                (actual[i] - expected).abs() < *tolerance,
+                "parameter {i}: {} vs {expected}",
+                actual[i]
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_caps_extreme_beta_and_unattainable_truncation_fail_explicitly() {
+        for upper in [0., -1., f64::NAN, f64::INFINITY] {
+            let mut cfg = config();
+            cfg.process_variance_upper = upper;
+            assert!(fit_hurdle_lognormal(&[0.], &cfg).is_err());
+            cfg = config();
+            cfg.observation_variance_upper = upper;
+            assert!(fit_hurdle_lognormal(&[1.], &cfg).is_err());
+        }
+        let mut cfg = config();
+        cfg.occurrence_alpha = 1e308;
+        cfg.occurrence_beta = 1e308;
+        assert!(fit_hurdle_lognormal(&[0.], &cfg).is_err());
+        let beta = Beta::new(1e308, 1e308).unwrap();
+        let mut rng = ChaCha8Rng::seed_from_u64(5);
+        assert!(probability_draw(&beta, &mut rng).is_err());
+        let error =
+            inverse_gamma(InverseGammaPrior::new(2., 100.).unwrap(), 0.0001, &mut rng).unwrap_err();
+        assert!(error.to_string().contains("rejection exhausted"));
+        assert!(inverse_gamma(
+            InverseGammaPrior::new(2., f64::from_bits(1)).unwrap(),
+            1.,
+            &mut rng
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn dynamic_positive_severity_and_occurrence_recover_simulated_parameters() {
+        let mut rng = ChaCha8Rng::seed_from_u64(604);
+        let mut level = 1.;
+        let mut observations = Vec::new();
+        for _ in 0..320 {
+            level += normal(&mut rng) * 0.01_f64.sqrt();
+            let amount = (level + normal(&mut rng) * 0.1_f64.sqrt()).exp();
+            observations.push(if rng.gen::<f64>() < 0.6 { amount } else { 0. });
+        }
+        let mut cfg = config();
+        cfg.num_draws = 1500;
+        cfg.num_warmup = 750;
+        cfg.process_variance_upper = 0.1;
+        cfg.observation_variance_upper = 0.5;
+        let fit = fit_hurdle_lognormal(&observations, &cfg).unwrap();
+        let n = (cfg.num_chains * cfg.num_draws) as f64;
+        let p = fit
+            .chains
+            .iter()
+            .flatten()
+            .map(|d| d.payment_probability)
+            .sum::<f64>()
+            / n;
+        let q = fit
+            .chains
+            .iter()
+            .flatten()
+            .map(|d| d.process_variance)
+            .sum::<f64>()
+            / n;
+        let r = fit
+            .chains
+            .iter()
+            .flatten()
+            .map(|d| d.observation_variance)
+            .sum::<f64>()
+            / n;
+        assert!((p - 0.6).abs() < 0.06, "occurrence {p}");
+        assert!((q - 0.01).abs() < 0.008, "process variance {q}");
+        assert!((r - 0.1).abs() < 0.035, "observation variance {r}");
+        let forecast = fit.forecast(3, 903).unwrap();
+        assert!(forecast
+            .paths
+            .observation_paths
+            .iter()
+            .flatten()
+            .flatten()
+            .all(|x| x.is_finite() && *x >= 0.));
     }
 }

--- a/rust_core/src/hurdle.rs
+++ b/rust_core/src/hurdle.rs
@@ -1,0 +1,484 @@
+//! A Bernoulli hurdle with dynamic lognormal positive amounts.
+//!
+//! `P(y[t] > 0) = p`, `p ~ Beta(a,b)`, and conditional on a positive amount,
+//! `log(y[t]) = level[t] + Normal(0,r)`, with a Gaussian random-walk level
+//! and explicit inverse-gamma priors on q and r. Zeros inform occurrence only;
+//! missing values inform neither component, but both retain their time position.
+//! Occurrence is static and independent of severity a priori. This factorization
+//! permits exact Beta occurrence draws and conjugate Gaussian severity FFBS/Gibbs.
+
+use crate::bayesian_forecast::{
+    BayesianForecastError, InverseGammaPrior, PosteriorPredictiveForecast,
+};
+use crate::state_space::LinearGaussianStateSpace;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use rand_distr::{Beta, Distribution, Gamma, StandardNormal};
+use rayon::prelude::*;
+
+const MAX_VALUES: usize = 25_000_000;
+
+#[derive(Debug, Clone)]
+pub struct HurdleLogNormalConfig {
+    pub occurrence_alpha: f64,
+    pub occurrence_beta: f64,
+    pub initial_log_level: f64,
+    pub initial_variance: f64,
+    pub process_variance_prior: InverseGammaPrior,
+    pub observation_variance_prior: InverseGammaPrior,
+    pub num_chains: usize,
+    pub num_draws: usize,
+    pub num_warmup: usize,
+    pub thinning: usize,
+    pub seed: u64,
+}
+
+impl HurdleLogNormalConfig {
+    pub fn validate(&self) -> Result<(), BayesianForecastError> {
+        for (name, value) in [
+            ("occurrence alpha", self.occurrence_alpha),
+            ("occurrence beta", self.occurrence_beta),
+            ("initial variance", self.initial_variance),
+        ] {
+            if !value.is_finite() || value <= 0.0 {
+                return Err(invalid(format!("{name} must be finite and positive")));
+            }
+        }
+        if !self.initial_log_level.is_finite() {
+            return Err(invalid("initial log level must be finite"));
+        }
+        InverseGammaPrior::new(
+            self.process_variance_prior.shape,
+            self.process_variance_prior.scale,
+        )?;
+        InverseGammaPrior::new(
+            self.observation_variance_prior.shape,
+            self.observation_variance_prior.scale,
+        )?;
+        if self.num_chains == 0 || self.num_draws == 0 || self.thinning == 0 {
+            return Err(invalid("chains, draws, and thinning must be positive"));
+        }
+        self.num_draws
+            .checked_mul(self.thinning)
+            .and_then(|n| n.checked_add(self.num_warmup))
+            .ok_or_else(|| invalid("iteration count overflow"))?;
+        allocation(&[self.num_chains, self.num_draws, 4])?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HurdleLogNormalDraw {
+    pub payment_probability: f64,
+    pub process_variance: f64,
+    pub observation_variance: f64,
+    pub terminal_log_level: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HurdleLogNormalPosterior {
+    /// Joint samples indexed `[chain][draw]`.
+    pub chains: Vec<Vec<HurdleLogNormalDraw>>,
+    pub time_count: usize,
+    pub observed_count: usize,
+    pub positive_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HurdleLogNormalForecast {
+    /// `state_paths` are E[y | p, future log level, observation variance].
+    /// `observation_paths` include exact zeros and positive payment realizations.
+    pub paths: PosteriorPredictiveForecast,
+    /// E[y | y > 0, future log level, observation variance].
+    pub positive_mean_paths: Vec<Vec<Vec<f64>>>,
+}
+
+/// Density with respect to a point mass at zero plus Lebesgue measure on positives.
+pub fn hurdle_lognormal_logp(
+    y: f64,
+    probability: f64,
+    log_level: f64,
+    log_variance: f64,
+) -> Result<f64, BayesianForecastError> {
+    if !y.is_finite()
+        || y < 0.0
+        || !probability.is_finite()
+        || !(0.0..=1.0).contains(&probability)
+        || !log_level.is_finite()
+        || !log_variance.is_finite()
+        || log_variance <= 0.0
+    {
+        return Err(invalid("hurdle density needs nonnegative finite y, probability in [0,1], finite log level and positive log variance"));
+    }
+    if y == 0.0 {
+        return Ok((-probability).ln_1p());
+    }
+    let log_y = y.ln();
+    Ok(probability.ln()
+        - log_y
+        - 0.5
+            * (std::f64::consts::TAU.ln()
+                + log_variance.ln()
+                + (log_y - log_level).powi(2) / log_variance))
+}
+
+pub fn fit_hurdle_lognormal(
+    observations: &[f64],
+    config: &HurdleLogNormalConfig,
+) -> Result<HurdleLogNormalPosterior, BayesianForecastError> {
+    config.validate()?;
+    if observations.iter().any(|y| y.is_infinite() || *y < 0.0) {
+        return Err(BayesianForecastError::InvalidObservations(
+            "hurdle observations must be nonnegative finite values or NaN".into(),
+        ));
+    }
+    let observed_count = observations.iter().filter(|y| y.is_finite()).count();
+    let positive_count = observations.iter().filter(|y| **y > 0.0).count();
+    if observed_count == 0 {
+        return Err(BayesianForecastError::InvalidObservations(
+            "at least one observed amount (including zero) is required".into(),
+        ));
+    }
+    allocation(&[observations.len(), config.num_chains, 10])?;
+    let occurrence = Beta::new(
+        config.occurrence_alpha + positive_count as f64,
+        config.occurrence_beta + (observed_count - positive_count) as f64,
+    )
+    .map_err(|e| numerical(e.to_string()))?;
+    let log_observations: Vec<f64> = observations
+        .iter()
+        .map(|y| if *y > 0.0 { y.ln() } else { f64::NAN })
+        .collect();
+    let chains = (0..config.num_chains)
+        .into_par_iter()
+        .map(|chain| {
+            let mut rng =
+                ChaCha8Rng::seed_from_u64(chain_seed(config.seed, chain, 0x4855_5244_4649_5401));
+            let mut draws = Vec::with_capacity(config.num_draws);
+            // With no positive amounts the severity posterior equals its prior.
+            // Direct independent draws avoid an uninformative augmented Gibbs chain.
+            if positive_count == 0 {
+                for _ in 0..config.num_draws {
+                    let q = inverse_gamma(config.process_variance_prior, &mut rng)?;
+                    let r = inverse_gamma(config.observation_variance_prior, &mut rng)?;
+                    let variance = config.initial_variance + observations.len() as f64 * q;
+                    let level = config.initial_log_level + normal(&mut rng) * variance.sqrt();
+                    if !level.is_finite() {
+                        return Err(numerical("prior terminal level overflowed"));
+                    }
+                    draws.push(HurdleLogNormalDraw {
+                        payment_probability: occurrence.sample(&mut rng),
+                        process_variance: q,
+                        observation_variance: r,
+                        terminal_log_level: level,
+                    });
+                }
+                return Ok(draws);
+            }
+            let mut q =
+                config.process_variance_prior.scale / (config.process_variance_prior.shape + 1.0);
+            let mut r = config.observation_variance_prior.scale
+                / (config.observation_variance_prior.shape + 1.0);
+            let iterations = config.num_warmup + config.num_draws * config.thinning;
+            for iteration in 0..iterations {
+                let model = LinearGaussianStateSpace::local_level(
+                    q,
+                    r,
+                    config.initial_log_level,
+                    config.initial_variance,
+                )
+                .map_err(|e| numerical(e.to_string()))?;
+                let states = model
+                    .sample_states_ffbs(&log_observations, &mut rng)
+                    .map_err(|e| numerical(e.to_string()))?;
+                let process_ss: f64 = states
+                    .windows(2)
+                    .map(|pair| (pair[1][0] - pair[0][0]).powi(2))
+                    .sum();
+                q = inverse_gamma(
+                    InverseGammaPrior {
+                        shape: config.process_variance_prior.shape
+                            + observations.len() as f64 / 2.0,
+                        scale: config.process_variance_prior.scale + process_ss / 2.0,
+                    },
+                    &mut rng,
+                )?;
+                let observation_ss: f64 = log_observations
+                    .iter()
+                    .zip(&states[1..])
+                    .filter(|(y, _)| y.is_finite())
+                    .map(|(y, x)| (y - x[0]).powi(2))
+                    .sum();
+                r = inverse_gamma(
+                    InverseGammaPrior {
+                        shape: config.observation_variance_prior.shape
+                            + positive_count as f64 / 2.0,
+                        scale: config.observation_variance_prior.scale + observation_ss / 2.0,
+                    },
+                    &mut rng,
+                )?;
+                if iteration >= config.num_warmup
+                    && (iteration + 1 - config.num_warmup).is_multiple_of(config.thinning)
+                {
+                    draws.push(HurdleLogNormalDraw {
+                        payment_probability: occurrence.sample(&mut rng),
+                        process_variance: q,
+                        observation_variance: r,
+                        terminal_log_level: states.last().expect("nonempty input")[0],
+                    });
+                }
+            }
+            Ok(draws)
+        })
+        .collect::<Result<Vec<_>, BayesianForecastError>>()?;
+    Ok(HurdleLogNormalPosterior {
+        chains,
+        time_count: observations.len(),
+        observed_count,
+        positive_count,
+    })
+}
+
+impl HurdleLogNormalPosterior {
+    pub fn parameter_names() -> Vec<String> {
+        [
+            "payment_probability",
+            "process_variance",
+            "observation_variance",
+            "terminal_log_level",
+        ]
+        .map(str::to_string)
+        .to_vec()
+    }
+
+    pub fn parameter_samples(&self) -> Vec<Vec<Vec<f64>>> {
+        self.chains
+            .iter()
+            .map(|chain| {
+                chain
+                    .iter()
+                    .map(|d| {
+                        vec![
+                            d.payment_probability,
+                            d.process_variance,
+                            d.observation_variance,
+                            d.terminal_log_level,
+                        ]
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    pub fn forecast(
+        &self,
+        horizon: usize,
+        seed: u64,
+    ) -> Result<HurdleLogNormalForecast, BayesianForecastError> {
+        if horizon == 0
+            || self.chains.is_empty()
+            || self.chains[0].is_empty()
+            || self.chains.iter().any(|c| c.len() != self.chains[0].len())
+        {
+            return Err(invalid(
+                "positive horizon and nonempty equal-length posterior chains required",
+            ));
+        }
+        allocation(&[self.chains.len(), self.chains[0].len(), horizon, 3])?;
+        type Paths = (Vec<Vec<f64>>, Vec<Vec<f64>>, Vec<Vec<f64>>);
+        let chains: Vec<Paths> = self.chains.par_iter().enumerate().map(|(index, chain)| {
+            let mut rng = ChaCha8Rng::seed_from_u64(chain_seed(seed, index, 0x4855_5244_5052_4501));
+            let mut expected = Vec::with_capacity(chain.len());
+            let mut positive = Vec::with_capacity(chain.len());
+            let mut observed = Vec::with_capacity(chain.len());
+            for draw in chain {
+                if !draw.payment_probability.is_finite() || !(0.0..=1.0).contains(&draw.payment_probability)
+                    || !draw.terminal_log_level.is_finite()
+                    || !draw.process_variance.is_finite() || draw.process_variance <= 0.0
+                    || !draw.observation_variance.is_finite() || draw.observation_variance <= 0.0 {
+                    return Err(invalid("invalid hurdle posterior draw"));
+                }
+                let mut level = draw.terminal_log_level;
+                let mut means = Vec::with_capacity(horizon);
+                let mut positive_means = Vec::with_capacity(horizon);
+                let mut observations = Vec::with_capacity(horizon);
+                for _ in 0..horizon {
+                    level += normal(&mut rng) * draw.process_variance.sqrt();
+                    let positive_mean = (level + draw.observation_variance / 2.0).exp();
+                    // Draw severity even when the indicator is zero so the two RNG
+                    // streams' consumption does not depend on payment probability.
+                    let amount = (level + normal(&mut rng) * draw.observation_variance.sqrt()).exp();
+                    let paid = rng.gen::<f64>() < draw.payment_probability;
+                    if !positive_mean.is_finite() || !amount.is_finite() || amount == 0.0 || positive_mean == 0.0 {
+                        return Err(numerical("lognormal forecast overflowed or underflowed; inspect log-scale priors"));
+                    }
+                    means.push(draw.payment_probability * positive_mean);
+                    positive_means.push(positive_mean);
+                    observations.push(if paid { amount } else { 0.0 });
+                }
+                expected.push(means); positive.push(positive_means); observed.push(observations);
+            }
+            Ok((expected, positive, observed))
+        }).collect::<Result<_, BayesianForecastError>>()?;
+        let mut paths = PosteriorPredictiveForecast {
+            state_paths: Vec::new(),
+            observation_paths: Vec::new(),
+        };
+        let mut positive_mean_paths = Vec::new();
+        for (means, positive, observed) in chains {
+            paths.state_paths.push(means);
+            paths.observation_paths.push(observed);
+            positive_mean_paths.push(positive);
+        }
+        Ok(HurdleLogNormalForecast {
+            paths,
+            positive_mean_paths,
+        })
+    }
+}
+
+fn allocation(factors: &[usize]) -> Result<(), BayesianForecastError> {
+    let count = factors
+        .iter()
+        .try_fold(1usize, |acc, n| acc.checked_mul(*n));
+    if count.is_none_or(|n| n > MAX_VALUES) {
+        Err(invalid("requested hurdle allocation exceeds 25 million values; reduce chains, draws, history, or horizon"))
+    } else {
+        Ok(())
+    }
+}
+fn inverse_gamma(
+    prior: InverseGammaPrior,
+    rng: &mut ChaCha8Rng,
+) -> Result<f64, BayesianForecastError> {
+    if !prior.shape.is_finite()
+        || prior.shape <= 0.0
+        || !prior.scale.is_finite()
+        || prior.scale <= 0.0
+    {
+        return Err(numerical("invalid inverse-gamma conditional"));
+    }
+    let gamma = Gamma::new(prior.shape, 1.0 / prior.scale).map_err(|e| numerical(e.to_string()))?;
+    let value = 1.0 / gamma.sample(rng);
+    if value.is_finite() && value > 0.0 {
+        Ok(value)
+    } else {
+        Err(numerical("inverse-gamma draw is nonfinite or nonpositive"))
+    }
+}
+fn normal(rng: &mut ChaCha8Rng) -> f64 {
+    StandardNormal.sample(rng)
+}
+fn chain_seed(seed: u64, chain: usize, domain: u64) -> u64 {
+    let mut z = seed ^ domain ^ (chain as u64).wrapping_mul(0x9e3779b97f4a7c15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb133111eb);
+    z ^ (z >> 31)
+}
+fn invalid(message: impl Into<String>) -> BayesianForecastError {
+    BayesianForecastError::InvalidConfiguration(message.into())
+}
+fn numerical(message: impl Into<String>) -> BayesianForecastError {
+    BayesianForecastError::NumericalFailure(message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn config() -> HurdleLogNormalConfig {
+        HurdleLogNormalConfig {
+            occurrence_alpha: 2.,
+            occurrence_beta: 3.,
+            initial_log_level: 1.,
+            initial_variance: 0.2,
+            process_variance_prior: InverseGammaPrior::new(4., 0.03).unwrap(),
+            observation_variance_prior: InverseGammaPrior::new(4., 0.3).unwrap(),
+            num_chains: 2,
+            num_draws: 2000,
+            num_warmup: 50,
+            thinning: 1,
+            seed: 92,
+        }
+    }
+    #[test]
+    fn occurrence_posterior_matches_beta_and_severity_prior_for_zero_history() {
+        let fit = fit_hurdle_lognormal(&[0., 0., f64::NAN, 0.], &config()).unwrap();
+        assert_eq!((fit.observed_count, fit.positive_count), (3, 0));
+        let draws: Vec<_> = fit.chains.iter().flatten().collect();
+        let mean = |f: fn(&HurdleLogNormalDraw) -> f64| {
+            draws.iter().map(|d| f(d)).sum::<f64>() / draws.len() as f64
+        };
+        assert!((mean(|d| d.payment_probability) - 2. / 8.).abs() < 0.01);
+        assert!((mean(|d| d.process_variance) - 0.01).abs() < 0.001);
+        assert!((mean(|d| d.observation_variance) - 0.1).abs() < 0.008);
+        assert!((mean(|d| d.terminal_log_level) - 1.).abs() < 0.025);
+        let variance = draws
+            .iter()
+            .map(|d| (d.terminal_log_level - 1.).powi(2))
+            .sum::<f64>()
+            / draws.len() as f64;
+        assert!((variance - 0.24).abs() < 0.02);
+    }
+    #[test]
+    fn density_matches_point_mass_and_lognormal_jacobian() {
+        assert!((hurdle_lognormal_logp(0., 0.3, 1., 0.5).unwrap() - 0.7_f64.ln()).abs() < 1e-14);
+        let at_median = hurdle_lognormal_logp(1_f64.exp(), 0.3, 1., 0.5).unwrap();
+        assert!((at_median - (0.3_f64.ln() - 1. - 0.5 * std::f64::consts::PI.ln())).abs() < 1e-14);
+        assert_eq!(
+            hurdle_lognormal_logp(0., 1., 0., 1.).unwrap(),
+            f64::NEG_INFINITY
+        );
+        assert!(hurdle_lognormal_logp(-1., 0.5, 0., 1.).is_err());
+    }
+    #[test]
+    fn one_positive_and_missing_steps_are_supported_and_seeded_across_threads() {
+        let mut cfg = config();
+        cfg.num_draws = 40;
+        let y = [0., f64::NAN, 2., 0., 0.];
+        let run = |threads| {
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(threads)
+                .build()
+                .unwrap()
+                .install(|| {
+                    let fit = fit_hurdle_lognormal(&y, &cfg).unwrap();
+                    let f = fit.forecast(3, 99).unwrap();
+                    (fit, f)
+                })
+        };
+        assert_eq!(run(1), run(3));
+    }
+    #[test]
+    fn predictive_zero_mass_and_amount_moments_match_known_parameters() {
+        let draw = HurdleLogNormalDraw {
+            payment_probability: 0.3,
+            process_variance: 0.01,
+            observation_variance: 0.2,
+            terminal_log_level: 1.,
+        };
+        let fit = HurdleLogNormalPosterior {
+            chains: vec![vec![draw; 30000]],
+            time_count: 1,
+            observed_count: 1,
+            positive_count: 1,
+        };
+        let f = fit.forecast(1, 42).unwrap();
+        let y: Vec<f64> = f.paths.observation_paths[0].iter().map(|p| p[0]).collect();
+        let zero = y.iter().filter(|v| **v == 0.).count() as f64 / y.len() as f64;
+        assert!((zero - 0.7).abs() < 0.01);
+        let expected = 0.3 * (1.0_f64 + 0.21 / 2.).exp();
+        assert!((y.iter().sum::<f64>() / y.len() as f64 - expected).abs() < 0.035);
+        for (mean, pos) in f.paths.state_paths[0].iter().zip(&f.positive_mean_paths[0]) {
+            assert_eq!(mean[0], 0.3 * pos[0]);
+        }
+    }
+    #[test]
+    fn rejects_invalid_observations_and_allocation_counts() {
+        for y in [&[][..], &[f64::NAN], &[-1.], &[f64::INFINITY]] {
+            assert!(fit_hurdle_lognormal(y, &config()).is_err());
+        }
+        let mut cfg = config();
+        cfg.num_draws = usize::MAX;
+        assert!(fit_hurdle_lognormal(&[0.], &cfg).is_err());
+    }
+}

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -7,6 +7,8 @@ pub mod compiled_model;
 pub mod data;
 pub mod diagnostics;
 pub mod distributions;
+pub mod forecast_batch;
+pub mod forecast_diagnostics;
 pub mod graph;
 pub mod hierarchical;
 pub mod hmc;

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod distributions;
 pub mod graph;
 pub mod hierarchical;
 pub mod hmc;
+pub mod hurdle;
 pub mod mass_matrix;
 pub mod nuts;
 pub mod param_ref;

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod autodiff;
 pub mod bayesian_ar;
 pub mod bayesian_forecast;
+pub mod bayesian_regression;
 pub mod bayesian_seasonal;
 pub mod bayesian_trend;
 pub mod compiled_model;

--- a/rust_core/src/lib.rs
+++ b/rust_core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod mass_matrix;
 pub mod nuts;
 pub mod param_ref;
 pub mod progress;
+pub mod runoff;
 pub mod sampler;
 pub mod state_space;
 

--- a/rust_core/src/runoff.rs
+++ b/rust_core/src/runoff.rs
@@ -6,11 +6,23 @@
 //! `count[lag] ~ Poisson(lambda * p[lag])`. Currency is not a count observation.
 //! The final category is an unscheduled tail, never a dated calendar payment.
 
-use rand::SeedableRng;
+use rand::{distributions::Open01, Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use rand_distr::{Beta, Binomial, Distribution, Gamma, Poisson};
 
 const MAX_EXACT_COUNT: u64 = (1_u64 << 53) - 1;
+const MAX_RETAINED_VALUES: usize = 25_000_000;
+
+fn validate_allocation(factors: &[usize]) -> Result<(), String> {
+    if factors
+        .iter()
+        .try_fold(1_usize, |n, factor| n.checked_mul(*factor))
+        .is_none_or(|n| n > MAX_RETAINED_VALUES)
+    {
+        return Err("requested runoff allocation exceeds 25 million values; reduce cohorts, lags, chains, draws, or horizon".into());
+    }
+    Ok(())
+}
 
 #[derive(Debug, Clone)]
 pub struct RunoffConfig {
@@ -133,6 +145,7 @@ fn validate_config(config: &RunoffConfig) -> Result<(), String> {
             "draws and chains must be positive and draws + warmup must not overflow".into(),
         );
     }
+    validate_allocation(&[config.draws, config.chains])?;
     Ok(())
 }
 
@@ -157,7 +170,31 @@ fn dirichlet(alpha: &[f64], rng: &mut ChaCha8Rng) -> Result<Vec<f64>, String> {
 }
 
 fn binomial(n: u64, probability: f64, rng: &mut ChaCha8Rng) -> Result<u64, String> {
-    Ok(Binomial::new(n, probability.clamp(0.0, 1.0))
+    let probability = probability.clamp(0.0, 1.0);
+    let p = probability.min(1.0 - probability);
+    // rand_distr 0.4's BINV uses powi(i32), so it incorrectly dispatches sparse
+    // n > i32::MAX cases to BTPE, whose rejection envelope can be invalid.
+    // Exact geometric waiting times handle these rare-event binomials in O(np).
+    if n > i32::MAX as u64 && n as f64 * p < 10.0 && p > 0.0 {
+        let mut remaining = n;
+        let mut events = 0_u64;
+        let log_failure = (-p).ln_1p();
+        while remaining > 0 {
+            let uniform: f64 = rng.sample(Open01);
+            let failures = (uniform.ln() / log_failure).floor();
+            if failures >= remaining as f64 {
+                break;
+            }
+            remaining -= failures as u64 + 1;
+            events += 1;
+        }
+        return Ok(if probability <= 0.5 {
+            events
+        } else {
+            n - events
+        });
+    }
+    Ok(Binomial::new(n, probability)
         .map_err(|e| e.to_string())?
         .sample(rng))
 }
@@ -211,6 +248,20 @@ pub fn fit_runoff(
 ) -> Result<RunoffPosterior, String> {
     validate_config(config)?;
     triangle.validate(config.alpha.len())?;
+    validate_allocation(&[
+        config.chains,
+        config.draws,
+        triangle
+            .counts
+            .len()
+            .checked_add(1)
+            .ok_or("cohort count overflow")?,
+        config
+            .alpha
+            .len()
+            .checked_add(3)
+            .ok_or("lag count overflow")?,
+    ])?;
     let exact = triangle.known_totals.iter().all(Option::is_some);
     let hazards = if exact {
         Some(known_total_hazard_posterior(triangle, &config.alpha)?)
@@ -378,6 +429,11 @@ impl RunoffPosterior {
         {
             return Err("steps must be positive and fit the integer calendar".into());
         }
+        validate_allocation(&[
+            self.chains.len(),
+            self.chains.first().map_or(0, Vec::len),
+            steps,
+        ])?;
         self.chains
             .iter()
             .map(|chain| {
@@ -595,6 +651,43 @@ mod tests {
             .sum::<f64>()
             / 10000.0;
         assert!((p - 0.2).abs() < 0.015);
+    }
+
+    #[test]
+    fn large_sparse_binomial_is_exact_and_bounded_allocations_reject_oversize() {
+        let mut rng = ChaCha8Rng::seed_from_u64(31);
+        let samples = (0..20000)
+            .map(|_| binomial(10_000_000_000, 2e-10, &mut rng).unwrap() as f64)
+            .collect::<Vec<_>>();
+        let (mean, variance) = mean_var(&samples);
+        assert!((mean - 2.0).abs() < 0.03);
+        assert!((variance - 2.0).abs() < 0.07);
+        let complements = (0..20000)
+            .map(|_| {
+                (10_000_000_000 - binomial(10_000_000_000, 1.0 - 2e-10, &mut rng).unwrap()) as f64
+            })
+            .collect::<Vec<_>>();
+        assert!((mean_var(&complements).0 - 2.0).abs() < 0.03);
+        let triangle = PaymentTriangle {
+            counts: vec![vec![Some(0), None], vec![None, None]],
+            origins: vec![0, 1],
+            valuation: 0,
+            known_totals: vec![Some(10_000_000_000); 2],
+        };
+        let mut cfg = config(vec![1.0, 1.0]);
+        cfg.draws = 10;
+        let fit = fit_runoff(&triangle, &cfg).unwrap();
+        assert!(fit
+            .chains
+            .iter()
+            .flatten()
+            .all(|d| d.totals == vec![10_000_000_000; 2]));
+        assert!(fit.calendar_samples(usize::MAX / 8).is_err());
+        cfg.chains = usize::MAX;
+        assert!(fit_runoff(&triangle, &cfg).is_err());
+        cfg.chains = 1;
+        cfg.draws = MAX_RETAINED_VALUES;
+        assert!(fit_runoff(&triangle, &cfg).is_err());
     }
 
     #[test]

--- a/rust_core/src/runoff.rs
+++ b/rust_core/src/runoff.rs
@@ -1,0 +1,664 @@
+//! Integer-event payment development with prefix censoring and an explicit tail.
+//!
+//! One shared `p ~ Dirichlet(alpha)` pools cohort lag probabilities. Known ultimate
+//! counts give multinomial allocations (Dirichlet-multinomial after integrating p).
+//! Unknown ultimates use independent `lambda ~ Gamma(shape, rate)` and independent
+//! `count[lag] ~ Poisson(lambda * p[lag])`. Currency is not a count observation.
+//! The final category is an unscheduled tail, never a dated calendar payment.
+
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use rand_distr::{Beta, Binomial, Distribution, Gamma, Poisson};
+
+const MAX_EXACT_COUNT: u64 = (1_u64 << 53) - 1;
+
+#[derive(Debug, Clone)]
+pub struct RunoffConfig {
+    pub alpha: Vec<f64>,
+    /// Gamma prior shape for each unknown ultimate's Poisson intensity.
+    pub total_shape: f64,
+    /// Gamma prior rate, not scale.
+    pub total_rate: f64,
+    pub draws: usize,
+    pub warmup: usize,
+    pub chains: usize,
+    pub seed: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct PaymentTriangle {
+    /// Incremental counts. None means unobserved; Some(0) is observed zero.
+    pub counts: Vec<Vec<Option<u64>>>,
+    /// Integer periods on one common calendar; development zero is origin.
+    pub origins: Vec<i64>,
+    pub valuation: i64,
+    /// None infers an uncertain ultimate under the Gamma-Poisson prior.
+    pub known_totals: Vec<Option<u64>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RunoffDraw {
+    pub lag_probabilities: Vec<f64>,
+    /// Complete allocations, including the unchanged observed cells.
+    pub counts: Vec<Vec<u64>>,
+    pub totals: Vec<u64>,
+    /// None for known-total cohorts.
+    pub intensities: Vec<Option<f64>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RunoffPosterior {
+    pub triangle: PaymentTriangle,
+    pub chains: Vec<Vec<RunoffDraw>>,
+    /// Exact independent conjugate draws when every ultimate is known.
+    pub exact: bool,
+}
+
+impl PaymentTriangle {
+    pub fn validate(&self, categories: usize) -> Result<(), String> {
+        if categories < 2 {
+            return Err("alpha needs at least one regular lag and a final tail category".into());
+        }
+        if self.counts.is_empty()
+            || self.origins.len() != self.counts.len()
+            || self.known_totals.len() != self.counts.len()
+        {
+            return Err(
+                "counts, origins, and totals must have the same nonzero cohort count".into(),
+            );
+        }
+        for (i, row) in self.counts.iter().enumerate() {
+            if row.len() != categories {
+                return Err(format!(
+                    "cohort {i}: count columns must match alpha including tail"
+                ));
+            }
+            let mut sum = 0_u64;
+            for (lag, count) in row.iter().enumerate() {
+                let date = self.origins[i]
+                    .checked_add(lag as i64)
+                    .ok_or("origin plus development overflows calendar")?;
+                if lag + 1 < categories && count.is_some() != (date <= self.valuation) {
+                    return Err(format!("cohort {i}, lag {lag}: elapsed regular cells must be observed and future cells unobserved"));
+                }
+                if lag + 1 == categories && count.is_some() && date > self.valuation {
+                    return Err(format!(
+                        "cohort {i}: tail cannot close before its first possible period"
+                    ));
+                }
+                if let Some(n) = count {
+                    if *n > MAX_EXACT_COUNT {
+                        return Err("counts must not exceed 2**53 - 1".into());
+                    }
+                    sum = sum.checked_add(*n).ok_or("observed count sum overflow")?;
+                }
+            }
+            if sum > MAX_EXACT_COUNT {
+                return Err("cohort observed total must not exceed 2**53 - 1".into());
+            }
+            if let Some(total) = self.known_totals[i] {
+                if total > MAX_EXACT_COUNT || sum > total {
+                    return Err(format!(
+                        "cohort {i}: known total must cover observed counts and be <= 2**53 - 1"
+                    ));
+                }
+                if row.iter().all(Option::is_some) && sum != total {
+                    return Err(format!(
+                        "cohort {i}: closed row must sum to its known total"
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_config(config: &RunoffConfig) -> Result<(), String> {
+    if config.alpha.len() < 2
+        || config.alpha.iter().any(|a| !a.is_finite() || *a <= 0.0)
+        || !config.alpha.iter().sum::<f64>().is_finite()
+    {
+        return Err("alpha must contain at least two finite positive concentrations".into());
+    }
+    if !config.total_shape.is_finite()
+        || config.total_shape <= 0.0
+        || !config.total_rate.is_finite()
+        || config.total_rate <= 0.0
+    {
+        return Err("total_shape and total_rate must be finite and positive".into());
+    }
+    if config.draws == 0 || config.chains == 0 || config.draws.checked_add(config.warmup).is_none()
+    {
+        return Err(
+            "draws and chains must be positive and draws + warmup must not overflow".into(),
+        );
+    }
+    Ok(())
+}
+
+fn beta_draw(a: f64, b: f64, rng: &mut ChaCha8Rng) -> Result<f64, String> {
+    let q = Beta::new(a, b).map_err(|e| e.to_string())?.sample(rng);
+    if !q.is_finite() {
+        return Err("nonfinite Beta draw; rescale extreme prior or counts".into());
+    }
+    Ok(q)
+}
+
+fn dirichlet(alpha: &[f64], rng: &mut ChaCha8Rng) -> Result<Vec<f64>, String> {
+    let mut remaining = 1.0;
+    let mut p = Vec::with_capacity(alpha.len());
+    for lag in 0..alpha.len() - 1 {
+        let q = beta_draw(alpha[lag], alpha[lag + 1..].iter().sum(), rng)?;
+        p.push(remaining * q);
+        remaining *= 1.0 - q;
+    }
+    p.push(remaining);
+    Ok(p)
+}
+
+fn binomial(n: u64, probability: f64, rng: &mut ChaCha8Rng) -> Result<u64, String> {
+    Ok(Binomial::new(n, probability.clamp(0.0, 1.0))
+        .map_err(|e| e.to_string())?
+        .sample(rng))
+}
+
+fn poisson(mean: f64, rng: &mut ChaCha8Rng) -> Result<u64, String> {
+    if mean == 0.0 {
+        return Ok(0);
+    }
+    if !mean.is_finite() || mean > MAX_EXACT_COUNT as f64 {
+        return Err("Poisson mean exceeds the supported exact-count range".into());
+    }
+    let value = Poisson::new(mean).map_err(|e| e.to_string())?.sample(rng);
+    if value > MAX_EXACT_COUNT as f64 {
+        return Err("Poisson draw exceeds the supported exact-count range".into());
+    }
+    Ok(value as u64)
+}
+
+/// Independent posterior stick-breaking hazards under known-total prefix censoring.
+/// A cohort contributes successes x_l and failures N - sum_{j<=l} x_j only at
+/// elapsed lags. The prior hazards are independent Beta(alpha_l, sum_{j>l} alpha_j).
+pub fn known_total_hazard_posterior(
+    triangle: &PaymentTriangle,
+    alpha: &[f64],
+) -> Result<Vec<(f64, f64)>, String> {
+    triangle.validate(alpha.len())?;
+    if alpha.iter().any(|a| !a.is_finite() || *a <= 0.0) || !alpha.iter().sum::<f64>().is_finite() {
+        return Err("alpha must be finite and positive".into());
+    }
+    let mut params = (0..alpha.len() - 1)
+        .map(|l| (alpha[l], alpha[l + 1..].iter().sum::<f64>()))
+        .collect::<Vec<_>>();
+    for (cohort, row) in triangle.counts.iter().enumerate() {
+        let mut remaining = triangle.known_totals[cohort].ok_or("all totals must be known")?;
+        for (lag, cell) in row.iter().take(alpha.len() - 1).enumerate() {
+            if let Some(n) = cell {
+                remaining -= n;
+                params[lag].0 += *n as f64;
+                params[lag].1 += remaining as f64;
+            }
+        }
+    }
+    Ok(params)
+}
+
+/// Fit native runoff, preserving chain/draw/cohort/lag alignment.
+/// Known-only fits use exact conjugate sampling; other fits use latent-count Gibbs.
+pub fn fit_runoff(
+    triangle: &PaymentTriangle,
+    config: &RunoffConfig,
+) -> Result<RunoffPosterior, String> {
+    validate_config(config)?;
+    triangle.validate(config.alpha.len())?;
+    let exact = triangle.known_totals.iter().all(Option::is_some);
+    let hazards = if exact {
+        Some(known_total_hazard_posterior(triangle, &config.alpha)?)
+    } else {
+        None
+    };
+    let categories = config.alpha.len();
+    let observed_sums = triangle
+        .counts
+        .iter()
+        .map(|r| r.iter().flatten().sum::<u64>())
+        .collect::<Vec<_>>();
+    let mut chains = Vec::with_capacity(config.chains);
+    for chain in 0..config.chains {
+        let mut rng = ChaCha8Rng::seed_from_u64(
+            config
+                .seed
+                .wrapping_add((chain as u64).wrapping_mul(0x9e3779b97f4a7c15)),
+        );
+        let mut p = dirichlet(&config.alpha, &mut rng)?;
+        let warmup = if exact { 0 } else { config.warmup };
+        let mut retained = Vec::with_capacity(config.draws);
+        for iteration in 0..warmup + config.draws {
+            let mut exact_hazards = Vec::new();
+            if let Some(params) = &hazards {
+                let mut rest = 1.0;
+                for (lag, (a, b)) in params.iter().enumerate() {
+                    let q = beta_draw(*a, *b, &mut rng)?;
+                    exact_hazards.push(q);
+                    p[lag] = rest * q;
+                    rest *= 1.0 - q;
+                }
+                p[categories - 1] = rest;
+            }
+            let mut counts = Vec::with_capacity(triangle.counts.len());
+            let mut totals = Vec::with_capacity(triangle.counts.len());
+            let mut intensities = Vec::with_capacity(triangle.counts.len());
+            for (i, row) in triangle.counts.iter().enumerate() {
+                let mut full = row.iter().map(|v| v.unwrap_or(0)).collect::<Vec<_>>();
+                if let Some(total) = triangle.known_totals[i] {
+                    let mut remaining = total - observed_sums[i];
+                    for lag in 0..categories {
+                        if row[lag].is_none() {
+                            if lag + 1 == categories {
+                                full[lag] = remaining;
+                            } else {
+                                let q = if exact {
+                                    exact_hazards[lag]
+                                } else {
+                                    let mass: f64 = p[lag..].iter().sum();
+                                    if mass == 0.0 && remaining > 0 {
+                                        return Err("unobserved lag probability underflow; use less extreme priors".into());
+                                    }
+                                    if mass == 0.0 {
+                                        0.0
+                                    } else {
+                                        p[lag] / mass
+                                    }
+                                };
+                                full[lag] = binomial(remaining, q, &mut rng)?;
+                            }
+                            remaining -= full[lag];
+                        }
+                    }
+                    intensities.push(None);
+                } else {
+                    // Marginal lambda conditional on observed cells, then regenerate
+                    // missing counts. This blocked update avoids conditioning lambda
+                    // on stale latent counts from an immature cohort.
+                    let exposure: f64 = row.iter().zip(&p).filter_map(|(n, p)| n.map(|_| p)).sum();
+                    let intensity = Gamma::new(
+                        config.total_shape + observed_sums[i] as f64,
+                        1.0 / (config.total_rate + exposure),
+                    )
+                    .map_err(|e| e.to_string())?
+                    .sample(&mut rng);
+                    if !intensity.is_finite() {
+                        return Err("nonfinite ultimate intensity draw".into());
+                    }
+                    for lag in 0..categories {
+                        if row[lag].is_none() {
+                            full[lag] = poisson(intensity * p[lag], &mut rng)?;
+                        }
+                    }
+                    intensities.push(Some(intensity));
+                }
+                let total = full
+                    .iter()
+                    .try_fold(0_u64, |sum, n| sum.checked_add(*n))
+                    .ok_or("ultimate count overflow")?;
+                if total > MAX_EXACT_COUNT {
+                    return Err("ultimate count exceeds 2**53 - 1".into());
+                }
+                totals.push(total);
+                counts.push(full);
+            }
+            if !exact {
+                let mut posterior_alpha = config.alpha.clone();
+                for row in &counts {
+                    for (a, n) in posterior_alpha.iter_mut().zip(row) {
+                        *a += *n as f64;
+                    }
+                }
+                p = dirichlet(&posterior_alpha, &mut rng)?;
+            }
+            if iteration >= warmup {
+                retained.push(RunoffDraw {
+                    lag_probabilities: p.clone(),
+                    counts,
+                    totals,
+                    intensities,
+                });
+            }
+        }
+        chains.push(retained);
+    }
+    Ok(RunoffPosterior {
+        triangle: triangle.clone(),
+        chains,
+        exact,
+    })
+}
+
+impl RunoffPosterior {
+    /// Parameter diagnostics cover the shared lag vector and each unknown cohort's
+    /// ultimate intensity and count. Observed cells and fixed known totals are excluded.
+    pub fn diagnostics(&self) -> crate::diagnostics::DiagnosticsReport {
+        let mut names = (0..self.triangle.counts[0].len())
+            .map(|lag| format!("lag_probability[{lag}]"))
+            .collect::<Vec<_>>();
+        for (i, total) in self.triangle.known_totals.iter().enumerate() {
+            if total.is_none() {
+                names.push(format!("intensity[{i}]"));
+                names.push(format!("ultimate[{i}]"));
+            }
+        }
+        let samples = self
+            .chains
+            .iter()
+            .map(|chain| {
+                chain
+                    .iter()
+                    .map(|draw| {
+                        let mut values = draw.lag_probabilities.clone();
+                        for (i, intensity) in draw.intensities.iter().enumerate() {
+                            if let Some(intensity) = intensity {
+                                values.push(*intensity);
+                                values.push(draw.totals[i] as f64);
+                            }
+                        }
+                        values
+                    })
+                    .collect()
+            })
+            .collect::<Vec<_>>();
+        crate::forecast_diagnostics::parameter_diagnostics(&samples, &names)
+    }
+
+    /// Future calendar counts for valuation+1,...,valuation+steps. This excludes
+    /// tail and regular cells beyond the requested horizon; no tail timing is assumed.
+    pub fn calendar_samples(&self, steps: usize) -> Result<Vec<Vec<Vec<u64>>>, String> {
+        if steps == 0
+            || steps > i64::MAX as usize
+            || self.triangle.valuation.checked_add(steps as i64).is_none()
+        {
+            return Err("steps must be positive and fit the integer calendar".into());
+        }
+        self.chains
+            .iter()
+            .map(|chain| {
+                chain
+                    .iter()
+                    .map(|draw| {
+                        let mut calendar = vec![0_u64; steps];
+                        for (i, row) in draw.counts.iter().enumerate() {
+                            for (lag, n) in row.iter().take(row.len() - 1).enumerate() {
+                                let date = self.triangle.origins[i] + lag as i64;
+                                let offset = date as i128 - self.triangle.valuation as i128 - 1;
+                                if offset >= 0 && offset < steps as i128 {
+                                    calendar[offset as usize] = calendar[offset as usize]
+                                        .checked_add(*n)
+                                        .ok_or("calendar count overflow")?;
+                                }
+                            }
+                        }
+                        Ok(calendar)
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// Unobserved tail counts, preserving cohorts. Closed observed tails return zero.
+    pub fn tail_samples(&self) -> Vec<Vec<Vec<u64>>> {
+        self.chains
+            .iter()
+            .map(|chain| {
+                chain
+                    .iter()
+                    .map(|draw| {
+                        draw.counts
+                            .iter()
+                            .enumerate()
+                            .map(|(i, row)| {
+                                if self.triangle.counts[i].last().unwrap().is_none() {
+                                    *row.last().unwrap()
+                                } else {
+                                    0
+                                }
+                            })
+                            .collect()
+                    })
+                    .collect()
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(alpha: Vec<f64>) -> RunoffConfig {
+        RunoffConfig {
+            alpha,
+            total_shape: 4.0,
+            total_rate: 0.2,
+            draws: 5000,
+            warmup: 300,
+            chains: 2,
+            seed: 182,
+        }
+    }
+
+    fn mean_var(values: &[f64]) -> (f64, f64) {
+        let mean = values.iter().sum::<f64>() / values.len() as f64;
+        (
+            mean,
+            values.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / values.len() as f64,
+        )
+    }
+
+    #[test]
+    fn complete_triangle_matches_dirichlet_moments() {
+        let triangle = PaymentTriangle {
+            counts: vec![
+                vec![Some(8), Some(3), Some(1)],
+                vec![Some(4), Some(5), Some(3)],
+            ],
+            origins: vec![0, 1],
+            valuation: 5,
+            known_totals: vec![Some(12), Some(12)],
+        };
+        let fit = fit_runoff(&triangle, &config(vec![2.0, 3.0, 1.0])).unwrap();
+        assert!(fit.exact);
+        let posterior = [14.0, 11.0, 5.0];
+        for (lag, a) in posterior.iter().enumerate() {
+            let samples = fit
+                .chains
+                .iter()
+                .flatten()
+                .map(|d| d.lag_probabilities[lag])
+                .collect::<Vec<_>>();
+            let (mean, variance) = mean_var(&samples);
+            assert!((mean - a / 30.0).abs() < 0.003);
+            assert!((variance - a * (30.0 - a) / (30.0_f64.powi(2) * 31.0)).abs() < 0.0004);
+        }
+        assert!(fit
+            .tail_samples()
+            .iter()
+            .flatten()
+            .flatten()
+            .all(|n| *n == 0));
+    }
+
+    #[test]
+    fn immature_zero_updates_exposure_and_future_is_beta_binomial() {
+        let triangle = PaymentTriangle {
+            counts: vec![vec![Some(0), None, None]],
+            origins: vec![0],
+            valuation: 0,
+            known_totals: vec![Some(10)],
+        };
+        let cfg = config(vec![2.0, 3.0, 5.0]);
+        assert_eq!(
+            known_total_hazard_posterior(&triangle, &cfg.alpha).unwrap(),
+            vec![(2.0, 18.0), (3.0, 5.0)]
+        );
+        let fit = fit_runoff(&triangle, &cfg).unwrap();
+        let samples = fit
+            .chains
+            .iter()
+            .flatten()
+            .map(|d| d.counts[0][1] as f64)
+            .collect::<Vec<_>>();
+        let (mean, variance) = mean_var(&samples);
+        assert!((mean - 10.0 * 3.0 / 8.0).abs() < 0.07);
+        let expected_variance = 10.0 * 3.0 * 5.0 * 18.0 / (64.0 * 9.0);
+        assert!((variance - expected_variance).abs() < 0.2);
+        let p0 = fit
+            .chains
+            .iter()
+            .flatten()
+            .map(|d| d.lag_probabilities[0])
+            .sum::<f64>()
+            / 10000.0;
+        assert!((p0 - 0.1).abs() < 0.003);
+    }
+
+    #[test]
+    fn masks_totals_seed_and_calendar_alignment() {
+        let triangle = PaymentTriangle {
+            counts: vec![vec![Some(4), None, None], vec![None, None, None]],
+            origins: vec![0, 1],
+            valuation: 0,
+            known_totals: vec![Some(9), Some(6)],
+        };
+        let mut cfg = config(vec![3.0, 2.0, 1.0]);
+        cfg.draws = 20;
+        let fit = fit_runoff(&triangle, &cfg).unwrap();
+        let repeat = fit_runoff(&triangle, &cfg).unwrap();
+        let calendar = fit.calendar_samples(2).unwrap();
+        let tails = fit.tail_samples();
+        for c in 0..cfg.chains {
+            for d in 0..cfg.draws {
+                let draw = &fit.chains[c][d];
+                assert_eq!(draw.counts, repeat.chains[c][d].counts);
+                assert_eq!(
+                    draw.lag_probabilities,
+                    repeat.chains[c][d].lag_probabilities
+                );
+                assert_eq!(draw.totals, vec![9, 6]);
+                assert_eq!(draw.counts[0][0], 4);
+                assert_eq!(calendar[c][d][0], draw.counts[0][1] + draw.counts[1][0]);
+                assert_eq!(calendar[c][d][1], draw.counts[1][1]);
+                assert_eq!(
+                    calendar[c][d].iter().sum::<u64>() + tails[c][d].iter().sum::<u64>() + 4,
+                    15
+                );
+            }
+        }
+        assert_ne!(
+            fit.chains[0][0].lag_probabilities,
+            fit.chains[1][0].lag_probabilities
+        );
+        let mut invalid = triangle.clone();
+        invalid.counts[0][1] = Some(0);
+        assert!(fit_runoff(&invalid, &cfg).is_err());
+        invalid = triangle.clone();
+        invalid.counts[0][0] = None;
+        assert!(fit_runoff(&invalid, &cfg).is_err());
+        invalid = triangle.clone();
+        invalid.known_totals[0] = Some(3);
+        assert!(fit_runoff(&invalid, &cfg).is_err());
+    }
+
+    #[test]
+    fn unknown_unobserved_ultimate_matches_gamma_poisson_prior() {
+        let triangle = PaymentTriangle {
+            counts: vec![vec![None, None, None]],
+            origins: vec![2],
+            valuation: 0,
+            known_totals: vec![None],
+        };
+        let fit = fit_runoff(&triangle, &config(vec![2.0, 3.0, 5.0])).unwrap();
+        assert!(!fit.exact);
+        let (mean, variance) = mean_var(
+            &fit.chains
+                .iter()
+                .flatten()
+                .map(|d| d.totals[0] as f64)
+                .collect::<Vec<_>>(),
+        );
+        // Gamma-Poisson mean a/b, variance a/b + a/b^2.
+        assert!((mean - 20.0).abs() < 0.4);
+        assert!((variance - 120.0).abs() < 7.0);
+        let p = fit
+            .chains
+            .iter()
+            .flatten()
+            .map(|d| d.lag_probabilities[0])
+            .sum::<f64>()
+            / 10000.0;
+        assert!((p - 0.2).abs() < 0.015);
+    }
+
+    #[test]
+    fn known_and_unknown_cohorts_recover_shared_lags() {
+        let mut rng = ChaCha8Rng::seed_from_u64(612);
+        let truth = [0.5, 0.3, 0.15, 0.05];
+        let mut triangle = PaymentTriangle {
+            counts: vec![],
+            origins: vec![],
+            valuation: 5,
+            known_totals: vec![],
+        };
+        for i in 0..120 {
+            let total = poisson(200.0, &mut rng).unwrap();
+            let mut remaining = total;
+            let mut row = Vec::new();
+            let origin = i % 7;
+            for lag in 0..4 {
+                let n = if lag == 3 {
+                    remaining
+                } else {
+                    binomial(
+                        remaining,
+                        truth[lag] / truth[lag..].iter().sum::<f64>(),
+                        &mut rng,
+                    )
+                    .unwrap()
+                };
+                remaining -= n;
+                row.push(if origin + lag <= 5 { Some(n) } else { None });
+            }
+            triangle.counts.push(row);
+            triangle.origins.push(origin as i64);
+            triangle
+                .known_totals
+                .push(if i % 3 == 0 { Some(total) } else { None });
+        }
+        let mut cfg = config(vec![1.0; 4]);
+        cfg.total_shape = 20.0;
+        cfg.total_rate = 0.1;
+        cfg.draws = 700;
+        let fit = fit_runoff(&triangle, &cfg).unwrap();
+        for (lag, expected) in truth.iter().enumerate() {
+            let mean = fit
+                .chains
+                .iter()
+                .flatten()
+                .map(|d| d.lag_probabilities[lag])
+                .sum::<f64>()
+                / (cfg.chains * cfg.draws) as f64;
+            assert!(
+                (mean - expected).abs() < 0.015,
+                "lag {lag}: {mean} vs {expected}"
+            );
+        }
+        for draw in fit.chains.iter().flatten() {
+            for (i, row) in triangle.counts.iter().enumerate() {
+                for (lag, n) in row.iter().enumerate() {
+                    if let Some(n) = n {
+                        assert_eq!(draw.counts[i][lag], *n);
+                    }
+                }
+                assert_eq!(draw.counts[i].iter().sum::<u64>(), draw.totals[i]);
+            }
+        }
+    }
+}

--- a/rust_core/src/state_space.rs
+++ b/rust_core/src/state_space.rs
@@ -86,6 +86,7 @@ pub struct LinearGaussianStateSpace {
     dimension: usize,
     transition: Vec<f64>,
     observation: Vec<f64>,
+    observation_rows: Option<Vec<Vec<f64>>>,
     process_covariance: Vec<f64>,
     observation_variance: f64,
     initial_mean: Vec<f64>,
@@ -143,6 +144,7 @@ impl LinearGaussianStateSpace {
             dimension,
             transition,
             observation,
+            observation_rows: None,
             process_covariance,
             observation_variance,
             initial_mean,
@@ -345,8 +347,109 @@ impl LinearGaussianStateSpace {
         self.dimension
     }
 
+    /// Set one finite observation row per training time. Missing observations
+    /// retain their rows. Forecasting then requires explicit future rows.
+    pub fn with_observation_rows(mut self, rows: Vec<Vec<f64>>) -> Result<Self, StateSpaceError> {
+        self.validate_rows(&rows, rows.len())?;
+        self.observation_rows = Some(rows);
+        Ok(self)
+    }
+
+    fn validate_rows(&self, rows: &[Vec<f64>], count: usize) -> Result<(), StateSpaceError> {
+        check_len("observation row count", rows.len(), count)?;
+        for row in rows {
+            check_len("observation row", row.len(), self.dimension)?;
+            check_finite("observation rows", row)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn transition(&self) -> &[f64] {
+        &self.transition
+    }
+    pub(crate) fn observation(&self) -> &[f64] {
+        &self.observation
+    }
+    pub(crate) fn set_variances(&mut self, indices: &[usize], variances: &[f64], observation: f64) {
+        for (&index, &variance) in indices.iter().zip(variances) {
+            self.process_covariance[index * self.dimension + index] = variance;
+        }
+        self.observation_variance = observation;
+    }
+
+    /// Augment a structural model with static uncertain coefficients. The
+    /// coefficient block has identity transition and exactly zero process noise.
+    pub fn with_static_regression(
+        &self,
+        design: &[Vec<f64>],
+        mean: &[f64],
+        covariance: &[f64],
+    ) -> Result<Self, StateSpaceError> {
+        if self.observation_rows.is_some() {
+            return Err(StateSpaceError::InvalidParameter(
+                "static regression augmentation requires a constant structural observation row"
+                    .into(),
+            ));
+        }
+        let p = mean.len();
+        if p == 0 {
+            return Err(StateSpaceError::InvalidDimension(
+                "coefficient prior must not be empty".into(),
+            ));
+        }
+        check_len(
+            "coefficient covariance",
+            covariance.len(),
+            p.checked_mul(p)
+                .ok_or_else(|| StateSpaceError::InvalidDimension("too many coefficients".into()))?,
+        )?;
+        let n = self.dimension + p;
+        let mut transition = vec![0.0; n * n];
+        let mut process = vec![0.0; n * n];
+        let mut initial = vec![0.0; n * n];
+        for i in 0..self.dimension {
+            for j in 0..self.dimension {
+                transition[i * n + j] = self.transition[i * self.dimension + j];
+                process[i * n + j] = self.process_covariance[i * self.dimension + j];
+                initial[i * n + j] = self.initial_covariance[i * self.dimension + j];
+            }
+        }
+        for i in 0..p {
+            transition[(i + self.dimension) * n + i + self.dimension] = 1.0;
+            for j in 0..p {
+                initial[(i + self.dimension) * n + j + self.dimension] = covariance[i * p + j];
+            }
+        }
+        let mut initial_mean = self.initial_mean.clone();
+        initial_mean.extend_from_slice(mean);
+        let mut observation = self.observation.clone();
+        observation.resize(n, 0.0);
+        let rows = design
+            .iter()
+            .map(|row| {
+                check_len("exog feature count", row.len(), p)?;
+                let mut full = self.observation.clone();
+                full.extend_from_slice(row);
+                Ok(full)
+            })
+            .collect::<Result<Vec<_>, StateSpaceError>>()?;
+        Self::new(
+            n,
+            transition,
+            observation,
+            process,
+            self.observation_variance,
+            initial_mean,
+            initial,
+        )?
+        .with_observation_rows(rows)
+    }
+
     pub fn filter(&self, observations: &[f64]) -> Result<KalmanFilterResult, StateSpaceError> {
         validate_observations(observations)?;
+        if let Some(rows) = &self.observation_rows {
+            self.validate_rows(rows, observations.len())?;
+        }
         let d = self.dimension;
         let mut previous_mean = self.initial_mean.clone();
         let mut previous_covariance = self.initial_covariance.clone();
@@ -357,6 +460,10 @@ impl LinearGaussianStateSpace {
         let mut log_likelihood = 0.0;
 
         for (time, &value) in observations.iter().enumerate() {
+            let observation = self
+                .observation_rows
+                .as_ref()
+                .map_or(self.observation.as_slice(), |rows| rows[time].as_slice());
             let predicted_mean = mat_vec(&self.transition, &previous_mean, d);
             let mut predicted_covariance = mat_mul_transpose_right(
                 &mat_mul(&self.transition, &previous_covariance, d),
@@ -375,14 +482,14 @@ impl LinearGaussianStateSpace {
             let (filtered_mean, filtered_covariance) = if value.is_nan() {
                 (predicted_mean.clone(), predicted_covariance.clone())
             } else {
-                let ph = mat_vec(&predicted_covariance, &self.observation, d);
-                let innovation_variance = dot(&self.observation, &ph) + self.observation_variance;
+                let ph = mat_vec(&predicted_covariance, observation, d);
+                let innovation_variance = dot(observation, &ph) + self.observation_variance;
                 if !innovation_variance.is_finite() || innovation_variance <= 0.0 {
                     return Err(StateSpaceError::NumericalFailure(format!(
                         "innovation variance at time {time} is not finite and positive"
                     )));
                 }
-                let predicted_observation = dot(&self.observation, &predicted_mean);
+                let predicted_observation = dot(observation, &predicted_mean);
                 let innovation = value - predicted_observation;
                 if !innovation.is_finite() {
                     return Err(StateSpaceError::NumericalFailure(format!(
@@ -399,7 +506,7 @@ impl LinearGaussianStateSpace {
                 let mut update = identity(d);
                 for i in 0..d {
                     for j in 0..d {
-                        update[i * d + j] -= gain[i] * self.observation[j];
+                        update[i * d + j] -= gain[i] * observation[j];
                     }
                 }
                 let left = mat_mul(&update, &predicted_covariance, d);
@@ -514,6 +621,23 @@ impl LinearGaussianStateSpace {
         observations: &[f64],
         steps: usize,
     ) -> Result<ForecastResult, StateSpaceError> {
+        if self.observation_rows.is_some() {
+            return Err(StateSpaceError::InvalidParameter(
+                "future observation rows are required for a time-varying design".into(),
+            ));
+        }
+        self.forecast_with_observation_rows(observations, &vec![self.observation.clone(); steps])
+    }
+
+    /// Forecast with a row for each future step, continuing after the final
+    /// training time. Both rows enter each cross-horizon covariance.
+    pub fn forecast_with_observation_rows(
+        &self,
+        observations: &[f64],
+        future_rows: &[Vec<f64>],
+    ) -> Result<ForecastResult, StateSpaceError> {
+        let steps = future_rows.len();
+        self.validate_rows(future_rows, steps)?;
         let filter = self.filter(observations)?;
         let (mut previous_mean, mut previous_covariance) = match (
             filter.filtered_means.last(),
@@ -527,7 +651,7 @@ impl LinearGaussianStateSpace {
         let mut state_covariances = Vec::with_capacity(steps);
         let mut observation_means = Vec::with_capacity(steps);
         let mut observation_variances = Vec::with_capacity(steps);
-        for step in 0..steps {
+        for (step, observation) in future_rows.iter().enumerate() {
             let mean = mat_vec(&self.transition, &previous_mean, d);
             let mut covariance = mat_mul_transpose_right(
                 &mat_mul(&self.transition, &previous_covariance, d),
@@ -537,11 +661,9 @@ impl LinearGaussianStateSpace {
             add_assign(&mut covariance, &self.process_covariance);
             symmetrize(&mut covariance, d);
             check_computed("forecast state", &mean, &covariance, step)?;
-            let observation_mean = dot(&self.observation, &mean);
-            let observation_variance = dot(
-                &self.observation,
-                &mat_vec(&covariance, &self.observation, d),
-            ) + self.observation_variance;
+            let observation_mean = dot(observation, &mean);
+            let observation_variance =
+                dot(observation, &mat_vec(&covariance, observation, d)) + self.observation_variance;
             if !observation_mean.is_finite()
                 || !observation_variance.is_finite()
                 || observation_variance <= 0.0
@@ -570,8 +692,8 @@ impl LinearGaussianStateSpace {
                         mat_mul_transpose_right(&cross_covariance, &self.transition, d);
                 }
                 let mut covariance = dot(
-                    &self.observation,
-                    &mat_vec(&cross_covariance, &self.observation, d),
+                    &future_rows[first],
+                    &mat_vec(&cross_covariance, &future_rows[second], d),
                 );
                 if first == second {
                     covariance += self.observation_variance;

--- a/scripts/test_release_artifact.py
+++ b/scripts/test_release_artifact.py
@@ -26,7 +26,9 @@ def main():
     with tempfile.TemporaryDirectory(prefix="rustmc-release-test-") as directory:
         temporary = Path(directory)
         environment = temporary / "env"
-        venv.EnvBuilder(with_pip=True).create(environment)
+        # Portable Python builds can use an executable-relative libpython path;
+        # copying that executable into a venv loses the library location on Unix.
+        venv.EnvBuilder(with_pip=True, symlinks=os.name != "nt").create(environment)
         executable = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
         subprocess.run([str(executable), "-m", "pip", "install", str(artifacts[0]), "numpy", "pytest"], check=True)
         # cwd and the import path stay outside the checkout. Tests can reference

--- a/scripts/test_release_artifact.py
+++ b/scripts/test_release_artifact.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Install one exact release artifact in a clean environment and run its tests."""
+import argparse
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import venv
+
+from verify_version import verify
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("kind", choices=("wheel", "sdist"))
+    parser.add_argument("--dist-dir", type=Path, default=Path("dist"))
+    args = parser.parse_args()
+    root = Path(__file__).resolve().parents[1]
+    expected = verify(root)
+    pattern = "rustmc-%s-*.whl" if args.kind == "wheel" else "rustmc-%s.tar.gz"
+    artifacts = sorted(args.dist_dir.resolve().glob(pattern % expected))
+    all_artifacts = sorted(args.dist_dir.resolve().glob("*.whl" if args.kind == "wheel" else "*.tar.gz"))
+    if len(artifacts) != 1 or artifacts != all_artifacts:
+        raise ValueError("expected only one %s artifact for %s, found %d matching artifacts or unrelated files" % (args.kind, expected, len(artifacts)))
+    with tempfile.TemporaryDirectory(prefix="rustmc-release-test-") as directory:
+        temporary = Path(directory)
+        environment = temporary / "env"
+        venv.EnvBuilder(with_pip=True).create(environment)
+        executable = environment / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+        subprocess.run([str(executable), "-m", "pip", "install", str(artifacts[0]), "numpy", "pytest"], check=True)
+        # cwd and the import path stay outside the checkout. Tests can reference
+        # repository fixtures while the import resolves to the installed archive.
+        clean_env = os.environ.copy()
+        clean_env.pop("PYTHONPATH", None)
+        clean_env["RUSTMC_REQUIRE_SITE_PACKAGES"] = "1"
+        subprocess.run([str(executable), "-c", "import rustmc; assert rustmc.__version__ == %r" % expected], cwd=temporary, env=clean_env, check=True)
+        subprocess.run([str(executable), str(root / "scripts/verify_wheel_install.py")], cwd=temporary, env=clean_env, check=True)
+        subprocess.run([str(executable), "-m", "pytest", "-q", str(root / "tests")], cwd=temporary, env=clean_env, check=True)
+    print("Verified exact release artifact: %s" % artifacts[0])
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        print("Release artifact verification failed: %s" % error, file=sys.stderr)
+        sys.exit(1)

--- a/scripts/verify_version.py
+++ b/scripts/verify_version.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Check release versions without dependencies, including on Python 3.9/3.10.
+
+This reads only literal version/name/path fields in the repository's known TOML
+layouts. It deliberately rejects unexpected forms instead of emulating a general
+TOML parser; Cargo separately validates full manifests and lock resolution.
+"""
+import os
+from pathlib import Path
+import re
+import sys
+
+
+def scalar(text, key):
+    matches = re.findall(r'^\s*' + re.escape(key) + r'\s*=\s*"([^"\n]+)"\s*(?:#.*)?$', text, re.M)
+    if len(matches) != 1:
+        raise ValueError("expected exactly one literal %s field" % key)
+    return matches[0]
+
+
+def table(path, name):
+    text = path.read_text(encoding="utf-8")
+    matches = re.findall(r'^\[' + re.escape(name) + r'\]\s*\n(.*?)(?=^\[|\Z)', text, re.M | re.S)
+    if len(matches) != 1:
+        raise ValueError("%s must have exactly one [%s] table" % (path, name))
+    return matches[0]
+
+
+def verify(root, tag=None):
+    versions = {
+        "rust_core/Cargo.toml": scalar(table(root / "rust_core/Cargo.toml", "package"), "version"),
+        "python_bindings/Cargo.toml": scalar(table(root / "python_bindings/Cargo.toml", "package"), "version"),
+        "pyproject.toml": scalar(table(root / "pyproject.toml", "project"), "version"),
+    }
+    expected = versions["rust_core/Cargo.toml"]
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", expected):
+        raise ValueError("release version must have the form X.Y.Z")
+    if tag is not None:
+        if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", tag):
+            raise ValueError("release tag must have the form vX.Y.Z")
+        expected = tag[1:]
+    dependencies = table(root / "python_bindings/Cargo.toml", "dependencies")
+    matches = re.findall(r'^rustmc_core\s*=\s*\{([^}]+)\}\s*$', dependencies, re.M)
+    if len(matches) != 1:
+        raise ValueError("expected one inline rustmc_core path/version dependency")
+    fields = dict(re.findall(r'(\w+)\s*=\s*"([^"\n]+)"', matches[0]))
+    versions["python_bindings dependency rustmc_core"] = fields.get("version", "missing")
+    if (root / "python_bindings" / fields.get("path", "")).resolve() != (root / "rust_core").resolve():
+        raise ValueError("binding dependency must point to this workspace's rust_core")
+    blocks = re.split(r'^\[\[package\]\]\s*$', (root / "Cargo.lock").read_text(encoding="utf-8"), flags=re.M)[1:]
+    for name in ("rustmc", "rustmc_core"):
+        packages = [block for block in blocks if re.search(r'^name\s*=\s*"' + name + r'"\s*$', block, re.M)]
+        if len(packages) != 1:
+            raise ValueError("Cargo.lock must contain exactly one %s package" % name)
+        versions["Cargo.lock %s" % name] = scalar(packages[0], "version")
+        if re.search(r'^source\s*=', packages[0], re.M):
+            raise ValueError("Cargo.lock %s must resolve to the workspace package" % name)
+    mismatches = ["%s=%s" % item for item in versions.items() if item[1] != expected]
+    if mismatches:
+        raise ValueError("expected version %s; mismatches: %s" % (expected, ", ".join(mismatches)))
+    return expected
+
+
+def main():
+    if len(sys.argv) > 2:
+        raise ValueError("usage: verify_version.py [vX.Y.Z]")
+    reference = os.environ.get("GITHUB_REF", "")
+    tag = sys.argv[1] if len(sys.argv) == 2 else (reference[len("refs/tags/"):] if reference.startswith("refs/tags/") else None)
+    version = verify(Path(__file__).resolve().parents[1], tag)
+    print("Version OK: %s (manifests, binding dependency, Cargo.lock%s)" % (version, ", tag" if tag else ""))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError) as error:
+        print("Version check failed: %s" % error, file=sys.stderr)
+        sys.exit(1)

--- a/scripts/verify_version.sh
+++ b/scripts/verify_version.sh
@@ -1,21 +1,6 @@
 #!/usr/bin/env bash
-# Verify that version in Cargo.toml and pyproject.toml matches the git tag (e.g. v0.6.0 -> 0.6.0).
-# Run from repo root. Usage: bash scripts/verify_version.sh [vX.Y.Z]
-set -e
-TAG="${1:-${GITHUB_REF#refs/tags/}}"
-if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  echo "No version tag (e.g. v0.6.0). Skipping check."
-  exit 0
-fi
-EXPECTED="${TAG#v}"
-CORE=$(grep '^version = ' rust_core/Cargo.toml | sed 's/.*"\(.*\)"/\1/')
-BINDINGS=$(grep '^version = ' python_bindings/Cargo.toml | sed 's/.*"\(.*\)"/\1/')
-PY=$(grep '^version = ' pyproject.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
-if [[ "$CORE" != "$EXPECTED" || "$BINDINGS" != "$EXPECTED" || "$PY" != "$EXPECTED" ]]; then
-  echo "Version mismatch: tag=$TAG (expected $EXPECTED)"
-  echo "  rust_core:          $CORE"
-  echo "  python_bindings:    $BINDINGS"
-  echo "  pyproject.toml:     $PY"
-  exit 1
-fi
-echo "Version OK: $EXPECTED"
+# Verify synchronized manifests/dependency/lock and, when supplied, vX.Y.Z tag.
+# Works from any directory; Python 3.9+ requires no third-party dependencies.
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/verify_version.py" "$@"

--- a/scripts/verify_wheel_install.py
+++ b/scripts/verify_wheel_install.py
@@ -62,6 +62,11 @@ def main() -> int:
         "BayesianAutoRegression", "BayesianAR", "BayesianARFit",
         "BayesianARForecast", "ParameterError", "InferenceError", "StateSpaceError", "sample",
         "batch_sample", "sample_prior_predictive",
+        "GaussianCoefficientPrior", "BayesianRegressionFit", "BayesianRegressionForecast",
+        "fourier_design", "ForecastBatchFit", "ForecastBatchForecast", "forecast_cell_seed",
+        "DirichletMultinomialRunoff", "RunoffFit",
+        "BayesianHurdleLogNormal", "BayesianHurdleLogNormalFit",
+        "BayesianHurdleLogNormalForecast", "hurdle_lognormal_logp",
     }
     missing = {name for name in expected_api if not hasattr(rmc, name)}
     if missing:

--- a/tests/test_bayesian_seasonal.py
+++ b/tests/test_bayesian_seasonal.py
@@ -131,7 +131,7 @@ def test_synthetic_variance_recovery_is_in_the_right_scale(rustmc_module):
         assert truth / 2.0 < posterior_median < truth * 2.0
 
 
-def test_validation_rejects_unidentified_or_invalid_seasonal_fits(rustmc_module):
+def test_validation_rejects_insufficient_or_invalid_seasonal_fits(rustmc_module):
     rmc = rustmc_module
     with pytest.raises(ValueError, match="sum to zero"):
         rmc.BayesianSeasonalLocalLevel(
@@ -143,8 +143,8 @@ def test_validation_rejects_unidentified_or_invalid_seasonal_fits(rustmc_module)
         )
     model = make_model(rmc)
     for observations in (
-        np.zeros(7),
-        np.array([0.0] * 5 + [np.nan] * 3),
+        np.zeros(1),
+        np.array([0.0] + [np.nan] * 3),
         np.array([0.0] * 7 + [np.inf]),
     ):
         with pytest.raises(ValueError):

--- a/tests/test_forecast_batch_diagnostics.py
+++ b/tests/test_forecast_batch_diagnostics.py
@@ -166,3 +166,74 @@ def test_batch_is_exactly_single_fit_with_documented_cell_seed(rustmc_module):
                                   batch.forecast(4, seed=84)[cell].observation_samples)
     with pytest.raises(ValueError, match="domain"):
         rmc.forecast_cell_seed(1, cell, "unknown")
+
+
+@pytest.mark.parametrize("model_index", range(3))
+def test_regression_batches_ragged_designs_priors_diagnostics_and_paths(rustmc_module, model_index):
+    rmc = rustmc_module
+    model = models(rmc)[model_index]
+    ys = [np.linspace(0.1, 0.8, 8), np.linspace(-0.2, 0.7, 10)]
+    xs = [np.arange(8, dtype=float)[:, None] / 8,
+          np.column_stack([np.ones(10), np.arange(10, dtype=float) / 10])]
+    priors = [rmc.GaussianCoefficientPrior(np.zeros(1), np.eye(1)),
+              rmc.GaussianCoefficientPrior(np.zeros(2), np.eye(2) * 2)]
+    ids = ["linear", "intercept+linear"]
+    kwargs = dict(chains=2, draws=16, warmup=8, seed=64)
+    batch = model.fit_batch(ys, ids, exog=xs, coefficient_priors=priors, threads=2, **kwargs)
+    reordered = model.fit_batch(ys[::-1], ids[::-1], exog=xs[::-1], coefficient_priors=priors[::-1],
+                                  threads=1, chunk_size=1, **kwargs)
+    for cell, prior, y, x in zip(ids, priors, ys, xs):
+        single = model.fit(y, exog=x, coefficient_prior=prior, chains=2, draws=16, warmup=8,
+                           seed=rmc.forecast_cell_seed(64, cell))
+        for name, values in batch[cell].get_samples_2d().items():
+            np.testing.assert_array_equal(values, reordered[cell].get_samples_2d()[name])
+            np.testing.assert_array_equal(values, single.get_samples_2d()[name])
+        names = {p["name"] for p in batch[cell].diagnostics()}
+        assert "coefficient[0]" in names
+        assert "terminal_state[0]" in names
+        assert "observation_variance" in names
+        assert batch[cell].sampler_stats["divergences"] is None
+        assert "joint conjugate Gibbs" in batch[cell].summary()
+    future = [np.array([[1.], [1.1], [1.2]]), np.array([[1., 1.], [1., 1.1], [1., 1.2]])]
+    forecast = batch.forecast(3, exog=future, seed=87, threads=2)
+    reversed_forecast = reordered.forecast(3, exog=future[::-1], seed=87, threads=1)
+    for cell in ids:
+        np.testing.assert_array_equal(forecast[cell].observation_samples,
+                                      reversed_forecast[cell].observation_samples)
+        np.testing.assert_allclose(forecast[cell].cumulative_observation_samples,
+                                  np.cumsum(forecast[cell].observation_samples, axis=-1))
+    missing = batch.forecast(3, errors="collect")
+    assert set(missing.errors) == set(ids)
+    assert all("future exog" in error for error in missing.errors.values())
+    malformed = batch.forecast(3, exog=[future[0], [[1.]]], errors="collect")
+    assert set(malformed.errors) == {ids[1]}
+
+
+def test_regression_batch_validation_is_per_cell(rustmc_module):
+    rmc = rustmc_module
+    model = models(rmc)[0]
+    y = [0., .1, .2]
+    x = np.ones((3, 1))
+    prior = rmc.GaussianCoefficientPrior(np.zeros(1), np.eye(1))
+    batch = model.fit_batch([y]*5, ["ok", "no_prior", "no_x", "bad_shape", "bad_values"],
+                            exog=[x, x, None, [[1.]], [[float("nan")]]*3],
+                            coefficient_priors=[prior, None, prior, prior, prior],
+                            draws=8, warmup=4, errors="collect")
+    assert set(batch.errors) == {"no_prior", "no_x", "bad_shape", "bad_values"}
+    assert batch["ok"].time_count == 3
+    with pytest.raises(ValueError, match="exog must have one"):
+        model.fit_batch([y], ["ok"], exog=[])
+    with pytest.raises(ValueError, match="coefficient_priors must have one"):
+        model.fit_batch([y], ["ok"], coefficient_priors=[])
+    plain = model.fit_batch([y], ["plain"], draws=8, warmup=4)
+    assert "without regression" in plain.forecast(2, exog=[[[1.], [2.]]], errors="collect").errors["plain"]
+
+
+def test_huge_batch_allocations_return_errors_instead_of_panicking(rustmc_module):
+    model = models(rustmc_module)[0]
+    huge = model.fit_batch([[1., 2., 3.]], ["huge"], chains=1, draws=2**61,
+                           warmup=0, errors="collect")
+    assert "allocation limit" in huge.errors["huge"]
+    tiny = model.fit_batch([[1., 2., 3.]], ["tiny"], chains=1, draws=8, warmup=0)
+    bad_forecast = tiny.forecast(2**61, errors="collect")
+    assert "allocation limit" in bad_forecast.errors["tiny"]

--- a/tests/test_forecast_batch_diagnostics.py
+++ b/tests/test_forecast_batch_diagnostics.py
@@ -147,7 +147,7 @@ def test_diagnostics_match_arviz_for_identical_retained_chains(rustmc_module):
         values = posterior[item["name"]]
         assert item["r_hat"] == pytest.approx(float(az.rhat(values, method="rank")), rel=1e-7)
         assert item["ess_bulk"] == pytest.approx(float(az.ess(values, method="bulk")), rel=.04)
-        assert item["ess_tail"] == pytest.approx(float(az.ess(values, method="tail")), rel=.04)
+        assert item["ess_tail"] == pytest.approx(float(az.ess(values, method="tail", prob=(.05, .95))), rel=.04)
         assert item["mcse_mean"] == pytest.approx(np.asarray(az.mcse(values, method="mean")).item(), rel=.04)
 
 

--- a/tests/test_forecast_batch_diagnostics.py
+++ b/tests/test_forecast_batch_diagnostics.py
@@ -1,0 +1,168 @@
+"""Native independent forecasting: identity, isolation and diagnostic semantics."""
+import numpy as np
+import pytest
+
+
+def models(rmc):
+    prior = rmc.InverseGammaPrior(3.0, 0.4)
+    return [
+        rmc.BayesianLocalLevel(process_variance_prior=prior, observation_variance_prior=prior),
+        rmc.BayesianSeasonalLocalLevel(period=4, level_variance_prior=prior,
+                                      seasonal_variance_prior=prior, observation_variance_prior=prior),
+        rmc.BayesianLocalLinearTrend(level_variance_prior=prior, slope_variance_prior=prior,
+                                    observation_variance_prior=prior),
+        rmc.BayesianAR(1, rmc.NormalInverseGammaPrior(np.zeros(2), np.eye(2), 3.0, 0.4)),
+    ]
+
+
+def samples(fit):
+    return fit.get_samples() if hasattr(fit, "get_samples") else fit.get_samples_2d()
+
+
+@pytest.mark.parametrize("model_index", range(4))
+def test_batch_identity_reorder_chunk_resume_threads_and_forecasts(rustmc_module, model_index):
+    model = models(rustmc_module)[model_index]
+    rng = np.random.default_rng(204)
+    y = rng.normal(size=16)
+    ys = [y, y[:12], y.copy()]
+    ids = ["north/α", "south", "same data different ID"]
+    kwargs = dict(chains=2, draws=24, warmup=12, seed=451)
+    batch = model.fit_batch(ys, ids, threads=1, chunk_size=3, **kwargs)
+    reordered = model.fit_batch(ys[::-1], ids[::-1], threads=3, chunk_size=1, **kwargs)
+    resumed = model.fit_batch(ys[1:2], ids[1:2], threads=2, **kwargs)
+    assert batch.ids == ids
+    assert len(batch) == 3
+    assert batch.errors == {}
+    for cell in ids:
+        for name, values in samples(batch[cell]).items():
+            np.testing.assert_array_equal(values, samples(reordered[cell])[name])
+    for name, values in samples(resumed[ids[1]]).items():
+        np.testing.assert_array_equal(values, samples(batch[ids[1]])[name])
+    key = next(iter(samples(batch[ids[0]])))
+    assert not np.array_equal(samples(batch[ids[0]])[key], samples(batch[ids[2]])[key])
+    forecasts = batch.forecast(5, seed=75, threads=3, chunk_size=1)
+    other = reordered.forecast(5, seed=75, threads=1, chunk_size=3)
+    resumed_fc = resumed.forecast(5, seed=75)
+    for cell in ids:
+        values = forecasts[cell].observation_samples
+        assert values.shape == (2, 24, 5)
+        np.testing.assert_array_equal(values, other[cell].observation_samples)
+    np.testing.assert_array_equal(forecasts[ids[1]].observation_samples,
+                                  resumed_fc[ids[1]].observation_samples)
+    assert not np.array_equal(forecasts[ids[0]].observation_samples,
+                              forecasts[ids[2]].observation_samples)
+
+
+def test_ragged_mixed_per_cell_models_errors_and_missing_schedule(rustmc_module):
+    all_models = models(rustmc_module)
+    y = np.arange(16, dtype=float) / 10
+    ragged = [y[:8], y, y[:10], y, [], [1.0, np.inf], "not a series"]
+    selected = all_models + [None, None, None]
+    ids = ["level", "seasonal", "trend", "ar", "empty", "infinite", "wrong_type"]
+    batch = all_models[0].fit_batch(ragged, ids, models=selected, chains=2, draws=12,
+                                    warmup=10, errors="collect", threads=2)
+    assert len(batch) == 7
+    assert set(batch.errors) == set(ids[4:])
+    assert batch.results[4:] == [None, None, None]
+    assert [batch[cell].time_count for cell in ids[:4]] == [8, 16, 10, 16]
+    assert set(batch.diagnostics()) == set(ids)
+    assert batch.diagnostics()["empty"] is None
+    with pytest.raises(rustmc_module.StateSpaceError, match="empty"):
+        batch["empty"]
+    with pytest.raises(KeyError):
+        batch["unknown"]
+    forecast = batch.forecast(3, errors="collect", threads=2)
+    assert set(forecast.errors) == set(ids[4:])
+    assert forecast.results[4:] == [None, None, None]
+    with pytest.raises(rustmc_module.StateSpaceError, match="empty"):
+        batch.forecast(3)
+    gaps = all_models[0].fit_batch([[0., np.nan, 1., 2.]], ["gaps"], draws=6, warmup=3)
+    assert gaps["gaps"].time_count == 4
+    assert gaps["gaps"].observed_count == 3
+
+
+def test_batch_validation_and_cell_numerical_failures(rustmc_module):
+    model = models(rustmc_module)[0]
+    y = [0., 1., 2.]
+    for kwargs, match in [({"threads": 0}, "threads"), ({"chunk_size": 0}, "chunk_size"),
+                          ({"errors": "ignore"}, "errors")]:
+        with pytest.raises(ValueError, match=match):
+            model.fit_batch([y], ["one"], **kwargs)
+    with pytest.raises(ValueError, match="unique"):
+        model.fit_batch([y, y], ["one", "one"])
+    with pytest.raises(ValueError, match="length"):
+        model.fit_batch([y], [])
+    with pytest.raises(ValueError, match="one entry"):
+        model.fit_batch([y], ["one"], models=[])
+    with pytest.raises(rustmc_module.StateSpaceError, match="empty"):
+        model.fit_batch([[], y], ["empty", "ok"], chunk_size=1)
+    batch = model.fit_batch([y, [1e308, -1e308]], ["ok", "overflow"], chains=1,
+                            draws=6, warmup=3, errors="collect")
+    assert batch["ok"].sampler_stats["numerical_failures"] == 0
+    assert "numerical" in batch.errors["overflow"].lower()
+    empty = model.fit_batch([], [], draws=6)
+    assert len(empty) == 0
+    assert empty.errors == {}
+
+
+@pytest.mark.parametrize("model_index", range(4))
+def test_diagnostics_and_sampler_metadata(rustmc_module, model_index):
+    model = models(rustmc_module)[model_index]
+    y = np.random.default_rng(813).normal(size=16)
+    kwargs = dict(chains=2, draws=40, seed=154)
+    if model_index != 3:
+        kwargs["warmup"] = 20
+    fit = model.fit(y, **kwargs)
+    diagnostics = {p["name"]: p for p in fit.diagnostics()}
+    assert len(diagnostics) == [3, 7, 5, 3][model_index]
+    for item in diagnostics.values():
+        assert item["ess_bulk"] > 0
+        assert item["ess_tail"] > 0
+        assert item["r_hat"] > 0
+        assert item["mcse_mean"] >= 0
+    stats = fit.sampler_stats
+    assert stats["divergences"] is None
+    assert stats["acceptance_rate"] is None
+    assert stats["numerical_failures"] == 0
+    assert stats["independent_chain_comparison"]
+    assert "ess_bulk" in fit.summary()
+    assert "Mean accept rate" not in fit.summary()
+    short_kwargs = dict(chains=1, draws=3)
+    if model_index != 3:
+        short_kwargs["warmup"] = 1
+    short = model.fit(y, **short_kwargs)
+    assert not short.sampler_stats["independent_chain_comparison"]
+    assert not short.sampler_stats["diagnostics_available"]
+    for item in short.diagnostics():
+        for key in ["r_hat", "ess_bulk", "ess_tail", "mcse_mean"]:
+            assert item[key] is None
+
+
+def test_diagnostics_match_arviz_for_identical_retained_chains(rustmc_module):
+    az = pytest.importorskip("arviz")
+    y = np.random.default_rng(714).normal(size=40)
+    fit = models(rustmc_module)[0].fit(y, chains=4, draws=600, warmup=300, seed=518)
+    posterior = fit.get_samples_2d()
+    for item in fit.diagnostics():
+        values = posterior[item["name"]]
+        assert item["r_hat"] == pytest.approx(float(az.rhat(values, method="rank")), rel=1e-7)
+        assert item["ess_bulk"] == pytest.approx(float(az.ess(values, method="bulk")), rel=.04)
+        assert item["ess_tail"] == pytest.approx(float(az.ess(values, method="tail")), rel=.04)
+        assert item["mcse_mean"] == pytest.approx(np.asarray(az.mcse(values, method="mean")).item(), rel=.04)
+
+
+def test_batch_is_exactly_single_fit_with_documented_cell_seed(rustmc_module):
+    rmc = rustmc_module
+    model = models(rmc)[0]
+    y = np.array([0.1, 0.2, np.nan, 0.4, 0.3])
+    cell = "program/α"
+    kwargs = dict(chains=2, draws=40, warmup=20)
+    batch = model.fit_batch([y], [cell], seed=76, **kwargs)
+    single = model.fit(y, seed=rmc.forecast_cell_seed(76, cell), **kwargs)
+    for name, values in single.get_samples_2d().items():
+        np.testing.assert_array_equal(values, batch[cell].get_samples_2d()[name])
+    forecast = single.forecast(4, seed=rmc.forecast_cell_seed(84, cell, "forecast"))
+    np.testing.assert_array_equal(forecast.observation_samples,
+                                  batch.forecast(4, seed=84)[cell].observation_samples)
+    with pytest.raises(ValueError, match="domain"):
+        rmc.forecast_cell_seed(1, cell, "unknown")

--- a/tests/test_hurdle.py
+++ b/tests/test_hurdle.py
@@ -34,8 +34,8 @@ def test_zero_history_retains_occurrence_uncertainty_and_prior_severity(rustmc_m
         forecast.mean_samples,
         samples["payment_probability"][..., None] * forecast.positive_mean_samples,
     )
-    assert fit.sampler_stats()["divergences"] is None
-    assert fit.sampler_stats()["acceptance_rate"] is None
+    assert fit.sampler_stats["divergences"] is None
+    assert fit.sampler_stats["acceptance_rate"] is None
     assert "no positive observations" in fit.summary()
 
 
@@ -131,7 +131,7 @@ def test_hurdle_batches_preserve_sparse_cells_seeds_and_coherent_forecasts(rustm
         for name, values in batch[cell].get_samples_2d().items():
             np.testing.assert_array_equal(values, reverse[cell].get_samples_2d()[name])
             np.testing.assert_array_equal(values, single.get_samples_2d()[name])
-        assert batch[cell].sampler_stats()["divergences"] is None
+        assert batch[cell].sampler_stats["divergences"] is None
     for name, values in resumed[ids[1]].get_samples_2d().items():
         np.testing.assert_array_equal(values, batch[ids[1]].get_samples_2d()[name])
     assert not np.array_equal(batch[ids[0]].get_samples_2d()["payment_probability"],

--- a/tests/test_hurdle.py
+++ b/tests/test_hurdle.py
@@ -1,0 +1,112 @@
+"""Sparse amount inference: support, uncertainty, independent references and paths."""
+import numpy as np
+import pytest
+
+
+def model(rmc, **kwargs):
+    return rmc.BayesianHurdleLogNormal(
+        rmc.InverseGammaPrior(4.0, 0.03),
+        rmc.InverseGammaPrior(4.0, 0.3),
+        initial_log_level=1.0,
+        initial_variance=0.2,
+        **kwargs,
+    )
+
+
+def test_zero_history_retains_occurrence_uncertainty_and_prior_severity(rustmc_module):
+    fit = model(rustmc_module).fit(np.zeros(18), chains=2, draws=1200, seed=9)
+    assert fit.observed_count == 18
+    assert fit.positive_count == 0
+    assert fit.severity_informed_by_data is False
+    samples = fit.get_samples_2d()
+    assert samples["payment_probability"].shape == (2, 1200)
+    assert abs(samples["payment_probability"].mean() - 1 / 20) < 0.004
+    assert np.all((samples["payment_probability"] > 0) & (samples["payment_probability"] < 1))
+    assert np.all(samples["process_variance"] <= 1.0)
+    assert np.all(samples["observation_variance"] <= 4.0)
+    forecast = fit.forecast(steps=6, seed=91)
+    y = forecast.observation_samples
+    assert y.shape == (2, 1200, 6)
+    assert np.isfinite(y).all() and np.all(y >= 0)
+    assert 0.935 < (y == 0).mean() < 0.965
+    assert np.any(y > 0)
+    np.testing.assert_allclose(
+        forecast.mean_samples,
+        samples["payment_probability"][..., None] * forecast.positive_mean_samples,
+    )
+    assert fit.sampler_stats()["divergences"] is None
+    assert fit.sampler_stats()["acceptance_rate"] is None
+    assert "no positive observations" in fit.summary()
+
+
+def test_positive_amounts_missing_steps_and_cumulative_paths(rustmc_module):
+    y = np.array([0.0, 0.0, 2.5, np.nan, 0.0, 4.0, 0.0, 0.0])
+    first = model(rustmc_module).fit(y, chains=2, draws=150, warmup=60, seed=8)
+    repeat = model(rustmc_module).fit(y, chains=2, draws=150, warmup=60, seed=8)
+    assert (first.time_count, first.observed_count, first.positive_count) == (8, 7, 2)
+    assert first.severity_informed_by_data
+    for key, value in first.get_samples_2d().items():
+        np.testing.assert_array_equal(value, repeat.get_samples_2d()[key])
+    forecast = first.forecast(5, seed=7)
+    np.testing.assert_array_equal(forecast.observation_samples, first.forecast(5, seed=7).observation_samples)
+    cumulative = np.cumsum(forecast.observation_samples, axis=2)
+    np.testing.assert_array_equal(forecast.cumulative_observation_samples, cumulative)
+    np.testing.assert_allclose(forecast.interval(), np.quantile(forecast.observation_samples, [0.025, 0.975], axis=(0, 1)))
+    np.testing.assert_allclose(forecast.cumulative_interval(), np.quantile(cumulative, [0.025, 0.975], axis=(0, 1)))
+    np.testing.assert_allclose(forecast.mean_interval(), np.quantile(forecast.mean_samples, [0.025, 0.975], axis=(0, 1)))
+    np.testing.assert_allclose(forecast.mean, forecast.mean_samples.mean(axis=(0, 1)))
+    names = {item["name"] for item in first.diagnostics()}
+    assert names == set(first.get_samples_2d())
+
+
+def test_one_positive_with_weak_history_is_supported(rustmc_module):
+    fit = model(rustmc_module).fit(np.array([0.0, np.nan, 3.0, 0.0]), chains=2, draws=30, warmup=20)
+    assert np.isfinite(fit.forecast(2).observation_samples).all()
+
+
+def test_density_matches_independent_lognormal_formula(rustmc_module):
+    logp = rustmc_module.hurdle_lognormal_logp
+    assert logp(0.0, 0.25, 1.0, 0.4) == pytest.approx(np.log(0.75))
+    y, p, mu, var = 3.0, 0.25, 1.0, 0.4
+    expected = np.log(p) - np.log(y) - 0.5 * (np.log(2 * np.pi * var) + (np.log(y) - mu)**2 / var)
+    assert logp(y, p, mu, var) == pytest.approx(expected)
+    assert logp(0.0, 1.0, 0.0, 1.0) == -np.inf
+    assert logp(1.0, 0.0, 0.0, 1.0) == -np.inf
+
+
+@pytest.mark.parametrize("y", [[], [np.nan], [-0.1], [np.inf], [-np.inf]])
+def test_invalid_amounts(rustmc_module, y):
+    with pytest.raises(ValueError):
+        model(rustmc_module).fit(np.asarray(y), draws=2, chains=1)
+
+
+def test_bounds_and_counts_are_validated_without_panics(rustmc_module):
+    for key in ("process_variance_upper", "observation_variance_upper"):
+        for value in (0.0, -1.0, np.nan, np.inf):
+            with pytest.raises(ValueError):
+                model(rustmc_module, **{key: value})
+    with pytest.raises(ValueError):
+        model(rustmc_module).fit(np.array([0.0]), draws=2**61)
+    fit = model(rustmc_module).fit(np.array([0.0]), draws=2, chains=1)
+    for horizon in (0, 2**61):
+        with pytest.raises(ValueError):
+            fit.forecast(horizon)
+    assert all(item["r_hat"] is None for item in fit.diagnostics())
+    with pytest.raises(ValueError):
+        fit.forecast(1).interval(1.0)
+
+
+def test_bounded_variance_priors_are_used_in_fit(rustmc_module):
+    fit = model(rustmc_module, process_variance_upper=0.012, observation_variance_upper=0.12).fit(
+        np.array([0.0, 2.0, 0.0, 3.0]), draws=100, chains=2, warmup=30,
+    )
+    samples = fit.get_samples_2d()
+    assert np.all((samples["process_variance"] > 0) & (samples["process_variance"] <= 0.012))
+    assert np.all((samples["observation_variance"] > 0) & (samples["observation_variance"] <= 0.12))
+
+
+def test_arviz_export_when_installed(rustmc_module):
+    pytest.importorskip("arviz")
+    fit = model(rustmc_module).fit(np.array([0., 2., 0., 3.]), chains=2, draws=20, warmup=10)
+    exported = fit.to_arviz()
+    np.testing.assert_array_equal(exported.posterior["payment_probability"], fit.get_samples_2d()["payment_probability"])

--- a/tests/test_hurdle.py
+++ b/tests/test_hurdle.py
@@ -110,3 +110,105 @@ def test_arviz_export_when_installed(rustmc_module):
     fit = model(rustmc_module).fit(np.array([0., 2., 0., 3.]), chains=2, draws=20, warmup=10)
     exported = fit.to_arviz()
     np.testing.assert_array_equal(exported.posterior["payment_probability"], fit.get_samples_2d()["payment_probability"])
+
+
+def test_hurdle_batches_preserve_sparse_cells_seeds_and_coherent_forecasts(rustmc_module):
+    rmc = rustmc_module
+    sparse = model(rmc)
+    histories = [np.zeros(9), np.array([0., np.nan, 2.5, 0.]), np.zeros(9)]
+    ids = ["never/α", "one-positive", "same-data/different-id"]
+    kwargs = dict(chains=2, draws=80, warmup=30, thin=2, seed=705)
+    batch = sparse.fit_batch(histories, ids, threads=1, chunk_size=3, **kwargs)
+    reverse = sparse.fit_batch(histories[::-1], ids[::-1], threads=3, chunk_size=1, **kwargs)
+    resumed = sparse.fit_batch(histories[1:2], ids[1:2], threads=2, **kwargs)
+    assert batch.ids == ids and batch.errors == {}
+    assert not batch[ids[0]].severity_informed_by_data
+    assert batch[ids[1]].severity_informed_by_data
+    assert (batch[ids[1]].time_count, batch[ids[1]].observed_count) == (4, 3)
+    for cell, y in zip(ids, histories):
+        single = sparse.fit(y, chains=2, draws=80, warmup=30, thin=2,
+                             seed=rmc.forecast_cell_seed(705, cell))
+        for name, values in batch[cell].get_samples_2d().items():
+            np.testing.assert_array_equal(values, reverse[cell].get_samples_2d()[name])
+            np.testing.assert_array_equal(values, single.get_samples_2d()[name])
+        assert batch[cell].sampler_stats()["divergences"] is None
+    for name, values in resumed[ids[1]].get_samples_2d().items():
+        np.testing.assert_array_equal(values, batch[ids[1]].get_samples_2d()[name])
+    assert not np.array_equal(batch[ids[0]].get_samples_2d()["payment_probability"],
+                              batch[ids[2]].get_samples_2d()["payment_probability"])
+    assert set(batch.diagnostics()) == set(ids)
+    assert {p["name"] for p in batch.diagnostics()[ids[0]]} == set(batch[ids[0]].get_samples_2d())
+    future = batch.forecast(6, seed=871, threads=3, chunk_size=1)
+    reverse_future = reverse.forecast(6, seed=871, threads=1)
+    resumed_future = resumed.forecast(6, seed=871)
+    for cell in ids:
+        paths = future[cell].observation_samples
+        assert np.isfinite(paths).all() and np.all(paths >= 0)
+        np.testing.assert_array_equal(paths, reverse_future[cell].observation_samples)
+        np.testing.assert_array_equal(paths, batch[cell].forecast(
+            6, seed=rmc.forecast_cell_seed(871, cell, "forecast")).observation_samples)
+        np.testing.assert_array_equal(np.cumsum(paths, axis=-1), future[cell].cumulative_observation_samples)
+        np.testing.assert_allclose(future[cell].mean_samples,
+                                  batch[cell].get_samples_2d()["payment_probability"][..., None]
+                                  * future[cell].positive_mean_samples)
+    np.testing.assert_array_equal(future[ids[1]].observation_samples,
+                                  resumed_future[ids[1]].observation_samples)
+
+
+def test_hurdle_batches_use_per_cell_priors_and_mix_with_regression(rustmc_module):
+    rmc = rustmc_module
+    sparse = model(rmc)
+    other = model(rmc, occurrence_alpha=3., occurrence_beta=2., process_variance_upper=.02)
+    zero_batch = sparse.fit_batch([np.zeros(4), np.zeros(4)], ["default", "other"],
+                                   models=[None, other], chains=2, draws=2000, seed=174, threads=2)
+    # Independent analytic Beta posterior references establish per-cell prior routing.
+    for cell, alpha, beta in [("default", 1., 5.), ("other", 3., 6.)]:
+        p = zero_batch[cell].get_samples_2d()["payment_probability"]
+        assert p.mean() == pytest.approx(alpha / (alpha + beta), abs=.01)
+        assert p.var() == pytest.approx(alpha * beta / ((alpha+beta)**2 * (alpha+beta+1)), rel=.12)
+    assert np.all(zero_batch["other"].get_samples_2d()["process_variance"] <= .02)
+    prior = rmc.InverseGammaPrior(3., .1)
+    gaussian = rmc.BayesianLocalLevel(prior, prior)
+    coefficient_prior = rmc.GaussianCoefficientPrior(np.zeros(1), np.eye(1))
+    y = [np.zeros(4), np.array([0., .2, .4, .6])]
+    x = [None, np.arange(4, dtype=float)[:, None]]
+    mixed = sparse.fit_batch(y, ["sparse", "regression"], models=[None, gaussian],
+                             exog=x, coefficient_priors=[None, coefficient_prior],
+                             chains=2, draws=24, warmup=12, threads=2)
+    assert isinstance(mixed["sparse"], rmc.BayesianHurdleLogNormalFit)
+    assert isinstance(mixed["regression"], rmc.BayesianRegressionFit)
+    prediction = mixed.forecast(2, exog=[None, np.array([[4.], [5.]])], threads=2)
+    assert prediction["sparse"].observation_samples.shape == (2, 24, 2)
+    assert prediction["regression"].observation_samples.shape == (2, 24, 2)
+    # The ordinary model's entry point must also recognize a hurdle per-cell model.
+    from_gaussian = gaussian.fit_batch([np.zeros(3)], ["hurdle"], models=[sparse], draws=8, warmup=2)
+    assert isinstance(from_gaussian["hurdle"], rmc.BayesianHurdleLogNormalFit)
+
+
+def test_hurdle_batch_errors_exog_and_allocation_guards(rustmc_module):
+    rmc = rustmc_module
+    sparse = model(rmc)
+    batch = sparse.fit_batch([[0.], [0., -1.], [np.nan]], ["ok", "negative", "missing"],
+                             chains=1, draws=8, warmup=2, errors="collect")
+    assert set(batch.errors) == {"negative", "missing"}
+    assert batch.results[1:] == [None, None]
+    assert set(batch.forecast(2, errors="collect").errors) == {"negative", "missing"}
+    with pytest.raises(ValueError, match="negative"):
+        sparse.fit_batch([[0., -1.]], ["negative"], draws=8)
+    assert "allocation limit" in sparse.fit_batch([[0.]], ["big"], draws=2**61,
+                                                   errors="collect").errors["big"]
+    assert "allocation limit" in batch.forecast(2**61, errors="collect").errors["ok"]
+    coefficient_prior = rmc.GaussianCoefficientPrior(np.zeros(1), np.eye(1))
+    for kwargs in [dict(exog=[[[1.]]]), dict(coefficient_priors=[coefficient_prior]),
+                   dict(exog=[[[1.]]], coefficient_priors=[coefficient_prior])]:
+        invalid = sparse.fit_batch([[0.]], ["unsupported"], draws=8, errors="collect", **kwargs)
+        assert "hurdle exog is unsupported" in invalid.errors["unsupported"]
+    plain = sparse.fit_batch([[0.]], ["plain"], chains=1, draws=8)
+    assert "hurdle exog is unsupported" in plain.forecast(1, exog=[[[1.]]], errors="collect").errors["plain"]
+    overflow = rmc.BayesianHurdleLogNormal(rmc.InverseGammaPrior(4., .03),
+                                         rmc.InverseGammaPrior(4., .3), initial_log_level=1000.)
+    numerical = sparse.fit_batch([[0.], [0.]], ["ok", "overflow"], models=[None, overflow],
+                                  chains=1, draws=8, threads=2)
+    forecasts = numerical.forecast(1, errors="collect")
+    assert set(forecasts.errors) == {"overflow"}
+    assert "overflow" in forecasts.errors["overflow"].lower()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -163,8 +163,8 @@ def test_wheel_installs_in_clean_environment(tmp_path):
     assert wheels, "maturin build produced no wheel"
 
     env_dir = tmp_path / "clean-env"
-    venv.EnvBuilder(with_pip=True).create(env_dir)
-    env_python = env_dir / "bin" / "python"
+    venv.EnvBuilder(with_pip=True, symlinks=os.name != "nt").create(env_dir)
+    env_python = env_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
 
     subprocess.run(
         [str(env_python), "-m", "pip", "install", "--quiet", str(wheels[0]), "numpy"],

--- a/tests/test_regression_forecasting.py
+++ b/tests/test_regression_forecasting.py
@@ -1,0 +1,144 @@
+"""Joint regression/structural inference, design contracts and calendar phase."""
+import numpy as np
+import pytest
+
+
+def prior(rmc, count=1, variance=4.0):
+    return rmc.GaussianCoefficientPrior(np.zeros(count), np.eye(count) * variance)
+
+
+def models(rmc):
+    ig = rmc.InverseGammaPrior
+    return [
+        rmc.BayesianLocalLevel(ig(3, 0.04), ig(3, 0.4)),
+        rmc.BayesianLocalLinearTrend(ig(3, 0.04), ig(3, 0.004), ig(3, 0.4)),
+        rmc.BayesianSeasonalLocalLevel(12, ig(3, 0.04), ig(3, 0.02), ig(3, 0.4)),
+    ]
+
+
+@pytest.mark.parametrize("model_index", range(3))
+def test_joint_fit_forecast_components_and_validation(rustmc_module, model_index):
+    rmc = rustmc_module
+    model = models(rmc)[model_index]
+    rng = np.random.default_rng(19)
+    x = rng.normal(size=(30, 1))
+    y = 2 * x[:, 0] + rng.normal(scale=0.3, size=30)
+    y[3] = np.nan
+    options = dict(chains=2, draws=70, warmup=50, seed=17, coefficient_prior=prior(rmc))
+    fit = model.fit(y, exog=x, **options)
+    repeated = model.fit(y, exog=x, **options)
+    assert isinstance(fit, rmc.BayesianRegressionFit)
+    assert fit.time_count == 30 and fit.observed_count == 29
+    for key, value in fit.get_samples_2d().items():
+        np.testing.assert_array_equal(value, repeated.get_samples_2d()[key])
+    beta = fit.get_samples_2d()["coefficients"]
+    assert beta.shape == (2, 70, 1)
+    assert abs(beta.mean() - 2.0) < 0.4
+    future = np.array([[1.0], [2.0], [-1.0]])
+    forecast = fit.forecast(3, exog=future, seed=4)
+    np.testing.assert_allclose(forecast.regression_samples, beta * future[:, 0])
+    structural = forecast.level_samples
+    if model_index == 2:
+        structural = structural + forecast.seasonal_samples
+    np.testing.assert_allclose(forecast.mean_samples, structural + forecast.regression_samples)
+    np.testing.assert_array_equal(forecast.cumulative_observation_samples,
+                                  np.cumsum(forecast.observation_samples, axis=2))
+    np.testing.assert_allclose(forecast.interval(), np.quantile(forecast.observation_samples, [0.025, 0.975], axis=(0, 1)))
+    for invalid in (None, np.zeros((2, 1)), np.zeros((3, 2)), np.full((3, 1), np.nan)):
+        with pytest.raises(ValueError):
+            fit.forecast(3, exog=invalid)
+    with pytest.raises(ValueError, match="prior"):
+        model.fit(y, exog=x, draws=1, warmup=1)
+    for invalid in (x[:-1], np.zeros((30, 2)), np.full((30, 1), np.inf)):
+        with pytest.raises(ValueError):
+            model.fit(y, exog=invalid, **options)
+
+
+def test_collinear_features_and_prior_validation(rustmc_module):
+    rmc = rustmc_module
+    model = models(rmc)[0]
+    fit = model.fit(np.ones(12), exog=np.ones((12, 2)), coefficient_prior=prior(rmc, 2), chains=1, draws=10, warmup=5)
+    assert np.isfinite(fit.get_samples_2d()["coefficients"]).all()
+    for covariance in (np.zeros((2, 2)), np.array([[1., 2.], [2., 1.]]), np.eye(1), np.full((2, 2), np.nan)):
+        with pytest.raises(ValueError):
+            rmc.GaussianCoefficientPrior(np.zeros(2), covariance)
+
+
+def test_fixed_time_varying_rows_against_direct_gaussian_conditioning(rustmc_module):
+    rmc = rustmc_module
+    z = np.array([[1., -1.], [1., 0.], [1., 1.], [1., 2.]])
+    y = np.array([1., 2., np.nan, 4.])
+    model = rmc.LinearGaussianStateSpace(np.eye(2), np.ones(2), np.zeros((2, 2)), 0.5, np.zeros(2), np.diag([2., 3.])).with_observation_rows(z)
+    keep = np.isfinite(y)
+    covariance = np.linalg.inv(np.diag([.5, 1/3]) + z[keep].T @ z[keep] / .5)
+    mean = covariance @ z[keep].T @ y[keep] / .5
+    smoothed = model.smooth(y)
+    np.testing.assert_allclose(smoothed.smoothed_means, np.tile(mean, (4, 1)))
+    future = np.array([[1., 3.], [1., -2.]])
+    forecast = model.forecast(y, 2, future_observation_rows=future)
+    np.testing.assert_allclose(forecast.observation_means, future @ mean)
+    expected = future @ covariance @ future.T + .5 * np.eye(2)
+    np.testing.assert_allclose(forecast.observation_covariance, expected)
+    np.testing.assert_allclose(forecast.cumulative_observation_variances[-1], expected.sum())
+    with pytest.raises(ValueError, match="future"):
+        model.forecast(y, 2)
+    with pytest.raises(ValueError):
+        model.filter(y[:3])
+    with pytest.raises(ValueError):
+        model.with_observation_rows(np.ones((4, 3)))
+
+
+@pytest.mark.parametrize("period,count", [(12, 12), (12, 18), (52, 9)])
+def test_short_seasonal_histories_and_missing_phases(rustmc_module, period, count):
+    rmc = rustmc_module
+    ig = rmc.InverseGammaPrior
+    y = np.sin(2 * np.pi * np.arange(count) / period)
+    y[1::3] = np.nan
+    model = rmc.BayesianSeasonalLocalLevel(period, ig(3, .04), ig(3, .08), ig(3, .4))
+    fit = model.fit(y, chains=1, draws=4, warmup=2)
+    assert np.isfinite(fit.forecast(3).observation_samples).all()
+
+
+def test_fourier_short_history_future_phase_and_shrinkage(rustmc_module):
+    rmc = rustmc_module
+    complete = rmc.fourier_design(30, 12, 2)
+    np.testing.assert_array_equal(rmc.fourier_design(12, 12, 2, start=18), complete[18:])
+    assert rmc.fourier_design(5, 12, 6).shape == (5, 11)
+    assert rmc.fourier_design(0, 12, 6).shape == (0, 11)
+    with pytest.raises(ValueError):
+        rmc.fourier_design(5, 12, 7)
+    model = models(rmc)[0]
+    y = complete[:18] @ np.array([1.5, -.8, .2, .1])
+    fit = model.fit(y, exog=complete[:18], coefficient_prior=prior(rmc, 4), chains=2, draws=100, warmup=70)
+    future = fit.forecast(12, exog=complete[18:])
+    truth = complete[18:] @ np.array([1.5, -.8, .2, .1])
+    assert np.mean((future.mean_samples.mean(axis=(0, 1)) - truth)**2) < .12
+
+
+def test_repeated_short_history_holdouts_and_prior_sensitivity(rustmc_module):
+    """A finite seeded calibration smoke check, not a universal coverage guarantee."""
+    rmc = rustmc_module
+    rng = np.random.default_rng(552)
+    x = rmc.fourier_design(24, 12, 1)
+    ig = rmc.InverseGammaPrior
+    model = rmc.BayesianLocalLevel(ig(3, .04), ig(3, .16), initial_variance=1.)
+    covered, squared_errors, baseline_errors = [], [], []
+    for repeat in range(12):
+        level = np.cumsum(rng.normal(scale=.1, size=24))
+        y = level + x @ np.array([1.5, -.8]) + rng.normal(scale=.2, size=24)
+        fit = model.fit(y[:18], exog=x[:18], coefficient_prior=prior(rmc, 2),
+                        chains=2, draws=70, warmup=50, seed=repeat)
+        prediction = fit.forecast(6, exog=x[18:], seed=repeat + 100)
+        lower, upper = prediction.interval(.9)
+        covered.extend((lower <= y[18:]) & (y[18:] <= upper))
+        squared_errors.extend((prediction.mean_samples.mean(axis=(0, 1)) - y[18:])**2)
+        baseline_errors.extend((y[6:12] - y[18:])**2)
+    assert np.mean(covered) >= .75
+    assert np.mean(squared_errors) < np.mean(baseline_errors)
+    # Unobserved harmonic phases retain uncertainty controlled by proper priors.
+    sparse = np.array([0., 0.] + [np.nan] * 10)
+    weak = model.fit(sparse, exog=x[:12], coefficient_prior=prior(rmc, 2, 9.),
+                     chains=2, draws=120, warmup=80, seed=23)
+    strong = model.fit(sparse, exog=x[:12], coefficient_prior=prior(rmc, 2, .01),
+                       chains=2, draws=120, warmup=80, seed=23)
+    assert weak.get_samples_2d()["coefficients"].std(axis=(0, 1)).sum() > strong.get_samples_2d()["coefficients"].std(axis=(0, 1)).sum()

--- a/tests/test_release_verification.py
+++ b/tests/test_release_verification.py
@@ -1,0 +1,62 @@
+"""Release version drift must fail before an upload, on Python 3.9+ too."""
+import importlib.util
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("release_version_check", ROOT / "scripts/verify_version.py")
+CHECK = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(CHECK)
+
+
+def release_copy(tmp_path):
+    for name in ("rust_core/Cargo.toml", "python_bindings/Cargo.toml", "pyproject.toml", "Cargo.lock"):
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(ROOT / name, target)
+    return tmp_path
+
+
+def test_versions_and_tags_are_checked_without_toml_dependency(tmp_path):
+    root = release_copy(tmp_path)
+    version = CHECK.verify(root)
+    assert CHECK.verify(root, "v" + version) == version
+    for invalid in ("v999.0.0", "not-a-tag", "v@CURRENT@-rc1"):
+        with pytest.raises(ValueError):
+            CHECK.verify(root, invalid)
+
+
+@pytest.mark.parametrize("name,old,new", [
+    ("pyproject.toml", 'version = "@CURRENT@"', 'version = "999.0.0"'),
+    ("python_bindings/Cargo.toml", 'path = "../rust_core", version = "@CURRENT@"', 'path = "../rust_core", version = "999.0.0"'),
+    ("python_bindings/Cargo.toml", 'path = "../rust_core"', 'path = "../elsewhere"'),
+    ("Cargo.lock", 'name = "rustmc_core"\nversion = "@CURRENT@"', 'name = "rustmc_core"\nversion = "999.0.0"'),
+    ("Cargo.lock", 'name = "rustmc"\nversion = "@CURRENT@"', 'name = "rustmc"\nversion = "999.0.0"'),
+])
+def test_dependency_and_lock_drift_are_rejected(tmp_path, name, old, new):
+    root = release_copy(tmp_path)
+    target = root / name
+    old = old.replace("@CURRENT@", CHECK.verify(root))
+    assert old in target.read_text()
+    target.write_text(target.read_text().replace(old, new, 1))
+    with pytest.raises(ValueError):
+        CHECK.verify(root)
+
+
+def test_version_cli_runs_from_outside_checkout(tmp_path):
+    result = subprocess.run([sys.executable, str(ROOT / "scripts/verify_version.py")], cwd=tmp_path, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "binding dependency, Cargo.lock" in result.stdout
+
+
+def test_artifact_gate_rejects_stale_extra_archives_before_install(tmp_path):
+    version = CHECK.verify(ROOT)
+    (tmp_path / ("rustmc-%s-cp39-abi3-manylinux_2_17_x86_64.whl" % version)).touch()
+    (tmp_path / "unrelated-1.0-cp39-abi3-manylinux_2_17_x86_64.whl").touch()
+    result = subprocess.run([sys.executable, str(ROOT / "scripts/test_release_artifact.py"), "wheel", "--dist-dir", str(tmp_path)], capture_output=True, text=True)
+    assert result.returncode == 1
+    assert "unrelated files" in result.stderr

--- a/tests/test_runoff.py
+++ b/tests/test_runoff.py
@@ -108,6 +108,20 @@ def test_short_diagnostics_and_invalid_prior():
             rustmc.DirichletMultinomialRunoff(alpha)
 
 
+def test_large_sparse_totals_and_oversized_calendar_are_safe():
+    fit = rustmc.DirichletMultinomialRunoff([1, 1]).fit(
+        np.array([[0., np.nan], [np.nan, np.nan]]), [0, 1], 0,
+        [10**10, 10**10], draws=10, chains=1,
+    )
+    assert (fit.ultimate_samples == 10**10).all()
+    with pytest.raises(ValueError, match="allocation"):
+        fit.calendar_samples(2**61)
+    with pytest.raises(ValueError, match="allocation"):
+        rustmc.DirichletMultinomialRunoff([1, 1]).fit(
+            np.array([[0., np.nan]]), [0], 0, [1], draws=10**9,
+        )
+
+
 def test_rolling_valuation_holdout_on_known_total_cohorts():
     rng = np.random.default_rng(203)
     truth = np.array([.5, .3, .15, .05])

--- a/tests/test_runoff.py
+++ b/tests/test_runoff.py
@@ -17,7 +17,7 @@ def test_complete_conjugate_posterior_and_diagnostics():
     assert fit.allocation_samples.shape == (2, 4000, 2, 3)
     assert fit.observed_mask.all()
     assert not fit.tail_samples.any()
-    stats = fit.sampler_stats()
+    stats = fit.sampler_stats
     assert stats["divergences"] is None
     assert stats["acceptance_rate"] is None
     assert len(fit.diagnostics()) == 3

--- a/tests/test_runoff.py
+++ b/tests/test_runoff.py
@@ -1,0 +1,138 @@
+"""Native integer-event runoff: censoring, exact references, and coherent paths."""
+import numpy as np
+import pytest
+import rustmc
+
+
+def test_complete_conjugate_posterior_and_diagnostics():
+    fit = rustmc.DirichletMultinomialRunoff([2, 3, 1]).fit(
+        np.array([[8., 3., 1.], [4., 5., 3.]]), [0, 1], 5,
+        totals=[12, 12], draws=4000, chains=2, seed=42,
+    )
+    p = fit.lag_probability_samples
+    np.testing.assert_allclose(p.mean(axis=(0, 1)), np.array([14, 11, 5]) / 30, atol=.004)
+    np.testing.assert_allclose(p.sum(axis=-1), 1)
+    assert fit.sampler == "independent_conjugate"
+    assert fit.allocation_samples.dtype == np.uint64
+    assert fit.allocation_samples.shape == (2, 4000, 2, 3)
+    assert fit.observed_mask.all()
+    assert not fit.tail_samples.any()
+    stats = fit.sampler_stats()
+    assert stats["divergences"] is None
+    assert stats["acceptance_rate"] is None
+    assert len(fit.diagnostics()) == 3
+    assert "independent_conjugate" in fit.summary()
+
+
+def test_future_calendar_and_tail_conserve_known_totals():
+    model = rustmc.DirichletMultinomialRunoff([3, 2, 1])
+    counts = np.array([[4., np.nan, np.nan], [np.nan, np.nan, np.nan]])
+    fit = model.fit(counts, [0, 1], 0, totals=[9, 6], draws=80, chains=2, seed=19)
+    repeat = model.fit(counts, [0, 1], 0, totals=[9, 6], draws=80, chains=2, seed=19)
+    np.testing.assert_array_equal(fit.allocation_samples, repeat.allocation_samples)
+    np.testing.assert_array_equal(fit.lag_probability_samples, repeat.lag_probability_samples)
+    allocation = fit.allocation_samples
+    np.testing.assert_array_equal(allocation.sum(axis=-1), fit.ultimate_samples)
+    assert (allocation[:, :, 0, 0] == 4).all()
+    calendar = fit.calendar_samples(2)
+    np.testing.assert_array_equal(calendar[:, :, 0], allocation[:, :, 0, 1] + allocation[:, :, 1, 0])
+    np.testing.assert_array_equal(calendar[:, :, 1], allocation[:, :, 1, 1])
+    assert (calendar.sum(axis=-1) + fit.tail_samples.sum(axis=-1) + 4 == 15).all()
+    assert not fit.calendar_samples(4)[:, :, 2:].any()
+    np.testing.assert_array_equal(fit.observed_mask, np.isfinite(counts))
+    assert np.isnan(fit.intensity_samples).all()
+
+
+def test_unknown_ultimate_matches_independent_quadrature():
+    # x0=3 observed, tail unknown. Integrate the marginal posterior for p0:
+    # p0^(alpha0+x0-1) (1-p0)^(alpha1-1) / (rate+p0)^(shape+x0).
+    nodes, weights = np.polynomial.legendre.leggauss(256)
+    p = (nodes + 1) / 2
+    weight = weights * p**4 * (1-p)**2 / (.2+p)**7
+    weight /= weight.sum()
+    expected_p = weight @ p
+    expected_intensity = weight @ (7 / (.2+p))
+    expected_remaining = weight @ (7 * (1-p) / (.2+p))
+    fit = rustmc.DirichletMultinomialRunoff([2, 3], total_shape=4, total_rate=.2).fit(
+        np.array([[3., np.nan]]), [0], 0, draws=6000, warmup=1200, chains=2, seed=61,
+    )
+    assert fit.sampler == "latent_count_gibbs"
+    assert abs(fit.lag_probability_samples[:, :, 0].mean() - expected_p) < .018
+    assert abs(fit.intensity_samples.mean() - expected_intensity) < .5
+    assert abs(fit.tail_samples.mean() - expected_remaining) < .5
+    assert (fit.ultimate_samples >= 3).all()
+    np.testing.assert_array_equal(fit.ultimate_samples, fit.tail_samples + 3)
+    assert {r["name"] for r in fit.diagnostics()} == {
+        "lag_probability[0]", "lag_probability[1]", "intensity[0]", "ultimate[0]",
+    }
+
+
+def test_zero_observation_has_information_and_prior_future_cohort_is_usable():
+    model = rustmc.DirichletMultinomialRunoff([2, 3], total_shape=4, total_rate=.2)
+    fit = model.fit(np.array([[0., np.nan], [np.nan, np.nan]]), [0, 1], 0,
+                    draws=3000, warmup=500, chains=2, seed=3)
+    assert (fit.allocation_samples[:, :, 0, 0] == 0).all()
+    assert fit.ultimate_samples[:, :, 0].mean() > 0
+    # No observed events in the future cohort: its ultimate marginal is its prior.
+    assert abs(fit.ultimate_samples[:, :, 1].mean() - 20) < .7
+    assert fit.ultimate_samples[:, :, 0].mean() < 20
+
+
+@pytest.mark.parametrize("counts, origins, valuation, totals", [
+    ([[1., 0., np.nan]], [0], 0, [5]),  # future zero is observed data, not a mask
+    ([[np.nan, np.nan, np.nan]], [0], 0, [5]),  # past missing not supported
+    ([[2., np.nan, np.nan]], [0], 0, [1]),
+    ([[1., 2., 3.]], [0], 3, [7]),  # closed total mismatch
+    ([[1.5, np.nan, np.nan]], [0], 0, [5]),
+    ([[-1., np.nan, np.nan]], [0], 0, [5]),
+    ([[np.inf, np.nan, np.nan]], [0], 0, [5]),
+    ([[1., np.nan, 0.]], [0], 0, [5]),  # tail closure before tail begins
+    ([[1., np.nan, np.nan]], [], 0, [5]),
+])
+def test_invalid_triangle_is_rejected(counts, origins, valuation, totals):
+    with pytest.raises(ValueError):
+        rustmc.DirichletMultinomialRunoff([1, 1, 1]).fit(
+            np.array(counts), origins, valuation, totals, draws=2, chains=1,
+        )
+
+
+def test_short_diagnostics_and_invalid_prior():
+    fit = rustmc.DirichletMultinomialRunoff([1, 1]).fit(
+        np.array([[0., np.nan]]), [0], 0, [2], draws=2, chains=1,
+    )
+    assert all(row["r_hat"] is None for row in fit.diagnostics())
+    with pytest.raises(ValueError):
+        fit.calendar_samples(0)
+    for alpha in ([1], [1, 0], [1, np.inf]):
+        with pytest.raises(ValueError):
+            rustmc.DirichletMultinomialRunoff(alpha)
+
+
+def test_rolling_valuation_holdout_on_known_total_cohorts():
+    rng = np.random.default_rng(203)
+    truth = np.array([.5, .3, .15, .05])
+    origins = np.repeat(np.arange(8), 5)
+    full = np.array([rng.multinomial(120, truth) for _ in origins], dtype=float)
+    covered = []
+    errors, uniform_errors = [], []
+    for valuation in [4, 5, 6]:
+        observed = origins[:, None] + np.arange(4) <= valuation
+        counts = np.where(observed, full, np.nan)
+        fit = rustmc.DirichletMultinomialRunoff([1, 1, 1, 1]).fit(
+            counts, origins.tolist(), valuation, [120] * len(origins),
+            draws=1200, chains=2, seed=valuation,
+        )
+        actual = sum(full[i, lag] for i in range(len(origins)) for lag in range(3)
+                     if origins[i] + lag == valuation + 1)
+        paths = fit.calendar_samples(1).reshape(-1)
+        low, high = np.quantile(paths, [.025, .975])
+        covered.append(low <= actual <= high)
+        errors.append(abs(paths.mean() - actual))
+        baseline = 0.
+        for i, row in enumerate(counts):
+            for lag in range(3):
+                if origins[i] + lag == valuation + 1:
+                    baseline += (120 - np.nansum(row)) / np.isnan(row).sum()
+        uniform_errors.append(abs(baseline - actual))
+    assert sum(covered) >= 2
+    assert np.mean(errors) < np.mean(uniform_errors)


### PR DESCRIPTION
Calendar effects previously required an external regression, independent forecasting cells required Python orchestration, and Gaussian observations could not represent exact-zero payment amounts. This adds joint Bayesian regressors, native independent batches, sparse amount forecasting, and censored payment-count runoff, and prepares synchronized rustmc_core/rustmc 0.11.0 releases.

Implemented behavior:
- Local-level, trend and seasonal fits accept time-varying exogenous designs and proper Gaussian coefficient priors. Coefficient, state and variance draws stay aligned through future and cumulative forecasts. Fixed state-space APIs also accept time-varying observation rows.
- Native batch fitting and forecasting preserve cell IDs/seeds across ordering, chunking and worker counts; support ragged inputs, mixed models and per-cell priors; and collect failures with allocation guards.
- Specialized fits expose rank-normalized R-hat, bulk/tail ESS, MCSE and sampler-specific metadata. Gibbs/FFBS acceptance and Hamiltonian divergences are unavailable.
- Seasonal fits require two finite observations instead of two full cycles. Fourier features preserve calendar phase and handle the Nyquist term.
- BayesianHurdleLogNormal learns static occurrence probability and dynamic positive lognormal severity, including all-zero histories. Explicit upper-truncated log-variance priors keep predictive amount moments finite. It participates in the batch API.
- DirichletMultinomialRunoff supports censored event-count triangles with known or Gamma-Poisson inferred ultimates, coherent calendar allocations and an unscheduled tail. Monetary amounts are not treated as counts.

Validation:
- cargo fmt and strict workspace/all-target clippy pass.
- 132 Rust unit tests and 12 recovery tests pass, including analytic joint moments, independent importance/quadrature references, seeded recovery, malformed inputs and allocation boundaries.
- 209 Python tests pass with ArviZ 1.x (1 skipped, 1 expected failure, 1 network test deselected).
- The exact Linux wheel passes an isolated install, API smoke check and applicable Python suite (193 passed).
- cargo package verifies rustmc_core 0.11.0. Native release wheel and source-archive checks run in this PR and on release tags before PyPI upload.

Limits: regression uses dense augmented FFBS; future regressors are supplied fixed scenarios. The hurdle occurrence probability is static and its variance bounds are explicit model assumptions. Runoff has shared stationary event lag probabilities and does not infer dates inside the tail. The retained batch benchmark explicitly fails its short-chain convergence gate and makes no statistical-quality speed claim. Python type stubs remain a known packaging gap.
