### PR TITLE
Focus the docs and examples on repeated Bayesian inference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to rustmc
 
-rustmc welcomes focused contributions that improve correctness, forecasting quality,
-reproducibility, or deployment ergonomics.
+rustmc welcomes focused contributions that improve correctness, repeated inference,
+partial pooling, and deployment.
 
 ## Development setup
 
@@ -49,3 +49,10 @@ Keep each pull request narrow enough to review. Include:
 
 Generated files, local worktrees, editor logs, and internal review notes do not belong in
 the repository.
+
+## Documentation
+
+Lead with what the reader can do. Use short paragraphs, familiar words, and runnable
+examples. Cut repeated claims and promotional language. Keep limitations next to
+the behavior they qualify. See [Google’s technical writing guide](https://developers.google.com/style/tone)
+and [GOV.UK’s plain-language guidance](https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/writing-guidelines/clear-language/).

--- a/README.md
+++ b/README.md
@@ -1,320 +1,105 @@
 # rustmc
 
-Bayesian inference powered by Rust, with a Python API.
+Bayesian models in Python. Inference in Rust.
 
-> **Project status: alpha.** rustmc is suitable for research, evaluation, and
-> controlled internal workflows. Its supported modeling surface is useful but still
-> intentionally smaller than mature probabilistic programming systems. Validate every
-> model on representative data before using its output for consequential decisions.
+rustmc focuses on small, structured models you need to fit repeatedly: regressions,
+group comparisons, calibration, and forecasts. Build a model once, fit new datasets,
+and keep the posterior draws for prediction and diagnostics.
 
-rustmc is a practical, general-purpose Bayesian toolkit. It combines graph-based
-automatic differentiation and NUTS/HMC with reusable compiled models, exact conjugate
-inference, and specialized state-space algorithms. A generic sampler is available when a
-model needs one, while focused methods can be added when a research or production problem
-benefits from them.
-
-rustmc complements PyMC and Stan rather than trying to replace them. Its practical
-distinction is native Rust execution and Rayon-powered parallelism across chains and
-repeated-model workloads. That foundation can support fast forecasting, regression, and
-domain-specific models in biomedical research, engineering, science, finance, and other
-fields. The project aims to keep those implementations understandable enough to inspect,
-adapt, and extend for real work.
-
-## Why rustmc
-
-- **General and specialized inference in one runtime.** The model builder uses
-  reverse-mode automatic differentiation with NUTS or HMC. Local-level, seasonal, and
-  trend models use FFBS/Gibbs, while Gaussian AR(p) uses an exact
-  Normal-Inverse-Gamma posterior.
-- **Compile once, bind many.** `ModelBuilder.compile()` separates immutable model
-  structure from validated datasets, including datasets with different row counts.
-- **Native execution.** Sampling, state-space operations, and chain coordination execute
-  in Rust outside the Python hot path.
-- **Deterministic parallelism.** Chains and repeated-model workloads use Rayon with
-  stable per-chain seed derivation and ordered results.
-- **A focused scope.** General inference and specialized model implementations share a
-  native core, so domain methods can be added without pursuing feature parity with a
-  mature probabilistic-programming language. The Python binding surface still needs the
-  modularization described in the roadmap before that extension path is as simple as it
-  should be.
-- **Bayesian workflow support.** Prior predictive checks, posterior predictive draws,
-  pointwise log likelihood, convergence diagnostics, and ArviZ export are available for
-  the generic inference path.
-- **Coherent uncertainty.** Specialized forecasting APIs retain complete
-  `(chain, draw, horizon)` paths so derived totals and other nonlinear quantities can be
-  calculated draw by draw.
-
-These are implementation capabilities, not a universal speed or accuracy claim.
-Performance and statistical quality depend on the model, data, tuning, and hardware.
-
-## Installation
-
-Install the latest published Python package with:
+The project is **alpha**. The Python package is supported; the Rust API is still
+changing. Check convergence and model fit on your own data.
 
 ```bash
 pip install rustmc
 ```
 
-To build the current source instead of installing a published wheel:
+NumPy is the only required Python dependency. Install `rustmc[viz]` for ArviZ and
+Matplotlib. Python 3.9–3.13 are covered by install tests.
 
-```bash
-git clone https://github.com/tbosier/rustmc.git
-cd rustmc
-python -m venv .venv
-source .venv/bin/activate
-python -m pip install --upgrade pip maturin numpy
-maturin develop --manifest-path python_bindings/Cargo.toml --release
-```
+## Fit a regression
 
-Python 3.9 through 3.13 are covered by source-install and wheel-install CI. NumPy is the
-only required Python runtime dependency. ArviZ and Matplotlib are optional:
-
-```bash
-pip install "rustmc[viz]"
-```
-
-The Python extension is the supported public package today. `rustmc_core` contains the
-Rust implementation, but its public API should still be considered unstable.
-
-## Quick start
-
-Version 0.12 adds [custom expressions and future-data prediction](docs/custom-models.md),
-[composable structural forecasts](docs/structural-forecasting.md), and
-[dynamic count, hurdle, and pooled Gaussian models](docs/dynamic-glm.md).
-The [forecasting workflow guide](docs/forecasting-workflows.md) covers backtests,
-scores, named features, scenarios, storage, and updates.
-
-This example fits a Bayesian linear regression with NUTS:
+This example estimates an instrument's offset, gain, and measurement noise.
 
 ```python
 import numpy as np
 import rustmc as rmc
 
 rng = np.random.default_rng(42)
-x = rng.normal(size=1_000)
-y = 2.5 * x + rng.normal(size=1_000)
+x = np.linspace(-2, 2, 100)
+y = 0.3 + 1.2 * x + rng.normal(0, 0.2, x.size)
 
-builder = rmc.ModelBuilder()
-beta = builder.normal_prior("beta", mu=0.0, sigma=1.0)
-builder.normal_likelihood(
-    "obs",
-    mu_expr=beta * "x",
-    sigma=1.0,
-    observed_key="y",
-)
+model = rmc.ModelBuilder()
+offset = model.normal_prior("offset", 0.0, 1.0)
+gain = model.normal_prior("gain", 1.0, 0.5)
+noise = model.half_normal_prior("noise", 0.5)
+model.normal_likelihood("reading", offset + gain * "x", noise, "y")
+compiled = model.compile()
 
-fit = rmc.sample(
-    model_spec=builder.build(),
-    data={"x": x, "y": y},
-    chains=4,
-    warmup=1_000,
-    draws=1_000,
-    seed=42,
+fit = compiled.sample(
+    {"x": x, "y": y}, chains=4, warmup=1000, draws=1000, seed=42,
+    show_progress=False,
 )
 print(fit.summary())
+
+future = fit.predict({"x": np.array([-1.0, 0.0, 1.0])}, seed=43)
+print(np.quantile(future["reading"], [0.025, 0.975], axis=(0, 1)))
 ```
 
-The same modeling surface supports scalar hierarchical priors, GLM-style expressions,
-and a vectorized `beta @ "X"` path backed by faer.
+`predict` keeps the `(chain, draw, observation)` axes. Use `expected=True` for the
+conditional mean without new observation noise. Priors above are chosen for this
+example's units.
 
-### Reuse one model structure
+## Reuse the model
 
-When the structure is shared across datasets, compile it once and bind new data:
+`compiled.sample()` accepts another dataset with the same columns and a different
+number of rows. `compiled.sample_batch()` fits independent datasets with stable IDs:
 
 ```python
-builder = rmc.ModelBuilder()
-intercept = builder.normal_prior("intercept", mu=0.0, sigma=5.0)
-slope = builder.normal_prior("slope", mu=0.0, sigma=2.0)
-builder.normal_likelihood(
-    "obs",
-    mu_expr=intercept + slope * "x",
-    sigma=1.0,
-    observed_key="y",
-)
-
-compiled = builder.compile()
 batch = compiled.sample_batch(
-    [
-        {"x": x_a, "y": y_a},
-        {"x": x_b, "y": y_b},
-    ],
-    ids=["dataset-a", "dataset-b"],
-    chains=4,
-    warmup=500,
-    draws=1_000,
-    seed=42,
+    [{"x": x, "y": y}, {"x": x[:50], "y": y[:50]}],
+    ids=["instrument-a", "instrument-b"],
+    chains=4, warmup=1000, draws=1000, threads=2, errors="collect",
+    show_progress=False,
 )
+for instrument in batch.ids:
+    if instrument not in batch.errors:
+        print(instrument, batch.get(instrument).summary())
+print(batch.errors)
 ```
 
-`CompiledModel` validates each binding against the same structural schema. The legacy
-`sample()` and `batch_sample()` entry points remain available.
+Independent fits do not share information. For related groups, build one
+[partial-pooling model](docs/examples/site-effects.md).
 
-## Forecasting as an application
+## What's included
 
-Forecasting is one application of rustmc's structure-aware inference rather than the
-definition of the library. Current specialized models include a joint hierarchical
-mean for ragged related series, Bayesian local level, seasonal local level, local linear
-trend, and directly observed Gaussian AR(p), plus fixed-parameter linear Gaussian
-state-space filtering, smoothing, and a sum-to-zero seasonal constructor.
+- NUTS and HMC with autodiff, constrained parameters, and parallel chains.
+- Scalar and vector regressions, group indexing, nonlinear expressions, and custom
+  log-density terms. See [custom models](docs/custom-models.md).
+- Prior and posterior prediction, pointwise log likelihood, R-hat, effective sample
+  size, Monte Carlo error, and ArviZ export.
+- Exact Gaussian AR regression, Gaussian hierarchical models, and Kalman/FFBS
+  algorithms for state-space models.
+- [Forecasting workflows](docs/forecasting-workflows.md) for structural, count,
+  hurdle, and runoff models, with joint predictive paths and backtests.
+- Versioned model and fit artifacts. Compiled model artifacts omit training data;
+  fitted artifacts include it. Neither resumes sampler adaptation or RNG state.
 
-For many short program series, fit one population → group → program posterior instead
-of independently batching models:
+The modeling language is deliberately small. PyMC and Stan offer broader model
+support. rustmc aims to earn its place through repeated fitting and a few well-tested
+specialized algorithms. Performance depends on the workload; see the
+[benchmark protocol](benchmarks/README.md).
 
-```python
-model = rmc.BayesianHierarchicalMean(
-    group_variance_prior=rmc.InverseGammaPrior(3.0, 20.0),
-    program_variance_prior=rmc.InverseGammaPrior(3.0, 10.0),
-    observation_variance_prior=rmc.InverseGammaPrior(3.0, 25.0),
-    population_mean_prior=100.0,
-    population_variance_prior=400.0,
-)
-fit = model.fit(
-    [program_a, program_b, program_c],       # unequal lengths are native
-    group_index=[0, 0, 1],
-    program_names=["a", "b", "c"],
-    group_names=["division-a", "division-b"],
-)
-forecast = fit.forecast(steps=12)
+## Start here
 
-# (chain, draw, program, step); chain/draw alignment preserves dependence.
-company_draws = forecast.observation_samples.sum(axis=2)
-division_draws = forecast.group_observation_samples
-```
+- [Instrument calibration](examples/instrument_calibration.py): regression and new-data prediction.
+- [Repeated calibration](examples/repeated_calibration.py): one model, several datasets.
+- [Site effects](examples/site_effects.py): partial pooling with unequal group sizes.
+- [Forecasting](examples/custom_forecast_workflow.py): fit, predict, and evaluate.
+- [Examples guide](examples/README.md) and [API reference](docs/reference.md).
 
-This MVP pools a static Gaussian intercept/mean; it is not a dynamic local-level model.
-Its conjugate Gibbs kernel samples the joint hierarchy directly and avoids requiring HMC
-to navigate a funnel. Centered Gibbs can still mix slowly near zero variance, so inspect
-`fit.summary()`/`fit.diagnostics()`; explicit priors remain important for sparse groups.
+The [roadmap](ROADMAP.md) tracks five priorities: statistical release gates,
+representative benchmarks, native model artifacts, bounded batches, and consistent
+results and diagnostics. Forecasting remains an application of that shared core.
 
-```python
-values = np.asarray(
-    [101, 98, 103, 105, 102, 108, 111, 109, 114, 116, 113, 119,
-     121, 118, 123, 126, 124, 129, 131, 128, 134, 136, 133, 139],
-    dtype=float,
-)
-
-model = rmc.BayesianLocalLevel(
-    process_variance_prior=rmc.InverseGammaPrior(shape=3.0, scale=20.0),
-    observation_variance_prior=rmc.InverseGammaPrior(shape=3.0, scale=50.0),
-    initial_mean=float(values[0]),
-    initial_variance=100.0,
-)
-fit = model.fit(values, chains=4, warmup=500, draws=1_000, seed=42)
-forecast = fit.forecast(steps=12, seed=43)
-
-predictive_lower, predictive_upper = forecast.interval(0.95)
-level_lower, level_upper = forecast.state_interval(0.95)
-
-# Derived quantities are summarized after calculation within each joint draw.
-six_period_totals = forecast.observation_samples[:, :, :6].sum(axis=2)
-total_mean = six_period_totals.mean()
-total_interval = np.quantile(six_period_totals, [0.025, 0.975])
-```
-
-The observation interval is posterior predictive; the latent-level interval is a
-credible interval for the expected level. Applications include demand, operations,
-sensor data, and financial series such as rebate accruals. Rebate payments are only an
-example: choose a model for settlement timing, zeros, contract drivers, and positive
-support, with priors matched to observation units.
-
-The fitted Gaussian models support [joint Bayesian regressors and Fourier calendar
-terms](docs/regression-forecasting.md), including known future design rows. Calendar
-coefficients, structural states, and variance parameters remain aligned in posterior
-forecast paths. [Native independent batches](docs/forecast-batches.md) fit ragged cells
-with stable IDs, explicit worker limits, per-cell diagnostics, and collected errors.
-Annual seasonal models accept histories shorter than two full cycles under proper priors.
-
-For sparse nonnegative amounts, [BayesianHurdleLogNormal](docs/sparse-amounts.md)
-combines a learned zero probability with dynamic positive severity and bounded log
-variances. [DirichletMultinomialRunoff](docs/runoff.md) models payment-event counts by
-cohort and lag, including unknown ultimate counts and an explicit unscheduled tail.
-Runoff count inputs represent events; currency amounts need an amount model.
-
-Forecasting examples:
-
-- [`examples/payment_triangle_runoff.py`](examples/payment_triangle_runoff.py): integer-event development with known or uncertain ultimates; [model and data contract](docs/runoff.md).
-- [`examples/rebate_accrual_forecast.py`](examples/rebate_accrual_forecast.py)
-- [`examples/bayesian_local_level_forecasting.py`](examples/bayesian_local_level_forecasting.py)
-- [`examples/bayesian_seasonal_forecasting.py`](examples/bayesian_seasonal_forecasting.py)
-- [`examples/bayesian_local_linear_trend_forecasting.py`](examples/bayesian_local_linear_trend_forecasting.py)
-- [`examples/bayesian_ar_forecasting.py`](examples/bayesian_ar_forecasting.py)
-- [`examples/custom_state_space_forecasting.py`](examples/custom_state_space_forecasting.py)
-
-## Implemented surface
-
-| Area | Current support |
-|---|---|
-| Generic inference | NUTS with configurable `target_accept`, fixed-trajectory HMC, transformed continuous parameters, parallel chains |
-| Continuous priors | Normal, Student-t, HalfNormal, Exponential, LogNormal, Gamma, Beta, Uniform |
-| Likelihoods | Normal, Bernoulli-logit, Poisson-log, Exponential, LogNormal, Negative Binomial |
-| Model structure | Joint ragged hierarchical means, scalar hierarchical priors, scalar/vector regression expressions, automatic non-centering for supported generic scalar hierarchies |
-| Diagnostics | Rank-normalized folded split R-hat, bulk/tail ESS, MCSE and HDIs on generic and specialized fits; sampler-specific divergence/acceptance metadata |
-| Predictive workflow | Prior predictive, posterior predictive, pointwise log likelihood, ArviZ export |
-| Repeated models | In-memory compile/bind reuse, generic batch sampling, and independent forecasting batches with stable cell IDs |
-| Fixed state space | Constant transitions and time-varying observation rows, Kalman filter, RTS smoother, missing observations, joint and cumulative conditional forecasts |
-| Specialized inference | Bayesian level/trend/seasonal regression, Fourier calendar features, Gaussian AR(p), sparse hurdle lognormal, and payment-count runoff |
-
-Bernoulli and Poisson are exposed for prior-predictive use, but discrete latent
-parameters are not suitable for the current gradient-based samplers. Fitted AR(p)
-coefficient draws are not constrained to the stationary region; explosive draws are
-possible and are not silently discarded.
-
-## Validation and benchmarks
-
-The repository includes finite-difference autodiff checks, analytic and synthetic
-posterior recovery, state-space reference tests, cross-thread determinism checks, Python
-API tests, and clean-wheel verification.
-
-Run the core verification with:
-
-```bash
-cargo fmt --all -- --check
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace --release
-python -m pytest -q
-```
-
-Run `python examples/run_benchmarks.py --help` for the benchmark harness. This README
-does not publish a numeric cross-engine result because the repository does not retain a
-complete raw output, environment, and revision for one. Use
-[`benchmarks/RESULTS_TEMPLATE.md`](benchmarks/RESULTS_TEMPLATE.md) when publishing a
-result, and report statistical quality together with wall time.
-
-The separate [`demo-docs` synthetic forecasting study](demo-docs/README.md) retains its
-generated data, model-selection code, raw outputs, RustMC plots, comparison timings, and
-negative results. It is a diagnostic example, not a general product benchmark.
-
-Tests establish behavior on their stated reference cases. They do not prove that a new
-model is appropriate for a user's data or that its intervals are calibrated under
-misspecification.
-
-## Current limitations
-
-- The expression and distribution surface is deliberately finite; arbitrary user-defined
-  probability functions and broad tensor algebra are not yet supported.
-- Expressions support scalar and elementwise operations, matrix-vector regression,
-  named dimensions, and group indexing; unrestricted tensor programs remain outside scope.
-- Generic compiled models and fits, structural models/fits, dynamic-family fits, and
-  forecast draws have versioned persistence. These are prediction artifacts, not sampler
-  checkpoints; they do not resume RNG/adaptation state.
-- Explicit unconstrained chain initialization is available. BFMI is not yet reported.
-- Structural AR coefficients, damping, and Student-t degrees of freedom are fixed.
-  Dynamic GLM scales and negative-binomial dispersion are fixed inputs; coefficients and
-  time states are inferred jointly. Learned scales for these GLMs need another kernel.
-- Singular predictive covariance systems are not supported by the structural FFBS solver.
-- Shared-factor dynamics, stochastic volatility, regime switching, and calendar-varying
-  payment lag probabilities remain future extensions.
-- Performance has not been established on a representative, retained benchmark corpus.
-
-See [`ROADMAP.md`](ROADMAP.md) for the ordered engineering plan and differentiated
-capability ideas.
-
-## Contributing
-
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for development and evidence requirements. Bug
-reports are most useful when they include a minimal model, seed, environment,
-diagnostics, and expected result.
-
-## License
-
-MIT
+For source builds and checks, see [Contributing](CONTRIBUTING.md).
+MIT licensed.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,199 +1,39 @@
-# rustmc roadmap and capability ideas
+# Direction
 
-This document describes direction, not release commitments. Items are ordered by
-dependency and user value. Correctness evidence and a coherent public API take priority
-over feature count.
+rustmc focuses on repeated Bayesian inference and structured partial pooling.
+Regression, calibration, group comparisons, and forecasting share the same core.
+We want a small library whose supported models are easy to fit, inspect, and deploy.
 
-## Implemented in 0.12
+These are the next five features, in dependency order. Each needs tests, documentation,
+and a working example before it is complete.
 
-The [September review](docs/repo-review-2026-09-09.md) led to custom expression and
-prediction APIs, named dimensions/group indexing, declarative model and fit persistence,
-stable-ID batches with collected failures, explicit initial positions, a native custom
-log-density interface, composable structural models, dynamic count/hurdle/pooled Gaussian
-models, and reusable forecast evaluation/scenario/update tools. See the new
-[workflow guide](docs/forecasting-workflows.md) and changelog for supported boundaries.
-The sections below retain longer-term direction; implemented items are foundations to
-extend rather than missing features. In particular, the remaining priorities are:
+| Feature | Work | Done when |
+|---|---|---|
+| Statistical release gates | Add fixed-data posterior references, repeated-simulation checks, and stricter positive recovery cases. Keep difficult negative controls separate. | Release checks fail on poor convergence, inaccurate posteriors, or silent diagnostic failures. |
+| Repeated-inference benchmarks | Measure single and ragged repeated regressions, including setup, fitting, prediction, and memory. Reuse compiled models in competing engines. | Raw runs retain every failure and report useful throughput only when statistical quality passes. |
+| Native model artifacts | Move the current model definition, validation, and compilation into the Rust core. Keep Python as an adapter. | The same artifact can be loaded, bound, fitted, and evaluated from Python and Rust. |
+| Bounded batches | Stream inputs and results, choose retained outputs, and rerun jobs by stable ID. | Memory stays bounded as job count grows, and one failed job can be collected without losing completed work. |
+| Results and diagnostics | Share a result protocol with named dimensions and joint draw identity. Record energy, BFMI, termination reasons, and the actual algorithm. | Users can inspect generic and specialized fits consistently; inapplicable diagnostics remain unavailable. |
 
-- Learned dynamic-GLM scales, dispersion and pooling strengths, with posterior geometry
-  and repeated-simulation checks before adding automatic inference selection.
-- Stationarity-aware learned AR priors, learned damping, richer initial/process
-  covariance structures, and support for singular state systems.
-- Streaming batch inputs/results and bounded retention; chunked dispatch currently
-  retains all datasets and results.
-- Further separation of the remaining Python model/sampler/preset binding code;
-  the new expression, prediction, persistence and model-family modules are already split.
-- BFMI/termination telemetry, larger calibration/misspecification studies, and useful
-  inference throughput measured only with acceptable convergence.
-- Shared-factor multivariate dynamics, stochastic volatility, changepoints/regimes,
-  calendar/cohort-dependent runoff and continuous payment severity/composition.
+## Next mathematical work
 
-## Product direction
+Expose the conjugate regression machinery already used by Gaussian AR models as an
+ordinary regression API. Then add exact sufficient-statistic updates for that model.
+Preserve its variance-scaled coefficient prior; other priors require other algorithms.
 
-rustmc should grow as a **practical, extensible, general Bayesian toolkit**. It should
-complement PyMC and Stan rather than duplicate their complete modeling languages. Its
-distinctive combination is:
+Evaluate one collapsed Gaussian hierarchy next: integrate out Gaussian effects, sample
+hyperparameters, and reconstruct joint effects for prediction. Compare it with existing
+Gibbs and noncentered sampling before extending the approach.
 
-1. a compact graph, autodiff, and sampling runtime for general supported models;
-2. compile-once/bind-many execution for repeated model structures;
-3. specialized exact, conjugate, or state-space inference when structure permits;
-4. deterministic posterior and predictive outputs that can be audited and deployed; and
-5. a stable native core usable without keeping Python in the execution path; and
-6. implementations that remain understandable and adaptable for focused work in science,
-   engineering, biomedical research, finance, and other domains.
+Learned scales for dynamic count and hurdle models can follow once the Gaussian path
+is dependable. Their current scales and pooling strengths are fixed inputs.
 
-Forecasting is an important proving ground for these ideas, but it is one application.
-Regression, GLMs, hierarchical models, experiments, reliability models, and other
-repeated Bayesian analyses should use the same foundations.
+## Scope
 
-## 1. Continuing correctness and release gates
+Keep the existing forecasting models and improve them through the shared foundations.
+Add distributions or algorithms when a concrete supported workload needs them.
+A universal inference planner, a tensor language, GPUs, distributed sampling, and
+new volatility or regime-switching families are outside the current plan.
 
-This is the release gate for everything below.
-
-- Keep analytic value and finite-difference gradient tests for every log density,
-  transform, and likelihood.
-- Add learned-auxiliary-parameter tests wherever a likelihood has parameters beyond its
-  linear predictor.
-- Pin rank-normalized folded R-hat, bulk/tail ESS, MCSE, and HDI behavior against
-  independent references and adversarial chains.
-- Add simulation-based calibration and posterior recovery for every supported family at
-  a scale appropriate for CI, with higher-power suites runnable on demand.
-- Complete the existing energy, tree-depth, and leapfrog telemetry with termination
-  reasons and BFMI inputs.
-- Make initialization configurable, extend `target_accept` tests across every sampling
-  entry point, and test failure reporting at the chain level.
-- Publish synchronized Python and Rust versions from one clean tag. Test the actual
-  stable-ABI wheels on Python 3.9 through 3.13 outside the checkout.
-- Retain raw validation and benchmark artifacts with the exact revision, environment,
-  command, seed, workload, and statistical-quality metrics.
-
-**Exit criterion:** a user can trace every supported density, diagnostic, wheel, and
-public numerical claim to a reproducible test or retained artifact.
-
-## 2. Complete the general modeling foundation
-
-The next priority is making common Bayesian models natural without trying to implement
-an unrestricted tensor language immediately.
-
-- Add named dimensions, coordinates, and validated group indexing.
-- Add vector-valued hierarchical priors and non-centered group effects.
-- Add offsets, exposure terms, weights where statistically meaningful, and prediction on
-  newly bound covariates.
-- Expand robust and constrained modeling support: Student-t likelihoods, censored data,
-  ordered/simplex transforms, and multivariate Gaussian building blocks.
-- Make missing-data behavior explicit per likelihood rather than relying on incidental
-  numeric handling.
-- Define a stable extension boundary for new distributions and graph operations so each
-  feature does not require unrelated Python and Rust surgery.
-- Split the Python binding monolith into focused model, inference, diagnostics,
-  state-space, and conversion modules, leaving `lib.rs` responsible primarily for module
-  registration.
-- Unify result shapes, parameter naming, coordinates, and ArviZ groups across scalar,
-  vector, hierarchical, and specialized fits.
-- Ship `py.typed` and maintained `.pyi` files for the supported Python API.
-
-**Exit criterion:** regression, common GLMs, and partial-pooling models have consistent
-construction, prediction, diagnostics, and typed results.
-
-## 3. Turn compile/bind into an operational advantage
-
-The in-memory structural split already exists. The next work should make it useful for
-large repeated workloads without making unsupported speed claims.
-
-- Give one compiled structure a first-class `fit`, `predict`, and `sample_batch` lifecycle.
-- Preserve dataset identities and deterministic seeds when a batch is reordered or
-  resumed.
-- Add collect-errors semantics so one invalid or unstable dataset does not discard an
-  otherwise successful batch.
-- Define one explicit parallelism policy across datasets, chains, and linear algebra.
-- Bound retained evaluator memory after unusually large bindings and report peak memory
-  in regression tests.
-- Add streaming or chunked dataset submission instead of requiring every payload to be
-  resident before inference starts.
-- Design a portable, versioned, slot-only artifact that never embeds an accidental
-  training dataset.
-- Provide a stable Rust runtime for binding an artifact and producing predictions or
-  posterior draws without Python.
-
-**Exit criterion:** the same audited artifact can be fitted or evaluated across many
-validated datasets with stable IDs, bounded memory, isolated failures, and reproducible
-results.
-
-## 4. Build a structure-aware inference planner
-
-This is the strongest long-term technical differentiator. A model should not pay for
-generic NUTS when its graph admits a safer or more direct method.
-
-- Detect conjugate Gaussian and Normal-Inverse-Gamma subgraphs and dispatch to exact
-  posterior kernels.
-- Add collapsed linear-Gaussian likelihood evaluation using the existing Kalman core.
-- Keep FFBS/Gibbs implementations as reference oracles while adding marginalized
-  state-space inference for unknown system parameters.
-- Introduce an explicit kernel registry: exact posterior, conjugate Gibbs, Kalman/FFBS,
-  Laplace, NUTS, and fixed-trajectory HMC should share a result contract.
-- Explain the selected kernel and its assumptions in machine-readable fit metadata.
-- Add MAP and Laplace approximation for models where a validated Hessian makes them
-  useful; report approximation diagnostics rather than presenting them as equivalent to
-  MCMC.
-- Investigate automatic reparameterization using graph structure and observed sampler
-  geometry.
-
-**Exit criterion:** inference selection is deterministic, inspectable, tested against an
-independent reference, and never silently changes the target distribution.
-
-## 5. Develop high-value applications on the shared core
-
-Application layers should validate the architecture without redefining the whole project.
-
-### Time series and forecasting
-
-- Use one dated forecast result for latent credible intervals, observation predictive
-  intervals, coherent paths, and draw-wise cumulative summaries.
-- Add rolling-origin backtesting with seasonal-naive and classical baselines, interval
-  coverage, bias, sharpness, CRPS/WIS, and prior-sensitivity reporting.
-- Extend the fitted seasonal component with calendar effects and multiple seasonalities;
-  add known future regressors, offsets/exposure, time-varying matrices, and robust or
-  positive observation families.
-- Add hierarchical pooling and probabilistic reconciliation across related series and
-  aggregation levels.
-- Add stationarity-aware AR priors or explicit diagnostics rather than clipping unstable
-  draws.
-
-Demand, staffing, reliability, sensor monitoring, and rebate accruals are example use
-cases. None should be hard-coded into the general inference or result APIs.
-
-### Other promising application layers
-
-- Repeated A/B-test and conversion models with partial pooling.
-- Reliability and event-rate models with exposure and censoring.
-- Small-area or site-level GLMs fitted across many related datasets.
-- Bayesian linear and generalized-linear model artifacts for embedded scoring.
-
-**Exit criterion:** each application ships with a representative dataset or generator,
-simple baselines, calibration evidence, and a clear statement of its estimand.
-
-## 6. Community and ecosystem
-
-- Maintain a small gallery of end-to-end, reproducible models rather than many overlapping
-  demo scripts.
-- Publish validation reports that include negative results and known failure regimes.
-- Add a pinned subset of PosteriorDB or comparable independent reference targets.
-- Document mathematical parameterizations and transformations at the public API boundary.
-- Stabilize `rustmc_core` in stages and publish explicit Rust API compatibility policy.
-- Provide issue templates for model requests, correctness reports, and reproducible
-  benchmarks.
-- Label approachable work in diagnostics, distributions, examples, and documentation for
-  first-time contributors.
-
-## Deferred directions
-
-The following may become useful, but should not displace the ordered work above:
-
-- broad arbitrary-PPL feature parity;
-- GPU or distributed MCMC;
-- Stan-language import;
-- browser-first inference;
-- a large collection of approximate inference algorithms without calibration evidence.
-
-The bar for adding one of these directions is a concrete workload where the existing
-architecture is the right foundation and correctness can be measured.
+A release number follows evidence and compatibility, not feature count. The Rust API
+and artifact compatibility policy will stabilize in stages.

--- a/docs/examples/linear-regression.ipynb
+++ b/docs/examples/linear-regression.ipynb
@@ -358,7 +358,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "PPC p-value (std): 1.000  (0.5 = perfect calibration)\n"
+      "PPC p-value (std): 1.000\n"
      ]
     }
    ],
@@ -379,7 +379,7 @@
     "plt.show()\n",
     "\n",
     "ppc_p = (y_rep.std(axis=1) > y.std()).mean()\n",
-    "print(f\"PPC p-value (std): {ppc_p:.3f}  (0.5 = perfect calibration)\")"
+    "print(f\"PPC p-value (std): {ppc_p:.3f}\")"
    ]
   }
  ],

--- a/docs/examples/linear-regression.md
+++ b/docs/examples/linear-regression.md
@@ -194,7 +194,7 @@ plt.tight_layout()
 plt.show()
 
 ppc_p = (y_rep.std(axis=1) > y.std()).mean()
-print(f"PPC p-value (std): {ppc_p:.3f}  (0.5 = perfect calibration)")
+print(f"PPC p-value (std): {ppc_p:.3f}")
 ```
 
 
@@ -203,4 +203,4 @@ print(f"PPC p-value (std): {ppc_p:.3f}  (0.5 = perfect calibration)")
     
 
 
-    PPC p-value (std): 1.000  (0.5 = perfect calibration)
+    PPC p-value (std): 1.000

--- a/docs/examples/repeated-calibration.md
+++ b/docs/examples/repeated-calibration.md
@@ -1,0 +1,13 @@
+# Repeated calibration
+
+Fit independent instrument datasets with one compiled regression model. Each can have
+a different number of readings. Stable IDs keep random streams tied to instruments
+when the batch order changes.
+
+Run `python examples/repeated_calibration.py` from the repository root.
+The [script](https://github.com/tbosier/rustmc/blob/main/examples/repeated_calibration.py)
+prints each fit's diagnostics and collects errors by instrument ID.
+
+This does not pool instruments. Use [site effects](site-effects.md) when group estimates
+should share information. Chunked batch dispatch currently retains inputs and fits;
+see the roadmap for bounded streaming.

--- a/docs/examples/site-effects.md
+++ b/docs/examples/site-effects.md
@@ -1,0 +1,14 @@
+# Site effects
+
+A partial-pooling model estimates a shared population mean, a between-site scale,
+and each site's deviation. Sites with fewer readings can borrow information from
+the population. The example uses a noncentered parameterization and unequal counts.
+
+Run `python examples/site_effects.py` from the repository root.
+The [script](https://github.com/tbosier/rustmc/blob/main/examples/site_effects.py)
+prints diagnostics, site intervals, and the posterior probability that one site's
+mean exceeds another's.
+
+Comparisons use paired posterior draws. Independently shuffling or fitting sites
+would lose the joint dependence. The observation noise is known in this example;
+a real model can assign it a positive prior.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,313 +1,50 @@
-# Getting Started
+# Get started
 
-## Installation
+Install the Python package with `pip install rustmc`. NumPy is required; ArviZ and
+Matplotlib are optional through `pip install "rustmc[viz]"`.
 
-### From PyPI (recommended)
-
-```bash
-pip install rustmc
-```
-
-### From source
-
-Requires Rust (stable) and [maturin](https://github.com/PyO3/maturin).
-
-```bash
-git clone https://github.com/tbosier/rustmc.git
-cd rustmc
-python -m venv .venv && source .venv/bin/activate
-pip install maturin numpy
-maturin develop --manifest-path python_bindings/Cargo.toml --release
-```
-
-## Your First Model
-
-A simple Bayesian linear regression: `y ~ Normal(beta * x, sigma)`.
+## Estimate an instrument's gain
 
 ```python
 import numpy as np
 import rustmc as rmc
 
-# Generate synthetic data
-np.random.seed(42)
-N = 500
-x = np.random.randn(N)
-y = 2.5 * x + np.random.normal(0, 1.5, N)
+rng = np.random.default_rng(42)
+x = np.linspace(-2, 2, 100)
+y = 0.3 + 1.2 * x + rng.normal(0, 0.2, len(x))
 
-# Build the model
-builder = rmc.ModelBuilder(data={"x": x, "y": y})
-beta  = builder.normal_prior("beta",  mu=0.0, sigma=5.0)
-sigma = builder.half_normal_prior("sigma", sigma=2.0)
-builder.normal_likelihood("obs", mu_expr=beta * "x", sigma=sigma, observed_key="y")
-model = builder.build()
-
-# Sample
-fit = rmc.sample(model_spec=model, chains=4, draws=2000, warmup=1000, seed=42)
+model = rmc.ModelBuilder()
+offset = model.normal_prior("offset", 0.0, 1.0)
+gain = model.normal_prior("gain", 1.0, 0.5)
+noise = model.half_normal_prior("noise", 0.5)
+model.normal_likelihood("reading", offset + gain * "x", noise, "y")
+compiled = model.compile()
+fit = compiled.sample(
+    {"x": x, "y": y}, chains=4, warmup=1000, draws=1000,
+    seed=42, show_progress=False,
+)
 print(fit.summary())
 ```
 
-## Reading the Output
+The posterior estimates the offset, gain, and measurement noise together. Choose
+priors in the units of your measurements.
 
-```
-4 chains x 2000 draws per chain
-
-Parameter        mean      std     hdi_3%    hdi_97%   ess_bulk   ess_tail    r_hat  mcse_mean
------------------------------------------------------------------------------------------------
-beta           2.4981   0.0670     2.3662     2.6258       3241       3108   1.0003   0.001178
-sigma          1.5043   0.0479     1.4142     1.5973       3887       2989   1.0003   0.000768
------------------------------------------------------------------------------------------------
-Mean accept rate: 0.94  |  Divergences: 0
-```
-
-- **mean / std** — posterior mean and standard deviation
-- **hdi_3% / hdi_97%** — 94% highest density interval
-- **ess_bulk / ess_tail** — effective sample size; aim for > 400
-- **r_hat** — rank-normalized folded split-chain convergence diagnostic; values near 1.0 indicate convergence
-- **mcse_mean** — Monte Carlo standard error of the mean
-
-## Core API
-
-### `ModelBuilder`
+Inspect R-hat, bulk/tail effective sample size, Monte Carlo error, and divergences.
+R-hat near one and enough effective samples are necessary checks, not proof that the
+model describes your data. Compare predictive draws with observations too.
 
 ```python
-builder = rmc.ModelBuilder(data={"x": x, "y": y})
+prediction = fit.predict({"x": np.array([-1.0, 0.0, 1.0])}, seed=43)
+interval = np.quantile(prediction["reading"], [0.025, 0.975], axis=(0, 1))
+print(interval)
 ```
 
-Data can be passed at build time or at sample time via the `data=` argument to `rmc.sample()`.
+Draws have `(chain, draw, observation)` axes. `expected=True` returns conditional
+means; the default also samples observation noise.
 
-### Priors
+Reuse `compiled` for another instrument. Use a [batch](examples/repeated-calibration.md)
+for independent fits or one [partial-pooling model](examples/site-effects.md) for
+related groups. See [custom models](custom-models.md) for the full construction API.
 
-```python
-# Scalar priors
-beta  = builder.normal_prior("beta",  mu=0.0, sigma=1.0)
-sigma = builder.half_normal_prior("sigma", sigma=2.0)
-alpha = builder.student_t_prior("alpha", nu=3.0, mu=0.0, sigma=1.0)
-p     = builder.beta_prior("p", alpha=1.0, beta=1.0)
-lam   = builder.gamma_prior("lam", alpha=2.0, beta=1.0)
-```
-
-### Likelihoods
-
-```python
-builder.normal_likelihood("obs", mu_expr=beta * "x", sigma=sigma, observed_key="y")
-```
-
-`mu_expr` can be:
-
-- A `ParamRef` directly: `mu_expr=beta`
-- A scalar multiply: `mu_expr=beta * "x"`
-- A linear combination: `mu_expr=alpha + beta * "x"`
-- A matrix multiply: `mu_expr=beta @ "X"` (promotes `beta` to a vector)
-
-### `rmc.sample()`
-
-```python
-fit = rmc.sample(
-    model_spec=model,
-    data={"x": x, "y": y},   # optional if passed to ModelBuilder
-    chains=4,
-    draws=2000,
-    warmup=1000,
-    seed=42,
-    sampler="nuts",           # "nuts" (default) or "hmc"
-)
-```
-
-### Compile once and bind many datasets
-
-When the model structure is repeated across datasets, compile it once and bind each
-payload separately:
-
-```python
-builder = rmc.ModelBuilder()
-beta = builder.normal_prior("beta", mu=0.0, sigma=1.0)
-builder.normal_likelihood("obs", beta * "x", sigma=1.0, observed_key="y")
-compiled = builder.compile()
-
-fit = compiled.sample({"x": x, "y": y}, chains=4, draws=1000)
-batch = compiled.sample_batch(
-    [{"y": store_a_y}, {"y": store_b_y}],
-    shared={"x": shared_x},
-    ids=["store-a", "store-b"],
-)
-```
-
-`compiled.bind(data)` validates the schema eagerly and returns a reusable `BoundModel`.
-Bindings may have different row counts, but matrix column counts and parameter shapes are
-part of the compiled structure.
-
-### Linear Gaussian state-space models
-
-For fixed-system filtering, smoothing, and forecasting:
-
-```python
-ssm = rmc.LinearGaussianStateSpace.local_level(
-    process_variance=0.2,
-    observation_variance=1.0,
-)
-filtered = ssm.filter(y_with_optional_nan_values)
-smoothed = ssm.smooth(y_with_optional_nan_values)
-forecast = ssm.forecast(y_with_optional_nan_values, steps=12)
-lower_95, upper_95 = forecast.interval(0.95)
-cumulative_lower, cumulative_upper = forecast.cumulative_interval(0.95)
-```
-
-This standalone API keeps the supplied variances fixed. Its interval includes state,
-process, and observation uncertainty, but not parameter uncertainty.
-
-For a known seasonal structure, `LinearGaussianStateSpace.seasonal_local_level(...)`
-adds sum-to-zero dummy seasonality. This is still a fixed-system constructor: the level,
-seasonal, and observation variances are supplied rather than inferred.
-
-For Bayesian local-level fitting and a parameter-integrated 95% forecast interval:
-
-```python
-bayesian = rmc.BayesianLocalLevel(
-    process_variance_prior=rmc.InverseGammaPrior(2.5, 0.3),
-    observation_variance_prior=rmc.InverseGammaPrior(2.5, 0.6),
-    initial_mean=0.0,
-    initial_variance=4.0,
-)
-fit = bayesian.fit(y_with_optional_nan_values, chains=4, draws=1000, warmup=500)
-forecast = fit.forecast(steps=12, seed=43)
-lower_95, upper_95 = forecast.interval(0.95)
-
-# Latent-state credible interval, excluding future observation noise:
-state_lower_95, state_upper_95 = forecast.state_interval(0.95)
-```
-
-The inverse-gamma priors are on variances and must be chosen for the units of your
-series; rustmc does not silently infer a universal scale.
-
-For one fitted sum-to-zero seasonal component:
-
-```python
-seasonal = rmc.BayesianSeasonalLocalLevel(
-    period=12,
-    level_variance_prior=rmc.InverseGammaPrior(3.0, 2.0),
-    seasonal_variance_prior=rmc.InverseGammaPrior(3.0, 1.0),
-    observation_variance_prior=rmc.InverseGammaPrior(3.0, 8.0),
-    initial_level=float(y_with_optional_nan_values[:12].mean()),
-)
-seasonal_fit = seasonal.fit(
-    y_with_optional_nan_values, chains=4, draws=1000, warmup=500
-)
-seasonal_forecast = seasonal_fit.forecast(steps=12, seed=43)
-lower, upper = seasonal_forecast.interval(0.95)
-cumulative_lower, cumulative_upper = seasonal_forecast.cumulative_interval(0.95)
-```
-
-Seasonal models require at least two finite observations, with no full-cycle minimum.
-Short histories can be fit, but seasonal and variance inference can be prior-sensitive;
-compare rolling-origin forecasts against simple seasonal baselines. For exogenous
-regressors and compact Fourier seasonality, see [regression forecasting](regression-forecasting.md).
-
-For a fitted stochastic level and slope:
-
-```python
-trend = rmc.BayesianLocalLinearTrend(
-    level_variance_prior=rmc.InverseGammaPrior(3.0, 0.2),
-    slope_variance_prior=rmc.InverseGammaPrior(3.0, 0.02),
-    observation_variance_prior=rmc.InverseGammaPrior(3.0, 0.8),
-    initial_level=0.0,
-    initial_slope=0.0,
-    initial_level_variance=4.0,
-    initial_slope_variance=1.0,
-)
-trend_fit = trend.fit(y_with_optional_nan_values, chains=4, draws=1000, warmup=500)
-trend_forecast = trend_fit.forecast(steps=12, seed=43)
-observation_lower, observation_upper = trend_forecast.interval(0.95)
-level_lower, level_upper = trend_forecast.level_interval(0.95)
-slope_lower, slope_upper = trend_forecast.slope_interval(0.95)
-```
-
-For a directly observed AR(p), choose any positive order and give an explicit
-Normal-Inverse-Gamma prior. Coefficients are ordered as
-`[intercept, lag_1, ..., lag_p]`:
-
-```python
-order = 3
-prior = rmc.NormalInverseGammaPrior(
-    coefficient_mean=np.zeros(order + 1),
-    coefficient_precision=np.eye(order + 1) * 0.1,
-    variance_shape=2.5,
-    variance_scale=0.2,
-)
-ar = rmc.BayesianAutoRegression(order=order, prior=prior)
-ar_fit = ar.fit(y_without_missing_values, chains=4, draws=1000, seed=42)
-ar_forecast = ar_fit.forecast(steps=12, seed=43)
-lower, upper = ar_forecast.interval(0.95)
-```
-
-AR(p) draws are exact conjugate posterior draws, so `fit()` has no warmup or thinning
-arguments. The likelihood conditions on the first `p` observations, missing values are
-currently rejected, and coefficient draws are not silently clipped to the stationary
-region.
-
-### `FitResult` methods
-
-```python
-fit.summary()            # formatted table
-fit.mean()               # dict: param -> float
-fit.std()                # dict: param -> float
-fit.get_samples()        # dict: param -> flattened samples
-fit.get_samples_2d()     # dict: param -> np.ndarray, shape (chains, draws)
-fit.diagnostics()        # list of per-parameter diagnostics
-fit.transition_diagnostics()  # sampler energy/tree/integrator telemetry
-fit.accept_rates()       # list of per-chain accept rates
-fit.step_sizes()         # list of per-chain step sizes
-fit.divergences()        # list of per-chain divergence counts
-fit.posterior_predictive(n_samples=500, seed=42)
-fit.log_likelihood()     # dict: likelihood -> np.ndarray, shape (chains, draws, obs)
-fit.to_arviz(include_ppc=True)
-```
-
-### Prior & Posterior Predictive
-
-```python
-prior_pred = rmc.sample_prior_predictive(model, n_samples=500, seed=0)
-ppc        = fit.posterior_predictive(n_samples=500, seed=42)
-```
-
-`sample_prior_predictive()` returns parameter draws plus simulated observations. `posterior_predictive()` returns simulated observations keyed by likelihood name.
-
-If you pass `n_samples`, `posterior_predictive()` randomly subsamples posterior draws without replacement. Use `None` to include all draws.
-
-### Hierarchical Priors
-
-Scalar hierarchical priors are supported today:
-
-```python
-mu_global = builder.normal_prior("mu_global", mu=0.0, sigma=5.0)
-sigma_group = builder.half_normal_prior("sigma_group", sigma=2.0)
-mu_group = builder.normal_prior("mu_group", mu=mu_global, sigma=sigma_group)
-```
-
-That works for scalar parameters and scalar `sigma` in the likelihood. Eligible scalar hierarchical normals are automatically compiled through a non-centered parameterization, while still appearing under the logical parameter name in summaries and ArviZ output. Vector-valued hierarchical blocks are not implemented yet.
-
-### Other likelihood families
-
-The same builder also supports:
-
-```python
-builder.bernoulli_logit_likelihood("clicked", eta_expr=alpha + beta * "x", observed_key="y")
-builder.poisson_log_likelihood("count", eta_expr=alpha + beta * "x", observed_key="y")
-builder.exponential_likelihood("time", eta_expr=alpha + beta * "x", observed_key="y")
-builder.log_normal_likelihood("sales", mu_expr=alpha + beta * "x", sigma=sigma, observed_key="y")
-builder.negative_binomial_likelihood("orders", eta_expr=alpha + beta * "x", alpha=dispersion, observed_key="y")
-```
-
-For model comparison with ArviZ:
-
-```python
-idata = fit.to_arviz(include_log_likelihood=True)
-# az.loo(idata)
-# az.waic(idata)
-```
-
-## Next Steps
-
-- [Linear Regression example](examples/linear-regression.md) — full workflow with prior/posterior predictive checks
-- [Hierarchical Models](examples/hierarchical.md) — partial pooling across groups
-- [Batch Inference](examples/batch-inference.md) — fitting many independent models at once
-- [High-Dimensional Regression](examples/high-dimensional.md) — faer-backed `X @ beta`
+For source builds, follow the repository's
+[contributing guide](https://github.com/tbosier/rustmc/blob/main/CONTRIBUTING.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,111 +1,25 @@
 # rustmc
 
-**Bayesian inference powered by Rust, with a Python API.**
+Bayesian models in Python. Inference in Rust.
 
-rustmc is a general Bayesian inference library with a deliberately scoped modeling
-surface. It combines graph-based automatic differentiation and NUTS/HMC with exact,
-conjugate, and state-space algorithms for models whose structure permits a more direct
-approach.
-
-## Why rustmc?
-
-The project is exploring a structure-aware inference runtime rather than a smaller clone
-of an existing probabilistic programming system. Generic models use the Rust autodiff and
-sampling engine. Repeated models can reuse a compiled structure across validated data
-bindings. Specialized algorithms remain available through the same package when they are
-a better match than sampling every latent variable with NUTS.
-
-## Differentiation
-
-- Generic NUTS/HMC and reverse-mode autodiff execute in Rust outside the Python hot path.
-- `ModelBuilder.compile()` separates immutable model structure from validated datasets.
-- Independent chains and repeated-model workloads share one Rayon thread pool.
-- Exact conjugate and state-space algorithms complement the generic sampler.
-- Diagnostics, predictive checks, pointwise log likelihood, and ArviZ export support a
-  complete Bayesian workflow for the current modeling surface.
-
-## Benchmarks
-
-The repository provides matched-protocol benchmark drivers; run `python
-examples/run_benchmarks.py` on the hardware you care about. No numeric performance result
-is published without retained raw command output, environment details, and an exact
-revision. See the top-level README and `benchmarks/RESULTS_TEMPLATE.md` for the protocol.
-
-## Install
+Use rustmc for regressions, partial pooling, calibration, and forecasts. Compile a
+model once, fit new datasets, and carry posterior uncertainty into predictions.
 
 ```bash
 pip install rustmc
 ```
 
-## Quick Example
+The project is alpha. Its modeling language is small, and the Rust API is still changing.
+Check diagnostics and model fit before interpreting results.
 
-```python
-import numpy as np
-import rustmc as rmc
+[Fit your first model](getting-started.md), then try
+[repeated calibration](examples/repeated-calibration.md) or
+[site effects](examples/site-effects.md). The [custom model guide](custom-models.md)
+covers expressions, dimensions, prediction, and persistence.
 
-x = np.random.randn(1000)
-y = 2.5 * x + np.random.randn(1000)
+[Forecasting](forecasting-workflows.md) uses the same Bayesian foundations, with
+specialized state-space, count, and sparse-amount models.
 
-builder = rmc.ModelBuilder()
-beta = builder.normal_prior("beta", mu=0.0, sigma=1.0)
-builder.normal_likelihood("obs", mu_expr=beta * "x", sigma=1.0, observed_key="y")
-model = builder.build()
-
-fit = rmc.sample(model_spec=model, data={"x": x, "y": y}, chains=4, draws=1000)
-print(fit.summary())
-```
-
-## What's Implemented
-
-**Sampling:** NUTS with multinomial candidate selection, block-structured mass matrix
-adaptation, dual-averaging step size, configurable `target_accept`, fixed-trajectory HMC
-fallback, and multi-chain parallelism via Rayon.
-
-**Priors:** Normal, HalfNormal, Exponential, LogNormal, StudentT, Gamma, Beta, Uniform, Bernoulli, Poisson. Constrained distributions are automatically sampled in unconstrained space.
-
-**Likelihoods:** Normal, Bernoulli-logit, Poisson-log, Exponential-log, LogNormal, and NegativeBinomial-log.
-
-**Modeling surface:** scalar hierarchical priors are supported, and scalar hierarchical normals are automatically compiled through a non-centered path where appropriate. Vector-valued hierarchical blocks are still on the roadmap.
-
-**Predictive workflow:** prior predictive sampling, posterior predictive sampling, pointwise log-likelihood, and ArviZ export are implemented for the current likelihood families.
-
-**Diagnostics:** Rank-normalized folded split R-hat, rank-normalized bulk/tail ESS,
-MCSE, empirical 94% HDI, divergence detection, and per-chain acceptance rates.
-
-**High-dimensional regression:** faer-backed `MatVecMul` op — `beta @ "X"` dispatches to a BLAS-level GEMV rather than N scalar graph nodes.
-
-**Compile once, bind many:** `ModelBuilder.compile()` returns an immutable
-`CompiledModel` whose validated bindings can have different row counts while sharing one
-graph structure.
-
-**Linear Gaussian state space:** `LinearGaussianStateSpace` provides fixed-system
-Kalman filtering, smoothing, missing-observation handling, and forecasting, with
-optional time-varying observation rows.
-
-**Forecasting application:** fitted local-level, seasonal local-level, and local-linear-trend structural models
-provide FFBS/Gibbs posterior prediction, while `BayesianAutoRegression(order=p)` supports
-directly observed Gaussian AR(p) at any positive lag order. All return coherent paths and
-parameter-integrated pointwise intervals.
-
-The Gaussian forecasting models support [joint Bayesian exogenous regressors and
-Fourier seasonality](regression-forecasting.md), [independent cell batches and
-diagnostics](forecast-batches.md), and seasonal histories shorter than two cycles.
-Specialized [sparse amount](sparse-amounts.md) and [payment-count runoff](runoff.md)
-models handle zeros and censored cohort development with explicit statistical contracts.
-
-## What Is Still Missing
-
-- A broader general modeling surface: named dimensions, group indexing, vector-valued
-  hierarchical models, robust likelihoods, and stable extension points.
-- Richer automatic reparameterization support.
-- Portable serialization and prediction-on-new-data for the in-memory re-bindable
-  compiled model; the legacy JSON artifact remains data-owning.
-- Generic Bayesian state-space estimation and collapsed Kalman-likelihood integration in
-  `ModelBuilder`; specialized local level, local trend, and direct AR(p) are implemented.
-- Consistent result coordinates, typed Python APIs, and richer sampler telemetry.
-- Higher-level applications for repeated inference, forecasting, and panel workflows.
-
-See the
-[project roadmap](https://github.com/tbosier/rustmc/blob/main/ROADMAP.md)
-for the ordered plan. Forecasting is one application of the shared inference core; it is
-not the boundary of the project.
+The current work focuses on stronger statistical checks, representative benchmarks,
+Rust artifact loading, bounded batches, and consistent results.
+See the [roadmap](https://github.com/tbosier/rustmc/blob/main/ROADMAP.md).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,27 @@
+# Examples
+
+Run these from the repository root after installing rustmc:
+
+```bash
+python examples/instrument_calibration.py
+python examples/repeated_calibration.py
+python examples/site_effects.py
+python examples/custom_forecast_workflow.py
+```
+
+| Example | Use it for |
+|---|---|
+| `instrument_calibration.py` | Regression, diagnostics, and prediction at new inputs. |
+| `repeated_calibration.py` | Independent fits with one compiled model and stable IDs. |
+| `site_effects.py` | Partial pooling and comparisons from joint posterior draws. |
+| `custom_forecast_workflow.py` | Structural forecasts and held-out scoring. |
+| `simple_example.py` | Prior and posterior predictive checks. |
+| `hierarchical_mean.py` | A specialized Gaussian Gibbs model and joint totals. |
+
+These use generated data. Their priors describe those examples; adapt them to your units.
+Short runs demonstrate the API. Inspect diagnostics before interpreting a fit.
+
+Performance comparisons belong in `benchmarks/`. The older `benchmark_*.py`,
+`compare_with_pymc.py`, and `batch_many_series.py` scripts are exploratory studies,
+not retained evidence for speed claims. Use `python -m benchmarks.run --help` for
+the reference protocol.

--- a/examples/hierarchical_example.py
+++ b/examples/hierarchical_example.py
@@ -33,19 +33,16 @@ from hierarchical_templates import build_centered_normal_partial_pooling
 
 # ── 1. Simulate data ─────────────────────────────────────────────────────────
 
-np.random.seed(42)
+rng = np.random.default_rng(42)
 
 J = 8                                       # number of groups
 sigma_obs = 2.0                             # known within-group noise
 N_per_group = 30                            # observations per group
 
-# True group means — deliberately spread across a wide range
-mu_true = np.array([5.0, -1.0, 3.0, 0.0, 8.0, 2.0, -3.0, 6.0])
-# True hyperparameters
-mu_global_true   = mu_true.mean()           # ≈ 2.5
-sigma_group_true = mu_true.std()            # ≈ 3.7
-
-ys = [np.random.normal(mu_true[j], sigma_obs, N_per_group) for j in range(J)]
+mu_global_true = 2.5
+sigma_group_true = 3.0
+mu_true = rng.normal(mu_global_true, sigma_group_true, J)
+ys = [rng.normal(mu_true[j], sigma_obs, N_per_group) for j in range(J)]
 data = {f"y_{j}": ys[j] for j in range(J)}
 
 print("Simulated data")

--- a/examples/hierarchical_templates.py
+++ b/examples/hierarchical_templates.py
@@ -1,10 +1,4 @@
-"""Reusable hierarchical-model helpers.
-
-This module captures the centered partial-pooling pattern that rustmc can
-already express today. It gives users a stable template boundary now, while
-the future non-centered API can slot in behind the same conceptual surface
-once the DSL grows parameter-to-parameter transforms.
-"""
+"""Scalar Normal partial pooling; the compiler noncenters supported hierarchies."""
 
 from dataclasses import dataclass
 from typing import Sequence
@@ -32,9 +26,8 @@ def build_centered_normal_partial_pooling(
 ) -> CenteredNormalHierarchy:
     """Build the centered 8-schools style hierarchy used by the examples.
 
-    The current rustmc DSL can represent scalar hyperpriors and scalar
-    hierarchical group means. This helper keeps that pattern reusable and
-    isolates the eventual non-centered API change to one place.
+    The model is written conditionally. rustmc compiles supported scalar
+    hierarchies into noncentered sampling coordinates.
     """
 
     mu_global = builder.normal_prior(mu_global_name, mu=mu_global_mu, sigma=mu_global_sigma)

--- a/examples/instrument_calibration.py
+++ b/examples/instrument_calibration.py
@@ -1,0 +1,30 @@
+"""Estimate an instrument's offset, gain, and noise; predict new readings."""
+import numpy as np
+import rustmc as rmc
+
+
+def calibration_model():
+    model = rmc.ModelBuilder()
+    offset = model.normal_prior("offset", 0.0, 1.0)
+    gain = model.normal_prior("gain", 1.0, 0.5)
+    noise = model.half_normal_prior("noise", 0.5)
+    model.normal_likelihood("reading", offset + gain * "x", noise, "y")
+    return model.compile()
+
+
+def main():
+    rng = np.random.default_rng(42)
+    x = np.linspace(-2, 2, 100)
+    y = 0.3 + 1.2 * x + rng.normal(0, 0.2, len(x))
+    fit = calibration_model().sample(
+        {"x": x, "y": y}, chains=4, warmup=1000, draws=1000,
+        seed=42, show_progress=False,
+    )
+    print(fit.summary())
+    prediction = fit.predict({"x": np.array([-1.0, 0.0, 1.0])}, seed=43)
+    print("95% predictive intervals:")
+    print(np.quantile(prediction["reading"], [0.025, 0.975], axis=(0, 1)))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/repeated_calibration.py
+++ b/examples/repeated_calibration.py
@@ -1,0 +1,27 @@
+"""Reuse one calibration model for independent instruments with different sample counts."""
+import numpy as np
+from instrument_calibration import calibration_model
+
+
+def main():
+    rng = np.random.default_rng(42)
+    datasets = []
+    ids = []
+    for i, rows in enumerate([40, 75, 120]):
+        x = np.linspace(-2, 2, rows)
+        y = 0.1 * i + (1.0 + 0.05 * i) * x + rng.normal(0, 0.2, rows)
+        ids.append(f"instrument-{i}")
+        datasets.append({"x": x, "y": y})
+    batch = calibration_model().sample_batch(
+        datasets, ids=ids, chains=4, warmup=1000, draws=1000,
+        threads=2, seed=42, errors="collect", show_progress=False,
+    )
+    for name in batch.ids:
+        if name in batch.errors:
+            print(name, batch.errors[name])
+        else:
+            print(name, batch.get(name).summary())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -10,8 +10,7 @@ Demonstrates the full Bayesian workflow:
   3. Posterior predictive     — generate replicated data from the posterior
 
 Both the slope (beta) and the observation noise (sigma) are inferred
-from data.  sigma gets a HalfNormal(2) prior — the standard choice for
-a positive scale parameter.
+from data.  sigma gets a HalfNormal(2) prior chosen for this example’s units.
 """
 
 import numpy as np
@@ -70,4 +69,4 @@ print(f"  y_rep mean:   {y_rep.mean():.4f}  (data mean: {y.mean():.4f})")
 print(f"  y_rep std:    {y_rep.std():.4f}   (data std:  {y.std():.4f})")
 # Simple posterior predictive p-value: fraction of reps where std > observed std
 ppc_p = (y_rep.std(axis=1) > y.std()).mean()
-print(f"  PPC p-value (std): {ppc_p:.3f}  (0.5 = perfect calibration)")
+print(f"  PPC p-value (std): {ppc_p:.3f}")

--- a/examples/site_effects.py
+++ b/examples/site_effects.py
@@ -1,0 +1,33 @@
+"""Estimate related site means with partial pooling and unequal sample counts."""
+import numpy as np
+import rustmc as rmc
+
+
+def main():
+    rng = np.random.default_rng(42)
+    counts = [8, 20, 50, 100]
+    site = np.repeat(np.arange(len(counts)), counts).astype(float)
+    site_means = np.array([-0.3, 0.2, 0.4, -0.1])
+    y = site_means[site.astype(int)] + rng.normal(0, 0.5, len(site))
+    model = rmc.ModelBuilder()
+    population = model.normal_prior("population", 0.0, 1.0)
+    between_sites = model.half_normal_prior("between_sites", 0.5)
+    z = model.vector_normal_prior("z", len(counts), 0.0, 1.0)
+    mean = population + between_sites * z["site"]
+    model.normal_likelihood("reading", mean, 0.5, "y")
+    model.deterministic("site_mean", mean)
+    fit = model.compile().sample(
+        {"site": site, "y": y}, chains=4, warmup=1500, draws=2000,
+        target_accept=0.95, seed=42, show_progress=False,
+    )
+    print(fit.summary())
+    means = fit.predict({"site": np.arange(len(counts), dtype=float)}, expected=True)["reading"]
+    print("Site posterior means:", means.mean(axis=(0, 1)))
+    print("95% credible intervals:", np.quantile(means, [0.025, 0.975], axis=(0, 1)))
+    # Compute comparisons within each joint draw to preserve dependence.
+    difference = means[:, :, 0] - means[:, :, 1]
+    print("P(site 0 mean > site 1 mean):", (difference > 0).mean())
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: rustmc
-site_description: Fast Bayesian inference in Rust with a Python API.
+site_description: Bayesian models in Python. Inference in Rust.
 site_url: https://tbosier.github.io/rustmc
 repo_url: https://github.com/tbosier/rustmc
 repo_name: tbosier/rustmc
@@ -34,6 +34,8 @@ nav:
   - Getting Started: getting-started.md
   - Custom Models: custom-models.md
   - Examples:
+    - Repeated Calibration: examples/repeated-calibration.md
+    - Site Effects: examples/site-effects.md
     - Linear Regression: examples/linear-regression.md
     - Hierarchical Models: examples/hierarchical.md
     - Hierarchical Templates: examples/hierarchical-templates.md


### PR DESCRIPTION
The README and guides now lead with regression, repeated inference, and partial pooling. The roadmap is reduced to five concrete features, with forecasting kept as an application of the shared core.

Adds runnable instrument-calibration, repeated-calibration, and site-effects examples. Corrects misleading posterior-predictive calibration wording, the hierarchical example's data generator, and stale template documentation. The prose follows the Google developer and GOV.UK plain-language guides linked in CONTRIBUTING.md.

Validation: all three new examples and the two corrected scripts ran against the current 0.12 release build; new examples reported zero divergences and R-hat below 1.01. `mkdocs build --strict` and `git diff --check` passed. This PR changes documentation and examples only.
